### PR TITLE
Add in N-dimmensional fits

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -53,13 +53,13 @@ namespace PROfit{
      */
 
     struct BranchVariable{
-        std::string name;
+        std::vector<std::string> names;
         std::string type;
         std::string associated_hist;
         std::string associated_systematic;
         bool central_value;
 
-        std::shared_ptr<TTreeFormula> branch_formula=nullptr;
+        std::vector<std::shared_ptr<TTreeFormula>> branch_formulas;
         std::shared_ptr<TTreeFormula> branch_monte_carlo_weight_formula = nullptr;
         std::shared_ptr<TTreeFormula> branch_true_value_formula=nullptr;
         std::shared_ptr<TTreeFormula> branch_true_L_formula=nullptr;
@@ -73,12 +73,12 @@ namespace PROfit{
         int include_systematics;
 
         //constructor
-        BranchVariable(std::string n, std::string t, std::string a) : name(n), type(t), associated_hist(a), central_value(false), oscillate(false), model_rule(-9), include_systematics(1){}
-        BranchVariable(std::string n, std::string t, std::string a_hist, std::string a_syst, bool cv) : name(n), type(t), associated_hist(a_hist), associated_systematic(a_syst), central_value(cv), oscillate(false), model_rule(-9),include_systematics(1){}
+        BranchVariable(std::vector<std::string> ns, std::string t, std::string a) : names(ns), type(t), associated_hist(a), central_value(false), oscillate(false), model_rule(-9), include_systematics(1){}
+        BranchVariable(std::vector<std::string> ns, std::string t, std::string a_hist, std::string a_syst, bool cv) : names(ns), type(t), associated_hist(a_hist), associated_systematic(a_syst), central_value(cv), oscillate(false), model_rule(-9),include_systematics(1){}
 
         /* Function: Return the TTreeformula for branch 'name', usually it's the reconstructed variable */
-        std::shared_ptr<TTreeFormula> GetFormula(){
-            return branch_formula;
+        std::vector<std::shared_ptr<TTreeFormula>> GetFormulas(){
+            return branch_formulas;
         }
 
         void SetOscillate(bool inbool){ oscillate = inbool; return;}
@@ -118,7 +118,7 @@ namespace PROfit{
         //Function: evaluate branch 'name' and return the value. Usually its reconstructed quantity
         //Note: when called, if the corresponding TreeFormula is not linked to a TTree, value of ZERO (0) will be returned.
         template <typename T=double>
-            T GetValue() const;
+            std::vector<T> GetValues() const;
 
 
         //Function: evaluate formula 'true_L_name' and return the value. Usually it's true baseline.
@@ -217,8 +217,10 @@ namespace PROfit{
             /*Vectors of length num_channels. Unless specificed all refer to fittable (reco) variables*/
             std::vector<size_t> m_num_subchannels; 
             std::vector<size_t> m_channel_num_bins;
-            std::vector<std::vector<double> > m_channel_bin_edges;
-            std::vector<std::vector<double> > m_channel_bin_widths;
+            std::vector<std::vector<size_t>> m_channel_num_bins_pervar;
+            std::vector<std::vector<size_t>> m_channel_strides_pervar;
+            std::vector<std::vector<std::vector<double> > > m_channel_bin_edges;
+            std::vector<std::vector<std::vector<double> > > m_channel_bin_widths;
 
             /* New true bins to save the truth level variables in addition.*/
             std::vector<size_t> m_channel_num_truebins;
@@ -349,7 +351,7 @@ namespace PROfit{
 
 
             /* Function: given channel index, return list of bin edges for this channel */
-            const std::vector<double>& GetChannelBinEdges(size_t channel_index) const;
+            const std::vector<double>& GetChannelBinEdges(size_t channel_index, size_t reco_index) const;
 
             /* Function: given channel index, return number of true bins for this channel */
             size_t GetChannelNTrueBins(size_t channel_index) const;
@@ -383,11 +385,12 @@ namespace PROfit{
 
 
     template <typename T>
-        T BranchVariable::GetValue() const{
-            if(branch_formula == NULL) return static_cast<T>(0);
+        std::vector<T> BranchVariable::GetValues() const{
+            if(branch_formulas.size() == 0) return {static_cast<T>(0)};
             else{
-                branch_formula->GetNdata();
-                return static_cast<T>(branch_formula->EvalInstance());
+                std::vector<T> ret;
+                for (auto const &b: branch_formulas) ret.push_back(static_cast<T>(b->EvalInstance()));
+                return ret;
             }
         }
 

--- a/inc/PROpeller.h
+++ b/inc/PROpeller.h
@@ -26,7 +26,7 @@ namespace PROfit{
             PROpeller(){
                 nevents = -1;
                 truth.clear();
-                reco.clear();
+                recos.clear();
                 baseline.clear();
                 pdg.clear();
                 added_weights.clear();
@@ -36,7 +36,7 @@ namespace PROfit{
             }
 
             /*Function: Primary Constructor from raw std::vectors of MC values */ 
-            PROpeller(const PROconfig &config, std::vector<float> &intruth, std::vector<float> &inreco, std::vector<float> &inbaseline, std::vector<int> &inpdg, std::vector<float> &inadded_weights, std::vector<int> &inbin_indices, std::vector<int> &inmodel_rule, std::vector<int> &intrue_bin_indices) : truth(intruth), reco(inreco), baseline(inbaseline), pdg(inpdg), added_weights(inadded_weights), bin_indices(inbin_indices), model_rule(inmodel_rule), true_bin_indices(intrue_bin_indices){
+            PROpeller(const PROconfig &config, std::vector<float> &intruth, std::vector<std::vector<float>> &inrecos, std::vector<float> &inbaseline, std::vector<int> &inpdg, std::vector<float> &inadded_weights, std::vector<int> &inbin_indices, std::vector<int> &inmodel_rule, std::vector<int> &intrue_bin_indices) : truth(intruth), recos(inrecos), baseline(inbaseline), pdg(inpdg), added_weights(inadded_weights), bin_indices(inbin_indices), model_rule(inmodel_rule), true_bin_indices(intrue_bin_indices){
                 nevents = truth.size();
                 hist = Eigen::MatrixXd::Constant(config.m_num_truebins_total, config.m_num_bins_total, 0);
                 for(size_t i = 0; i < bin_indices.size(); ++i)
@@ -45,7 +45,7 @@ namespace PROfit{
 
             /* the Core MC is saved in these vectors.*/
             std::vector<float> truth;
-            std::vector<float> reco;
+            std::vector<std::vector<float>> recos;
             std::vector<float> baseline;
             std::vector<int>   pdg;
             std::vector<float> added_weights;

--- a/inc/PROspec.h
+++ b/inc/PROspec.h
@@ -67,8 +67,8 @@ namespace PROfit{
 
 
             /* Function: given subchannel name/index, generate TH1D histogram of corresponding spectrum */
-            TH1D toTH1D(const PROconfig& inconfig, int subchannel_index) const;
-            TH1D toTH1D(const PROconfig& inconfig, const std::string& subchannel_fullname) const;
+            TH1D toTH1D(const PROconfig& inconfig, int subchannel_index, int reco_dim=0) const;
+            TH1D toTH1D(const PROconfig& inconfig, const std::string& subchannel_fullname, int reco_dim=0) const;
 
 
             /* Function: save TH1Ds of all subchannels into a root file */

--- a/inc/PROtocall.h
+++ b/inc/PROtocall.h
@@ -14,17 +14,22 @@
 namespace PROfit{
 
 
+    /* Function: given a local bin value, return the bin projected onto the dimension of the 
+     * reconstructed variable(s) given by reco_dim
+     */
+    int ProjectedBin(const PROconfig &inconfig, int channel_index, int reco_dim, int local_bin);
+
     /* Function: given a value for reconstructed variable, figure out which local bin in the histogram it belongs to
      * Note: bin index start from 0, not 1
      * Note: return value of -1 means the reco value is out of range
      */
-    int FindLocalBin(const PROconfig &inconfig, double reco_value, int channel_index);
+    int FindLocalBin(const PROconfig &inconfig, const std::vector<double> &reco_value, int channel_index);
     /* Function: given a value for reconstructed variable, figure out which global bin it belongs to
      * Note: bin index start from 0, not 1
      * Note: if  the reco value is out of range, then return value of -1
      */
-    int FindGlobalBin(const PROconfig &inconfig, double reco_value, int subchannel_index);
-    int FindGlobalBin(const PROconfig &inconfig, double reco_value, const std::string& subchannel_fullname);
+    int FindGlobalBin(const PROconfig &inconfig, const std::vector<double> &reco_value, int subchannel_index);
+    int FindGlobalBin(const PROconfig &inconfig, const std::vector<double> &reco_value, const std::string& subchannel_fullname);
 
     /* Function: given a value for true variable, figure out which local bin in the histogram it belongs to
      * Note: bin index start from 0, not 1

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -224,28 +224,41 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
             // What are the bin edges and bin widths (bin widths just calculated from edges now)
             tinyxml2::XMLElement *pBin = pChan->FirstChildElement("bins");
-            std::stringstream iss(pBin->Attribute("edges"));
+            m_channel_bin_edges.push_back({});
+            m_channel_bin_widths.push_back({});
+            m_channel_num_bins_pervar.push_back({});
+            m_channel_strides_pervar.push_back({});
+            while (pBin) {
+                std::stringstream iss(pBin->Attribute("edges"));
 
-            double number;
-            std::vector<double> binedge;
-            std::vector<double> binwidth;
-            std::string binstring = "";
-            while ( iss >> number ){
-                binedge.push_back( number );
-                binstring+=" "+std::to_string(number);
+                double number;
+                std::vector<double> binedge;
+                std::vector<double> binwidth;
+                std::string binstring = "";
+                while ( iss >> number ){
+                    binedge.push_back( number );
+                    binstring+=" "+std::to_string(number);
+                }
+
+                log<LOG_DEBUG>(L"%1% || Loading Bins with edges %2%  ") % __func__ % binstring.c_str();
+
+                for(size_t b = 0; b<binedge.size()-1; b++){
+                    binwidth.push_back(fabs(binedge.at(b)-binedge.at(b+1)));
+                }
+
+                m_channel_bin_edges.back().push_back(binedge);
+                m_channel_bin_widths.back().push_back(binwidth);
+                pBin = pBin->NextSiblingElement("bins");
             }
 
-            log<LOG_DEBUG>(L"%1% || Loading Bins with edges %2%  ") % __func__ % binstring.c_str();
-
-            for(size_t b = 0; b<binedge.size()-1; b++){
-                binwidth.push_back(fabs(binedge.at(b)-binedge.at(b+1)));
+            size_t stride = 1;
+            for (auto const &edges: m_channel_bin_edges.back()) {
+                size_t nbin = edges.size() - 1;
+                stride *= nbin;
+                m_channel_num_bins_pervar.back().push_back(nbin);
+                m_channel_strides_pervar.back().push_back(stride);
             }
-
-            m_channel_num_bins.push_back(binedge.size()-1);
-
-            m_channel_bin_edges.push_back(binedge);
-            m_channel_bin_widths.push_back(binwidth);
-
+            m_channel_num_bins.push_back(stride);
 
             tinyxml2::XMLElement *pBinT = pChan->FirstChildElement("truebins");
             if(pBinT){
@@ -524,15 +537,18 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
                 }
 
-
+                    std::stringstream tup(bnam);
+                    std::string s;
+                    std::vector<std::string> bnams;
+                    while (getline(tup, s, ':')) bnams.push_back(s);
 
                     if(use_universe){
-                        TEMP_branch_variables.push_back( std::make_shared<BranchVariable>(bnam, "double", bhist ) );
+                        TEMP_branch_variables.push_back( std::make_shared<BranchVariable>(bnams, "double", bhist ) );
                     } else  if((std::string)bcentral == "true"){
-                        TEMP_branch_variables.push_back( std::make_shared<BranchVariable>(bnam, "double", bhist,bsyst, true) );
+                        TEMP_branch_variables.push_back( std::make_shared<BranchVariable>(bnams, "double", bhist,bsyst, true) );
                         log<LOG_DEBUG>(L"%1% || Setting as  CV for det sys.") % __func__ ;
                     } else {
-                        TEMP_branch_variables.push_back( std::make_shared<BranchVariable>(bnam, "double", bhist,bsyst, false) );
+                        TEMP_branch_variables.push_back( std::make_shared<BranchVariable>(bnams, "double", bhist,bsyst, false) );
                         log<LOG_DEBUG>(L"%1% || Setting as individual (not CV) for det sys.") % __func__ ;
                     }
 
@@ -804,7 +820,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
         log<LOG_INFO>(L"%1% || num_channels: %2% ") % __func__ % m_num_channels;
         for(size_t i = 0 ; i!=m_num_channels; ++i){
             log<LOG_INFO>(L"%1% || num of subchannels: %2% ") % __func__ % m_num_subchannels[i];
-            log<LOG_INFO>(L"%1% || num of bins: %2% ") % __func__ % m_channel_num_bins[i];
+            log<LOG_INFO>(L"%1% || num of bins: %3% ") % __func__ % m_channel_num_bins[i];
 
         }
         log<LOG_INFO>(L"%1% || num_bins_detector_block: %2%") % __func__ % m_num_bins_detector_block;
@@ -880,7 +896,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
         return m_vec_subchannel_index[index];
     }
 
-    const std::vector<double>& PROconfig::GetChannelBinEdges(size_t channel_index) const{
+    const std::vector<double>& PROconfig::GetChannelBinEdges(size_t channel_index, size_t reco_index) const{
 
         if( channel_index >= m_num_channels){
             log<LOG_ERROR>(L"%1% || Given channel index: %2% is out of bound") % __func__ % channel_index;
@@ -888,8 +904,14 @@ int PROconfig::LoadFromXML(const std::string &filename){
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
+        if (reco_index >= m_channel_bin_edges[channel_index].size()) {
+            log<LOG_ERROR>(L"%1% || Given reco index: %2% is out of bound for channel %3%") % __func__ % reco_index % channel_index;
+            log<LOG_ERROR>(L"%1% || Total number of reco variables : %2%") % __func__ % m_channel_bin_edges[channel_index].size();
+            log<LOG_ERROR>(L"Terminating.");
+            exit(EXIT_FAILURE);
+        }
 
-        return m_channel_bin_edges[channel_index];
+        return m_channel_bin_edges[channel_index][reco_index];
     }
 
     size_t PROconfig::GetChannelNTrueBins(size_t channel_index) const{
@@ -966,8 +988,10 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
             //update channel-related info
             std::vector<size_t> temp_channel_num_bins(m_num_channels, 0);
-            std::vector<std::vector<double>> temp_channel_bin_edges(m_num_channels, std::vector<double>());
-            std::vector<std::vector<double>> temp_channel_bin_widths(m_num_channels, std::vector<double>());
+            std::vector<std::vector<std::vector<double>>> temp_channel_bin_edges(m_num_channels, std::vector<std::vector<double>>());
+            std::vector<std::vector<std::vector<double>>> temp_channel_bin_widths(m_num_channels, std::vector<std::vector<double>>());
+            std::vector<std::vector<size_t>> temp_channel_num_bins_pervar(m_num_channels, std::vector<size_t>());
+            std::vector<std::vector<size_t>> temp_channel_strides_pervar(m_num_channels, std::vector<size_t>());
 
             std::vector<size_t> temp_channel_num_truebins(m_num_channels, 0);
             std::vector<std::vector<double>> temp_channel_truebin_edges(m_num_channels, std::vector<double>());
@@ -981,6 +1005,8 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     temp_channel_num_bins[chan_index] = m_channel_num_bins[i];
                     temp_channel_bin_edges[chan_index] = m_channel_bin_edges[i];
                     temp_channel_bin_widths[chan_index] = m_channel_bin_widths[i];
+                    temp_channel_num_bins_pervar[chan_index] = m_channel_num_bins_pervar[i];
+                    temp_channel_strides_pervar[chan_index] = m_channel_strides_pervar[i];
 
                     temp_channel_num_truebins[chan_index] = m_channel_num_truebins[i];
                     temp_channel_truebin_edges[chan_index] = m_channel_truebin_edges[i];
@@ -997,6 +1023,8 @@ int PROconfig::LoadFromXML(const std::string &filename){
             m_channel_num_bins = temp_channel_num_bins;
             m_channel_bin_edges = temp_channel_bin_edges;
             m_channel_bin_widths = temp_channel_bin_widths;
+            m_channel_num_bins_pervar = temp_channel_num_bins_pervar;
+            m_channel_strides_pervar = temp_channel_strides_pervar;
             m_channel_num_truebins = temp_channel_num_truebins;
             m_channel_truebin_edges = temp_channel_truebin_edges;
             m_channel_truebin_widths = temp_channel_truebin_widths;

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -151,9 +151,10 @@ namespace PROfit {
                     exit(EXIT_FAILURE);
                 }
 
-                branch_variable->branch_formula = std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), branch_variable->name.c_str(), trees[fid]);
-                log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  branch_variable->name.c_str();
-
+                for (const std::string &name: branch_variable->names) {
+                    branch_variable->branch_formulas.push_back(std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), name.c_str(), trees[fid]));
+                    log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  name.c_str();
+                }
 
                 //grab monte carlo weight
                 if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
@@ -401,8 +402,11 @@ namespace PROfit {
                     exit(EXIT_FAILURE);
                 }
 
-                branch_variable->branch_formula = std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), branch_variable->name.c_str(), trees[fid]);
-                log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  branch_variable->name.c_str();
+                for (const std::string &name: branch_variable->names) {
+                    branch_variable->branch_formulas.push_back(std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), name.c_str(), trees[fid]));
+                    log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  name.c_str();
+                }
+
                 branch_variable->branch_true_L_formula = std::make_shared<TTreeFormula>(("branch_L_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), branch_variable->true_L_name.c_str(), trees[fid]);
                 log<LOG_INFO>(L"%1% || Setting up L variable for this branch: %2%") % __func__ %  branch_variable->true_L_name.c_str();
                 branch_variable->branch_true_value_formula = std::make_shared<TTreeFormula>(("branch_true_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), branch_variable->true_param_name.c_str(), trees[fid]);
@@ -730,8 +734,10 @@ namespace PROfit {
                     exit(EXIT_FAILURE);
                 }
 
-                branch_variable->branch_formula = std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), branch_variable->name.c_str(), trees[fid]);
-                log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  branch_variable->name.c_str();
+                for (const std::string &name: branch_variable->names) {
+                    branch_variable->branch_formulas.push_back(std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), name.c_str(), trees[fid]));
+                    log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  name.c_str();
+                }
 
                 branch_variable->branch_true_pdg_formula  =  std::make_shared<TTreeFormula>(("branch_add_pdg_"+std::to_string(fid)+"_" + std::to_string(ib)).c_str(),branch_variable->pdg_name.c_str(),trees[fid]);
                 branch_variable->branch_true_value_formula  =  std::make_shared<TTreeFormula>(("branch_add_trueE_"+std::to_string(fid)+"_" + std::to_string(ib)).c_str(),branch_variable->true_param_name.c_str(),trees[fid]);
@@ -857,7 +863,7 @@ namespace PROfit {
                 if(i%1000==0)log<LOG_DEBUG>(L"%1% || ---- universe %2%/%3% ") % __func__  % files[fid]->GetName() % nevents ;
 
                 for(int ib = 0; ib != num_branch; ++ib) {
-                    double reco_value = branches[ib]->GetValue<double>();
+                    std::vector<double> reco_value = branches[ib]->GetValues<double>();
                     float additional_weight = branches[ib]->GetMonteCarloWeight();
                     //additional_weight *= pot_scale[fid]; POT NOT YET FIX
                     int global_bin = FindGlobalBin(inconfig, reco_value, subchannel_index[ib]);
@@ -867,12 +873,16 @@ namespace PROfit {
                     int global_true_bin = FindGlobalTrueBin(inconfig, baseline / true_param, subchannel_index[ib]);
                     int model_rule = branches[ib]->GetModelRule();
 
-                    log<LOG_DEBUG>(L"%1% || Reco and True E values: %2% and  %3%") % __func__ % reco_value % true_param;
+                    log<LOG_DEBUG>(L"%1% || Reco and True E values: %2% and  %3%") % __func__ % reco_value[0] % true_param;
 
                     if(additional_weight == 0 || global_bin < 0)
                         continue;
 
-                    inprop.reco.push_back((float)reco_value);
+                    for (unsigned ir = 0; ir < reco_value.size(); ir++) {
+                      if (inprop.recos.size() <= ir) inprop.recos.push_back({});
+                      inprop.recos[ir].push_back(reco_value[ir]);
+                    }
+
                     inprop.added_weights.push_back(additional_weight);
                     inprop.bin_indices.push_back(global_bin);
                     inprop.pdg.push_back(pdg_id);
@@ -1027,9 +1037,10 @@ namespace PROfit {
                     exit(EXIT_FAILURE);
                 }
 
-                branch_variable->branch_formula = std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), branch_variable->name.c_str(), trees[fid]);
-                log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  branch_variable->name.c_str();
-
+                for (const std::string &name: branch_variable->names) {
+                    branch_variable->branch_formulas.push_back(std::make_shared<TTreeFormula>(("branch_form_"+std::to_string(fid) +"_" + std::to_string(ib)).c_str(), name.c_str(), trees[fid]));
+                    log<LOG_INFO>(L"%1% || Setting up reco variable for this branch: %2%") % __func__ %  name.c_str();
+                }
 
                 //grab monte carlo weight
                 if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
@@ -1075,7 +1086,7 @@ namespace PROfit {
                 for(int ib = 0; ib != num_branch; ++ib) {
 
                     //guanqun: why have different types for branch_variables 
-                    double reco_value = branches[ib]->GetValue<double>();
+                    std::vector<double> reco_value = branches[ib]->GetValues<double>();
                     double additional_weight = branches[ib]->GetMonteCarloWeight();
                     additional_weight *= pot_scale[fid];
 
@@ -1088,7 +1099,7 @@ namespace PROfit {
                         continue;
 
                     if(i%100==0)	
-                        log<LOG_DEBUG>(L"%1% || Subchannel %2% -- Reco variable value: %3%, MC event weight: %4%, correponds to global bin: %5%") % __func__ %  subchannel_index[ib] % reco_value % additional_weight % global_bin;
+                        log<LOG_DEBUG>(L"%1% || Subchannel %2% -- Reco variable value: %3%, MC event weight: %4%, correponds to global bin: %5%") % __func__ %  subchannel_index[ib] % reco_value[0] % additional_weight % global_bin;
 
                     spec.Fill(global_bin, additional_weight);
 
@@ -1108,7 +1119,7 @@ namespace PROfit {
     void process_cafana_event(const PROconfig &inconfig, const std::shared_ptr<BranchVariable>& branch, const std::map<std::string, std::vector<eweight_type>*>& eventweight_map, double mcpot, int subchannel_index, std::vector<SystStruct>& syst_vector, const std::vector<double>& syst_additional_weight, PROpeller& inprop){
 
         int total_num_sys = syst_vector.size(); 
-      	double reco_value = branch->GetValue<double>();
+      	std::vector<double> reco_value = branch->GetValues<double>();
         double true_param = branch->GetTrueValue<double>();
         double baseline = branch->GetTrueL<double>();
         double true_value = baseline / true_param;
@@ -1125,7 +1136,11 @@ namespace PROfit {
         if(global_true_bin < 0)
             return;
 
-        inprop.reco.push_back((float)reco_value);
+        for (unsigned ir = 0; ir < reco_value.size(); ir++) {
+            if (inprop.recos.size() <= ir) inprop.recos.push_back({});
+            inprop.recos[ir].push_back(reco_value[ir]);
+        }
+
         inprop.added_weights.push_back(mc_weight);
         inprop.bin_indices.push_back(global_bin);
         inprop.pdg.push_back(pdg_id);
@@ -1170,7 +1185,7 @@ namespace PROfit {
     void process_sbnfit_event(const PROconfig &inconfig, const std::shared_ptr<BranchVariable>& branch, const std::map<std::string, std::vector<eweight_type>>& eventweight_map, int subchannel_index, std::vector<SystStruct>& syst_vector, const std::vector<double>& syst_additional_weight){
 
         int total_num_sys = syst_vector.size(); 
-        double reco_value = branch->GetValue<double>();
+        std::vector<double> reco_value = branch->GetValues<double>();
         double mc_weight = branch->GetMonteCarloWeight();
         int global_bin = FindGlobalBin(inconfig, reco_value, subchannel_index);
         if(global_bin < 0 )  //out of range

--- a/xml/PROxml_CAFAna2D.xml
+++ b/xml/PROxml_CAFAna2D.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" ?>
+
+<!--specifies neutrino mode or antineutrino mode-->
+<mode name="nu" />
+
+<detector name="SBND" />
+
+<channel name="numu" unit="Reconstructed Neutrino Energy [GeV]">
+<bins edges="0.3 0.4 0.45 0.5 0.55 0.6 0.65 0.7 0.75 0.8 0.85 0.9 0.95 1.0 1.25 1.5 2.0 2.5 3.0"/>
+<bins edges="0.3 0.4 0.45 0.5 0.55 0.6 0.65 0.7 0.75 0.8 0.85 0.9 0.95 1.0 1.25 1.5 2.0 2.5 3.0"/>
+        <truebins min="0" max="2" nbins="200"/>
+    <subchannel name="cc" plotname="#nu_{#mu} CC" color="#FF6961"/>
+</channel>
+
+<plotpot value="2e20"/>
+
+<variation_list>
+    <allowlist type="covariance">expskin_Flux</allowlist>  
+    <allowlist type="covariance">horncurrent_Flux</allowlist>  
+    <allowlist type="covariance">nucleoninexsec_Flux</allowlist>  
+    <allowlist type="covariance">nucleonqexsec_Flux</allowlist>  
+    <allowlist type="covariance">nucleontotxsec_Flux</allowlist>  
+    <allowlist type="covariance">pioninexsec_Flux</allowlist>  
+    <allowlist type="covariance">pionqexsec_Flux</allowlist>  
+    <allowlist type="covariance">piontotxsec_Flux</allowlist>  
+    <allowlist type="covariance">piplus_Flux</allowlist>  
+    <allowlist type="covariance">piminus_Flux</allowlist>  
+    <allowlist type="covariance">kplus_Flux</allowlist>  
+    <allowlist type="covariance">kminus_Flux</allowlist>  
+    <allowlist type="covariance">kzero_Flux</allowlist> 
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_CoulombCCQE</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_DISBYVariationResponse</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_FSI_N_VariationResponse</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_FSI_pi_VariationResponse</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_NCELVariationResponse</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_CCRESVariationResponse</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_NCRESVariationResponse</allowlist>-->
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC2pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC2pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC2pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC2pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC2pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC2pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC2pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC1pi</allowlist>
+    <allowlist type="covariance">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC2pi</allowlist>
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_NormCCMEC</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_NormNCMEC</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_RPA_CCQE</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisim_ZExpAVariationResponse</allowlist>-->
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_AhtBY</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_BhtBY</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_CoulombCCQE</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_CV1uBY</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_CV2uBY</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_EtaNCEL</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrAbs_N</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrAbs_pi</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrCEx_N</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrCEx_pi</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrInel_N</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrInel_pi</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrPiProd_N</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_FrPiProd_pi</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MFP_N</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MFP_pi</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MaCCRES</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MaNCEL</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MaNCRES</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MvCCRES</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MvNCRES</allowlist>
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarnCC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarnCC2pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarnNC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarnNC2pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarpCC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarpCC2pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarpNC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvbarpNC2pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvnCC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvnCC2pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvnNC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvnNC2pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvpCC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvpCC2pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvpNC1pi</allowlist>-->
+    <!--<allowlist>GENIEReWeight_SBN_v1_multisigma_NonRESBGvpNC2pi</allowlist>-->
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_NormCCMEC</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_NormNCMEC</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_RPA_CCQE</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_ZExpA1CCQE</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_ZExpA2CCQE</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_ZExpA3CCQE</allowlist>
+    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_ZExpA4CCQE</allowlist>
+</variation_list>
+
+<model tag="numudis">
+    <rule index="0" name="No Osc"/>
+    <rule index="1" name="Numu Dis"/>
+    <rule index="2" name="Nue App"/>
+</model>
+
+
+<MCFile treename="events/selectedNu" filename="selected_events.root" scale = "1.0" maxevents="50000" pot="2.8e20"> 
+    <friend treename="events/multisimTree" filename="selected_events.root"/>
+    <friend treename="events/multisigmaTree" filename="selected_events.root"/>
+     <branch
+         associated_subchannel = "nu_SBND_numu_cc"
+         name                  = "recoE:recoE"
+         true_param_name       = "trueE" 
+         model_rule            = "1"
+         true_L_name           = "trueL / 1000"
+         pdg_name              = "truePDG"
+         additional_weight     = "CC"
+         />
+</MCFile>
+
+


### PR DESCRIPTION
Implement by converting BranchVariable and PROpeller classes to use a vector of reconstructed variables. Add into XML configuration by having user specify multiple <bins> in a channel, and to split the name field by colon (:).