### PR TITLE
Update gradient in PROchi to be n finite differences

### DIFF
--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -1,4 +1,6 @@
 #include "PROchi.h"
+#include "Eigen/src/Core/Matrix.h"
+#include "PROlog.h"
 using namespace PROfit;
 
 
@@ -13,9 +15,13 @@ float PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradient
 
     // Get Spectra from FillRecoSpectra
     Eigen::VectorXd subvector1 = param.segment(0, 2);
-    std::vector<float> fitparams(subvector1.data(), subvector1.data() + subvector1.size());
-    Eigen::VectorXd subvector2 = param.segment(2,1);
+    //std::vector<float> fitparams(subvector1.data(), subvector1.data() + subvector1.size());
+    std::vector<float> fitparams{};
+    //Eigen::VectorXd subvector2 = param.segment(2,nparams - 2);
+    Eigen::VectorXd subvector2 = param;
     std::vector<float> shifts(subvector2.data(), subvector2.data() + subvector2.size());
+
+    log<LOG_DEBUG>(L"%1% || Shifts size is %2%") % __func__ % shifts.size();
 
     PROspec result = FillRecoSpectra(*config, *peller, *syst, *osc, shifts, fitparams);
 
@@ -46,16 +52,34 @@ float PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradient
     std::cout<<"shape: "<<inverted_collapsed_full_covariance.size()<<std::endl;
     std::cout<<inverted_collapsed_full_covariance<<std::endl;
 
+    for (int i = 0; i < nparams; i++) {
+        Eigen::VectorXd tmpParams = last_param;
+        tmpParams(i) = param(i);
+        Eigen::VectorXd subvector2 = tmpParams;
+        std::vector<float> shifts(subvector2.data(), subvector2.data() + subvector2.size());
+        PROspec result = FillRecoSpectra(*config, *peller, *syst, *osc, shifts, fitparams);
+        // Calcuate Full Covariance matrix
+        Eigen::MatrixXd diag = result.Spec().array().matrix().asDiagonal(); 
+        Eigen::MatrixXd full_covariance =  diag*(syst->fractional_covariance)*diag;
+        // Collapse Covariance and Spectra 
+        Eigen::MatrixXd collapsed_full_covariance =  CollapseMatrix(*config,full_covariance);  
+        Eigen::MatrixXd stat_covariance = data.Spec().array().matrix().asDiagonal();
+        Eigen::MatrixXd collapsed_stat_covariance = CollapseMatrix(*config, stat_covariance); 
+        // Invert Collaped Matrix Matrix 
+        Eigen::MatrixXd inverted_collapsed_full_covariance = (collapsed_full_covariance+collapsed_stat_covariance).inverse();
+        // Calculate Chi^2  value
+        Eigen::VectorXd delta  = result.Spec() - data.Spec(); 
+        float pull = subvector2.array().square().sum(); 
+        float value = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+        gradient(i) = (value-last_value)/(param(i) - last_param(i));
+    }
+
+    std::cout<<"Grad: "<<gradient<<std::endl;
+
     // Calculate Chi^2  value
     Eigen::VectorXd delta  = result.Spec() - data.Spec(); 
     float pull = subvector2.array().square().sum(); 
-    float value = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
-
-    // Simple gradient here
-    Eigen::VectorXd diff = param-last_param;
-    gradient = (value-last_value)/diff.array();
-
-    std::cout<<"Grad: "<<gradient<<std::endl;
+    float value = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
 
     //log<LOG_DEBUG>(L"%1% || value %2%, last_value %3%, pull") % __func__ % value  % last_value % pull;
     log<LOG_DEBUG>(L"%1% || FINISHED ITERATION got vals: %2% %3%") % __func__ % value % last_value ;

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -51,6 +51,10 @@ float PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradient
     std::cout<<inverted_collapsed_full_covariance<<std::endl;
 
     for (int i = 0; i < nparams; i++) {
+        if(param(i) == last_param(i)) {
+            gradient(i) = 1;
+            continue;
+        }
         Eigen::VectorXd tmpParams = last_param;
         tmpParams(i) = param(i);
         //Eigen::VectorXd subvector2 = tmpParams;

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -15,10 +15,8 @@ float PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradient
 
     // Get Spectra from FillRecoSpectra
     Eigen::VectorXd subvector1 = param.segment(0, 2);
-    //std::vector<float> fitparams(subvector1.data(), subvector1.data() + subvector1.size());
-    std::vector<float> fitparams{};
-    //Eigen::VectorXd subvector2 = param.segment(2,nparams - 2);
-    Eigen::VectorXd subvector2 = param;
+    std::vector<float> fitparams(subvector1.data(), subvector1.data() + subvector1.size());
+    Eigen::VectorXd subvector2 = param.segment(2,nparams - 2);
     std::vector<float> shifts(subvector2.data(), subvector2.data() + subvector2.size());
 
     log<LOG_DEBUG>(L"%1% || Shifts size is %2%") % __func__ % shifts.size();

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -53,7 +53,10 @@ float PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradient
     for (int i = 0; i < nparams; i++) {
         Eigen::VectorXd tmpParams = last_param;
         tmpParams(i) = param(i);
-        Eigen::VectorXd subvector2 = tmpParams;
+        //Eigen::VectorXd subvector2 = tmpParams;
+        Eigen::VectorXd subvector1 = tmpParams.segment(0, 2);
+        std::vector<float> fitparams(subvector1.data(), subvector1.data() + subvector1.size());
+        Eigen::VectorXd subvector2 = tmpParams.segment(2,nparams - 2);
         std::vector<float> shifts(subvector2.data(), subvector2.data() + subvector2.size());
         PROspec result = FillRecoSpectra(*config, *peller, *syst, *osc, shifts, fitparams);
         // Calcuate Full Covariance matrix


### PR DESCRIPTION
Prior gradient calculation was just using the difference from all parameters varied, but we actually want to calculate the difference with each parameter changed individually.

Fits without oscillation parameters (i.e., fitting pull systs only) tend to succeed, ~but fits with oscillation parameters still throw exceptions~. Now seems to work most of the time after [47b934d](https://github.com/markrosslonergan/Elephant_Vanishes/pull/52/commits/47b934d1ba861281f6180b151bdb0a9d3edb7d41)