### PR TITLE
Update PROfc

### DIFF
--- a/bin/PROfc.cxx
+++ b/bin/PROfc.cxx
@@ -67,8 +67,8 @@ void fc_worker(fc_args args) {
         param.delta = 1e-6;
 
         size_t nparams = args.systs.GetNSplines();
-        Eigen::VectorXd lb = Eigen::VectorXd::Constant(nparams, -3.0);
-        Eigen::VectorXd ub = Eigen::VectorXd::Constant(nparams, 3.0);
+        Eigen::VectorXd lb = Eigen::VectorXd::Map(args.systs.spline_lo.data(), args.systs.spline_lo.size());
+        Eigen::VectorXd ub = Eigen::VectorXd::Map(args.systs.spline_hi.data(), args.systs.spline_hi.size());
         PROfitter fitter(ub, lb, param);
 
         PROchi chi("3plus1",&args.config,&args.prop,&args.systs,&osc, newSpec, nparams, args.systs.GetNSplines(), strat);
@@ -86,6 +86,10 @@ void fc_worker(fc_args args) {
         lb_osc(0) = -2; lb_osc(1) = -std::numeric_limits<double>::infinity();
         Eigen::VectorXd ub_osc = Eigen::VectorXd::Constant(nparams, 3.0);
         ub_osc(0) = 2; ub_osc(1) = 0;
+        for(size_t i = 2; i < nparams; ++i) {
+            lb_osc(i) = lb(i-2);
+            ub_osc(i) = ub(i-2);
+        }
         PROfitter fitter_osc(ub_osc, lb_osc, param);
 
         PROchi chi_osc("3plus1",&args.config,&args.prop,&args.systs,&osc, newSpec, nparams, args.systs.GetNSplines(), strat);

--- a/bin/PROfc.cxx
+++ b/bin/PROfc.cxx
@@ -57,8 +57,7 @@ void fc_worker(fc_args args) {
         for(size_t i = 0; i < args.config.m_num_bins_total; i++)
             throwC(i) = d(rng);
         PROspec shifted = FillRecoSpectra(args.config, args.prop, args.systs, &osc, throws, args.phy_params, strat);
-        std::cout << "Num total bins " << args.config.m_num_bins_total << " Num spectrum bins " << shifted.Spec().size() << std::endl;
-        PROspec newSpec = PROspec::PoissonVariation(PROspec(shifted.Spec() + args.L * throwC, shifted.Error()));
+        PROspec newSpec = PROspec::PoissonVariation(PROspec(CollapseMatrix(args.config, shifted.Spec()) + args.L * throwC, CollapseMatrix(args.config, shifted.Error())));
 
         // No oscillations
         LBFGSpp::LBFGSBParam<double> param;  
@@ -155,7 +154,7 @@ int main(int argc, char* argv[])
 
     Eigen::MatrixXd diag = FillCVSpectrum(myConf, myprop, !eventbyevent).Spec().array().matrix().asDiagonal();
     Eigen::MatrixXd full_cov = diag * systs.fractional_covariance * diag;
-    Eigen::LLT<Eigen::MatrixXd> llt(full_cov);
+    Eigen::LLT<Eigen::MatrixXd> llt(CollapseMatrix(myConf, full_cov));
     
     std::vector<std::vector<double>> dchi2s;
     dchi2s.reserve(nthread);

--- a/bin/PROsurf.cxx
+++ b/bin/PROsurf.cxx
@@ -119,6 +119,10 @@ int main(int argc, char* argv[])
     PROspec data = injected_pt[0] != 0 && injected_pt[1] != 0 ? FillRecoSpectra(config, prop, systs, &osc, injected_systs, pparams, !eventbyevent) :
                    injected_systs.size() ? FillRecoSpectra(config, prop, systs, injected_systs, !eventbyevent) :
                    FillCVSpectrum(config, prop, !eventbyevent);
+    Eigen::VectorXd data_vec = CollapseMatrix(config, data.Spec());
+    Eigen::VectorXd err_vec_sq = data.Error().array().square();
+    Eigen::VectorXd err_vec = CollapseMatrix(config, err_vec_sq).array().sqrt();
+    data = PROspec(data_vec, err_vec);
 
     if(syst_list.size()) {
       systs = systs.subset(syst_list);

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -79,9 +79,7 @@ double PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradien
       //std::cout<<inverted_collapsed_full_covariance<<std::endl;
 
     // Calculate Chi^2  value
-    Eigen::VectorXd delta  = result.Spec() - data.Spec(); 
-    //Collapse
-    delta = CollapseMatrix(*config, delta);  
+    Eigen::VectorXd delta  = CollapseMatrix(*config,result.Spec()) - data.Spec(); 
 
     if(!(fixed_index<0)){
         //subvector2[fixed_index]=0;   
@@ -130,8 +128,7 @@ double PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradien
                 }
            
             // Calculate Chi^2  value
-            Eigen::VectorXd delta  = result.Spec() - data.Spec(); 
-            delta = CollapseMatrix(*config, delta);  
+            Eigen::VectorXd delta  = CollapseMatrix(*config,result.Spec()) - data.Spec(); 
 
             if(!(fixed_index<0)){
                 //subvector2[fixed_index]=0;   

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -40,10 +40,11 @@ double PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradien
 
     Eigen::MatrixXd inverted_collapsed_full_covariance(config->m_num_bins_total_collapsed,config->m_num_bins_total_collapsed);
     
-    Eigen::MatrixXd stat_covariance = data.Spec().array().matrix().asDiagonal();
-    log<LOG_DEBUG>(L"%1% || stat %2% x %3% ") % __func__% stat_covariance.cols() % stat_covariance.rows();
-    Eigen::MatrixXd collapsed_stat_covariance = CollapseMatrix(*config, stat_covariance); 
-    log<LOG_DEBUG>(L"%1% || Collapsed the first matrix") % __func__;
+    //Eigen::MatrixXd stat_covariance = data.Spec().array().matrix().asDiagonal();
+    Eigen::MatrixXd collapsed_stat_covariance = data.Spec().array().matrix().asDiagonal();
+    //log<LOG_DEBUG>(L"%1% || stat %2% x %3% ") % __func__% stat_covariance.cols() % stat_covariance.rows();
+    //Eigen::MatrixXd collapsed_stat_covariance = CollapseMatrix(*config, stat_covariance); 
+    //log<LOG_DEBUG>(L"%1% || Collapsed the first matrix") % __func__;
 
     //std::cout<<"cStat: "<<collapsed_stat_covariance.size()<<std::endl;
     //std::cout<<collapsed_stat_covariance<<std::endl;
@@ -113,8 +114,6 @@ double PROchi::operator()(const Eigen::VectorXd &param, Eigen::VectorXd &gradien
             std::vector<float> shifts(subvector2.data(), subvector2.data() + subvector2.size());
             PROspec result = FillRecoSpectra(*config, *peller, *syst, osc, shifts, fitparams, strat != EventByEvent);
             // Calcuate Full Covariance matrix
-            Eigen::MatrixXd stat_covariance = data.Spec().array().matrix().asDiagonal();
-            Eigen::MatrixXd collapsed_stat_covariance = CollapseMatrix(*config, stat_covariance); 
             Eigen::MatrixXd inverted_collapsed_full_covariance(config->m_num_bins_total_collapsed,config->m_num_bins_total_collapsed);
 
             if(syst->GetNCovar()){

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -134,7 +134,7 @@ void PROsurf::FillSurface(const PROconfig &config, const PROpeller &prop, const 
         chi_file.open(filename);
     }
 
-    data.plotSpectrum(config,"TTCV");
+    //data.plotSpectrum(config,"TTCV");
 
     std::vector<surfOut> grid;
     for(size_t i = 0; i < nbinsx; i++) {


### PR DESCRIPTION
Big update to PROfc to keep it working properly with recent changes. This also adds a new output option which will save the results to either a csv or a TTree.

This also involves changing the PROchi "data" parameter to be already collapsed. We were expecting the data PROspec passed to PROchi to be uncollapsed. I changed PROsurf to work with this now, but not sure how this affects the python stuff Gray has been working on. 

One thing this revealed is that PROspec's plotting expects the spectrum to be uncollapsed, so that doesn't work with the data spectrum anymore in PROsurf. I commented that out, but I actually think there are two things to fix here.
1. PROspec should be able to plot either a collapsed or uncollapsed spectrum
2. In PROsurf, when plotting the CV, we should be using MC not data

I also noticed while doing this that PROsyst uses a lot of std::vector<float> while other things tend to use Eigen::VectorXd. The std vs Eigen vector is not much of an issue since they're easy to convert between, but the float vs double difference makes that harder. We should just decide on float vs double and be consistent about that.