### PR TITLE
Fix two bugs introduced by my PR to add more options to PROsurf

### DIFF
--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -45,6 +45,8 @@ namespace PROfit {
 
             size_t GetNSplines() { return splines.size(); }
 
+            size_t GetNCovar() const { return covmat.size(); }
+
             //----- Spline and Covariance matrix related ---
             //----- Spline and Covariance matrix related ---
 

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -49,7 +49,7 @@ double PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradien
     //std::cout<<collapsed_stat_covariance<<std::endl;
     
     //only calculate a syst covariance if we have any covariance parameters as defined in the xml
-    if(config->m_num_variation_type_covariance > 0){
+    if(syst->GetNCovar()){
 
       // Calculate Full Syst Covariance matrix
       Eigen::MatrixXd diag = result.Spec().array().matrix().asDiagonal(); 
@@ -117,7 +117,7 @@ double PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradien
             Eigen::MatrixXd collapsed_stat_covariance = CollapseMatrix(*config, stat_covariance); 
             Eigen::MatrixXd inverted_collapsed_full_covariance(config->m_num_bins_total_collapsed,config->m_num_bins_total_collapsed);
 
-            if(config->m_num_variation_type_covariance > 0){
+            if(syst->GetNCovar()){
 
                 Eigen::MatrixXd diag = result.Spec().array().matrix().asDiagonal(); 
                 Eigen::MatrixXd full_covariance =  diag*(syst->fractional_covariance)*diag;

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -28,17 +28,21 @@ namespace PROfit {
 
     PROsyst PROsyst::subset(const std::vector<std::string> &systs) {
         PROsyst ret;
+        log<LOG_DEBUG>(L"%1% | Creating a subset with a list of %2% systematics.") % __func__ % systs.size();
         for(const std::string &name: systs) {
+            log<LOG_DEBUG>(L"%1% | Looking up systematic %2% from subset list.") % __func__ % name.c_str();
             const auto &[idx, stype] = syst_map[name];
             switch(stype) {
             case SystType::Spline:
                 ret.syst_map[name] = std::make_pair(ret.splines.size(), SystType::Spline);
                 ret.spline_names.push_back(name);
                 ret.splines.push_back(splines[idx]);
+                break;
             case SystType::Covariance:
                 ret.syst_map[name] = std::make_pair(ret.covmat.size(), SystType::Covariance);
                 ret.covmat.push_back(covmat[idx]);
                 ret.corrmat.push_back(corrmat[idx]);
+                break;
             }
         }
         ret.fractional_covariance = ret.SumMatrices();
@@ -55,10 +59,12 @@ namespace PROfit {
                 ret.syst_map[name] = std::make_pair(ret.splines.size(), SystType::Spline);
                 ret.spline_names.push_back(name);
                 ret.splines.push_back(splines[idx]);
+                break;
             case SystType::Covariance:
                 ret.syst_map[name] = std::make_pair(ret.covmat.size(), SystType::Covariance);
                 ret.covmat.push_back(covmat[idx]);
                 ret.corrmat.push_back(corrmat[idx]);
+                break;
             }
         }
         ret.fractional_covariance = ret.SumMatrices();


### PR DESCRIPTION
Thanks to Jeanie for uncovering this. I forgot to add break after the cases in PROsyst::subset and PROsyst::excluding. Then, after fixing that bug, it turns out PROchi was calculating a covariance matrix differently depending on whether there were covar type systs in PROsyst. That's expected, but it wasn't checking PROsyst and actually checking PROconfig. But the new PROsurf options break that by allowing PROsyst to differ from the systs in PROconfig.