### PR TITLE
On/Off Systematics

### DIFF
--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -111,7 +111,7 @@ namespace PROfit {
 
             /* names of all systs*/
             std::vector<std::string> spline_names;
-            std::vector<float> spline_lo, spline_hi;
+            std::vector<double> spline_lo, spline_hi;
         private:
             std::unordered_map<std::string, std::pair<size_t, SystType>> syst_map;
             std::vector<Spline> splines;

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -111,6 +111,7 @@ namespace PROfit {
 
             /* names of all systs*/
             std::vector<std::string> spline_names;
+            std::vector<float> spline_lo, spline_hi;
         private:
             std::unordered_map<std::string, std::pair<size_t, SystType>> syst_map;
             std::vector<Spline> splines;

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -101,8 +101,10 @@ std::vector<surfOut> PROsurf::PointHelper(const PROconfig *config, const PROpell
         param.max_linesearch = 50;
         param.delta = 1e-6;
 
-        Eigen::VectorXd lb = Eigen::VectorXd::Constant(nparams, -3.0);
-        Eigen::VectorXd ub = Eigen::VectorXd::Constant(nparams, 3.0);
+        //Eigen::VectorXd lb = Eigen::VectorXd::Constant(nparams, -3.0);
+        //Eigen::VectorXd ub = Eigen::VectorXd::Constant(nparams, 3.0);
+        Eigen::VectorXd lb = Eigen::VectorXd::Map(systs->spline_lo.data(), systs->spline_lo.size());
+        Eigen::VectorXd ub = Eigen::VectorXd::Map(systs->spline_hi.data(), systs->spline_hi.size());
 
         PROfitter fitter(ub, lb, param);
         output.chi = fitter.Fit(chi);
@@ -261,8 +263,10 @@ int PROfit::PROfile(const PROconfig &config, const PROpeller &prop, const PROsys
 
         for(int i=0; i<=30;i++){
 
-            Eigen::VectorXd lb = Eigen::VectorXd::Constant(nparams, -3.0);
-            Eigen::VectorXd ub = Eigen::VectorXd::Constant(nparams, 3.0);
+            //Eigen::VectorXd lb = Eigen::VectorXd::Constant(nparams, -3.0);
+            //Eigen::VectorXd ub = Eigen::VectorXd::Constant(nparams, 3.0);
+            Eigen::VectorXd ub = Eigen::VectorXd::Map(systs.spline_hi.data(), systs.spline_hi.size());
+            Eigen::VectorXd lb = Eigen::VectorXd::Map(systs.spline_lo.data(), systs.spline_lo.size());
             Eigen::VectorXd x = Eigen::VectorXd::Constant(nparams, 0.0);
             Eigen::VectorXd grad = Eigen::VectorXd::Constant(nparams, 0.0);
             Eigen::VectorXd bestx = Eigen::VectorXd::Constant(nparams, 0.0);

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -13,7 +13,8 @@ namespace PROfit {
                 log<LOG_INFO>(L"%1% || Entering multisigma?") % __func__;
                 FillSpline(syst);
                 spline_names.push_back(syst.systname); 
-
+                spline_lo.push_back(syst.knobval[0]);
+                spline_hi.push_back(syst.knobval.back());
                 //anyspline=true;
             } else if(syst.mode == "covariance") {
                 log<LOG_INFO>(L"%1% || Entering covariance syst world?") % __func__;
@@ -37,11 +38,16 @@ namespace PROfit {
                 ret.syst_map[name] = std::make_pair(ret.splines.size(), SystType::Spline);
                 ret.spline_names.push_back(name);
                 ret.splines.push_back(splines[idx]);
+                ret.spline_hi.push_back(spline_hi[idx]);
+                ret.spline_lo.push_back(spline_lo[idx]);
                 break;
             case SystType::Covariance:
                 ret.syst_map[name] = std::make_pair(ret.covmat.size(), SystType::Covariance);
                 ret.covmat.push_back(covmat[idx]);
                 ret.corrmat.push_back(corrmat[idx]);
+                break;
+            default:
+                log<LOG_ERROR>(L"%1% || Unrecognized syst type %2% for syst %3%.") % __func__ % static_cast<int>(stype) % name.c_str();
                 break;
             }
         }
@@ -59,11 +65,16 @@ namespace PROfit {
                 ret.syst_map[name] = std::make_pair(ret.splines.size(), SystType::Spline);
                 ret.spline_names.push_back(name);
                 ret.splines.push_back(splines[idx]);
+                ret.spline_hi.push_back(spline_hi[idx]);
+                ret.spline_lo.push_back(spline_lo[idx]);
                 break;
             case SystType::Covariance:
                 ret.syst_map[name] = std::make_pair(ret.covmat.size(), SystType::Covariance);
                 ret.covmat.push_back(covmat[idx]);
                 ret.corrmat.push_back(corrmat[idx]);
+                break;
+            default:
+                log<LOG_ERROR>(L"%1% || Unrecognized syst type %2% for syst %3%.") % __func__ % static_cast<int>(stype) % name.c_str();
                 break;
             }
         }

--- a/xml/ICARUS_run2_numudis.xml
+++ b/xml/ICARUS_run2_numudis.xml
@@ -101,6 +101,7 @@
     <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_ZExpA2CCQE</allowlist>
     <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_ZExpA3CCQE</allowlist>
     <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_ZExpA4CCQE</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_DecayAngMEC</allowlist>
 </variation_list>
 
 <model tag="numudis">


### PR DESCRIPTION
Add ability to read and use on/off systematics (e.g., DecayAngMEC)

PROsurf now gets upper and lower bounds from PROsyst. PROfitter will then use these to rescale the sampled points. Other places where upper and lower bounds are set should be changed, but I at least think PROsurf is good to go.

Splines for on/off systematics are linear since there are only 2 points. This is kind of overkill and these systs are ok to go in the covariance matrix only to reduce the number of minimized parameters.

Add DecayAngMEC to the ICARUS run 2 numu disappearance xml.