### PR TITLE
PROmodel

### DIFF
--- a/bin/PROfc.cxx
+++ b/bin/PROfc.cxx
@@ -5,6 +5,7 @@
 #include "PROtocall.h"
 #include "PROcreate.h"
 #include "PROpeller.h"
+#include "PROsc.h"
 #include "PROchi.h"
 #include "PROcess.h"
 #include "PROfitter.h"
@@ -47,16 +48,16 @@ void fc_worker(fc_args args) {
     std::mt19937 rng{rd()};
     PROsc osc(args.prop);
     PROchi::EvalStrategy strat = args.binned ? PROchi::BinnedChi2 : PROchi::EventByEvent;
+    Eigen::VectorXf throws = Eigen::VectorXf::Constant(args.phy_params.size() + args.systs.GetNSplines(), 0);
     for(size_t u = 0; u < args.todo; ++u) {
         log<LOG_INFO>(L"%1% | Thread #%2% Throw #%3%") % __func__ % args.thread % u;
         std::normal_distribution<float> d;
-        std::vector<float> throws;
         Eigen::VectorXf throwC = Eigen::VectorXf::Constant(args.config.m_num_bins_total, 0);
         for(size_t i = 0; i < args.systs.GetNSplines(); i++)
-            throws.push_back(d(rng));
+            throws(i+args.phy_params.size()) = d(rng);
         for(size_t i = 0; i < args.config.m_num_bins_total; i++)
             throwC(i) = d(rng);
-        PROspec shifted = FillRecoSpectra(args.config, args.prop, args.systs, &osc, throws, args.phy_params, strat);
+        PROspec shifted = FillRecoSpectra(args.config, args.prop, args.systs, osc, throws, strat);
         PROspec newSpec = PROspec::PoissonVariation(PROspec(CollapseMatrix(args.config, shifted.Spec()) + args.L * throwC, CollapseMatrix(args.config, shifted.Error())));
 
         // No oscillations

--- a/bin/PROfc.cxx
+++ b/bin/PROfc.cxx
@@ -72,7 +72,7 @@ void fc_worker(fc_args args) {
         Eigen::VectorXf ub = Eigen::VectorXf::Map(args.systs.spline_hi.data(), args.systs.spline_hi.size());
         PROfitter fitter(ub, lb, param);
 
-        PROchi chi("3plus1",&args.config,&args.prop,&args.systs,&osc, newSpec, nparams, args.systs.GetNSplines(), strat);
+        PROchi chi("3plus1",&args.config,&args.prop,&args.systs,&osc, newSpec, strat);
         float chi2_syst = fitter.Fit(chi);
 
         // With oscillations
@@ -93,7 +93,7 @@ void fc_worker(fc_args args) {
         }
         PROfitter fitter_osc(ub_osc, lb_osc, param);
 
-        PROchi chi_osc("3plus1",&args.config,&args.prop,&args.systs,&osc, newSpec, nparams, args.systs.GetNSplines(), strat);
+        PROchi chi_osc("3plus1",&args.config,&args.prop,&args.systs,&osc, newSpec, strat);
         float chi2_osc = fitter_osc.Fit(chi_osc); 
 
         Eigen::VectorXf t = Eigen::VectorXf::Map(throws.data(), throws.size());

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -81,8 +81,7 @@ int main(int argc, char* argv[])
 
     //PROfile(myConf, myprop, systs, osc, data, "profit_test", true);
     
-    PROchi chi("", &myConf, &myprop, &systs, &osc, data, systs.GetNSplines()+2, systs.GetNSplines(),
-            PROfit::PROchi::BinnedChi2);
+    PROchi chi("", &myConf, &myprop, &systs, &osc, data, PROfit::PROchi::BinnedChi2);
 
     LBFGSpp::LBFGSBParam<float> param;  
     param.epsilon = 1e-6;

--- a/bin/PROfit_CAFAna.cxx
+++ b/bin/PROfit_CAFAna.cxx
@@ -2,6 +2,7 @@
 #include "PROspec.h"
 #include "PROsyst.h"
 #include "PROcreate.h"
+#include "PROsc.h"
 #include "PROpeller.h"
 #include "PROchi.h"
 #include "PROcess.h"

--- a/bin/PROfit_CAFAna.cxx
+++ b/bin/PROfit_CAFAna.cxx
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
     newSpec.Print();
 
     //Build chi^2 object
-    PROchi chi("3plus1",&myConf,&myprop,&systs,oscillate ? &osc : NULL, newSpec, nparams, systs.GetNSplines());
+    PROchi chi("3plus1",&myConf,&myprop,&systs,oscillate ? &osc : NULL, newSpec);
 
     // Bounds
     Eigen::VectorXf lb = Eigen::VectorXf::Constant(nparams, -3.0);

--- a/bin/PROsurf.cxx
+++ b/bin/PROsurf.cxx
@@ -136,9 +136,9 @@ int main(int argc, char* argv[])
 
     PROmetric *metric;
     if(chi2 == "PROchi") {
-        metric = new PROchi("", &config, &prop, &systs, &osc, data, systs.GetNSplines(), systs.GetNSplines(), PROmetric::BinnedChi2);
+        metric = new PROchi("", &config, &prop, &systs, &osc, data, PROmetric::BinnedChi2);
     } else if(chi2 == "PROCNP") {
-        metric = new PROCNP("", &config, &prop, &systs, &osc, data, systs.GetNSplines(), systs.GetNSplines(), PROmetric::BinnedChi2);
+        metric = new PROCNP("", &config, &prop, &systs, &osc, data, PROmetric::BinnedChi2);
     } else {
         log<LOG_ERROR>(L"%1% || Unrecognized chi2 function %2%") % __func__ % chi2.c_str();
         abort();
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
 
     //Define grid and Surface
     size_t nbinsx = grid_size[0], nbinsy = grid_size[1];
-    PROsurf surface(*metric, 0, 1, nbinsx, logx ? PROsurf::LogAxis : PROsurf::LinAxis, xlo, xhi,
+    PROsurf surface(*metric, 1, 0, nbinsx, logx ? PROsurf::LogAxis : PROsurf::LinAxis, xlo, xhi,
                     nbinsy, logy ? PROsurf::LogAxis : PROsurf::LinAxis, ylo, yhi);
     
     if(statonly)

--- a/bin/PROsurf.cxx
+++ b/bin/PROsurf.cxx
@@ -105,14 +105,24 @@ int main(int argc, char* argv[])
     //Define the model (currently 3+1 SBL)
     PROsc osc(prop);
     
-    std::vector<float> pparams = {std::log10(injected_pt[0]), std::log10(injected_pt[1])};
+    Eigen::VectorXf pparams{{std::log10(injected_pt[0]), std::log10(injected_pt[1])}};
     log<LOG_INFO>(L"%1% || Injected point: sinsq2t = %2%, dmsq = %3%") % __func__ % injected_pt[0] % injected_pt[1];
-    for(const auto& [name, shift]: injected_systs)
-      log<LOG_INFO>(L"%1% || Injected syst: %2% shifted by %3%") % __func__ % name.c_str() % shift;
+    Eigen::VectorXf allparams = Eigen::VectorXf::Constant(osc.nparams + systs.GetNSplines(), 0);
+    for(int i = 0; i < pparams.size(); ++i) allparams(i) = pparams(i);
+    for(const auto& [name, shift]: injected_systs) {
+        log<LOG_INFO>(L"%1% || Injected syst: %2% shifted by %3%") % __func__ % name.c_str() % shift;
+        auto it = std::find(systs.spline_names.begin(), systs.spline_names.end(), name);
+        if(it == systs.spline_names.end()) {
+            log<LOG_ERROR>(L"%1% || Error: Unrecognized spline %2%. Ignoring this injected shift.") % __func__ % name.c_str();
+            continue;
+        }
+        int idx = std::distance(systs.spline_names.begin(), it);
+        allparams(idx) = shift;
+    }
     //Grab Asimov Data
-    PROspec data = injected_pt[0] != 0 && injected_pt[1] != 0 ? FillRecoSpectra(config, prop, systs, &osc, injected_systs, pparams, !eventbyevent) :
-                   injected_systs.size() ? FillRecoSpectra(config, prop, systs, injected_systs, !eventbyevent) :
-                   FillCVSpectrum(config, prop, !eventbyevent);
+    PROspec data = (injected_pt[0] != 0 && injected_pt[1] != 0) || injected_systs.size() ? 
+        FillRecoSpectra(config, prop, systs, osc, allparams, !eventbyevent) :
+        FillCVSpectrum(config, prop, !eventbyevent);
     Eigen::VectorXf data_vec = CollapseMatrix(config, data.Spec());
     Eigen::VectorXf err_vec_sq = data.Error().array().square();
     Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq).array().sqrt();

--- a/bin/PROsurf.cxx
+++ b/bin/PROsurf.cxx
@@ -146,13 +146,13 @@ int main(int argc, char* argv[])
 
     //Define grid and Surface
     size_t nbinsx = grid_size[0], nbinsy = grid_size[1];
-    PROsurf surface(*metric, nbinsx, logx ? PROsurf::LogAxis : PROsurf::LinAxis, xlo, xhi,
+    PROsurf surface(*metric, 0, 1, nbinsx, logx ? PROsurf::LogAxis : PROsurf::LinAxis, xlo, xhi,
                     nbinsy, logy ? PROsurf::LogAxis : PROsurf::LinAxis, ylo, yhi);
     
     if(statonly)
         surface.FillSurfaceStat(config, !savetoroot ? filename : "");
     else
-        surface.FillSurface(systs, !savetoroot ? filename : "", nthread);
+        surface.FillSurface(!savetoroot ? filename : "", nthread);
 
     //And do a PROfile of pulls at the data also
     //PROfile(config,prop,systs,osc,data,filename+"_PROfile");

--- a/bin/PROtest.cxx
+++ b/bin/PROtest.cxx
@@ -207,33 +207,33 @@ int main(int argc, char* argv[])
         std::vector<float> param = {0,0};
         std::vector<float> nulpram;
 
-        PROspec CVe = FillRecoSpectra(config, prop, systs, &osc, nulpram, nulpram, false);
-        CVe.plotSpectrum(config,"CVe");
-        CVe.Print();
-        PROspec CVb = FillRecoSpectra(config, prop, systs, &osc, nulpram, nulpram, true);
-        CVb.plotSpectrum(config,"CVb");
-        CVb.Print();
+        //PROspec CVe = FillRecoSpectra(config, prop, systs, &osc, nulpram, nulpram, false);
+        //CVe.plotSpectrum(config,"CVe");
+        //CVe.Print();
+        //PROspec CVb = FillRecoSpectra(config, prop, systs, &osc, nulpram, nulpram, true);
+        //CVb.plotSpectrum(config,"CVb");
+        //CVb.Print();
 
-        PROspec SYe = FillRecoSpectra(config, prop, systs, &osc, shift, nulpram, false);
-        SYe.plotSpectrum(config,"SYe");
-        SYe.Print();
-        PROspec SYb = FillRecoSpectra(config, prop, systs, &osc, shift, nulpram, true);
-        SYb.plotSpectrum(config,"SYb");
-        SYb.Print();
+        //PROspec SYe = FillRecoSpectra(config, prop, systs, &osc, shift, nulpram, false);
+        //SYe.plotSpectrum(config,"SYe");
+        //SYe.Print();
+        //PROspec SYb = FillRecoSpectra(config, prop, systs, &osc, shift, nulpram, true);
+        //SYb.plotSpectrum(config,"SYb");
+        //SYb.Print();
 
-        PROspec OSe = FillRecoSpectra(config, prop, systs, &osc, nulpram, param, false);
-        OSe.plotSpectrum(config,"OSe");
-        OSe.Print();
-        PROspec OSb = FillRecoSpectra(config, prop, systs, &osc, nulpram, param, true);
-        OSb.plotSpectrum(config,"OSb");
-        OSb.Print();
+        //PROspec OSe = FillRecoSpectra(config, prop, systs, &osc, nulpram, param, false);
+        //OSe.plotSpectrum(config,"OSe");
+        //OSe.Print();
+        //PROspec OSb = FillRecoSpectra(config, prop, systs, &osc, nulpram, param, true);
+        //OSb.plotSpectrum(config,"OSb");
+        //OSb.Print();
 
-        PROspec FUe = FillRecoSpectra(config, prop, systs, &osc, shift, param, false);
-        FUe.plotSpectrum(config,"FUe");
-        FUe.Print();
-        PROspec FUb = FillRecoSpectra(config, prop, systs, &osc, shift, param, true);
-        FUb.plotSpectrum(config,"FUb");
-        FUb.Print();
+        //PROspec FUe = FillRecoSpectra(config, prop, systs, &osc, shift, param, false);
+        //FUe.plotSpectrum(config,"FUe");
+        //FUe.Print();
+        //PROspec FUb = FillRecoSpectra(config, prop, systs, &osc, shift, param, true);
+        //FUb.plotSpectrum(config,"FUb");
+        //FUb.Print();
     }
 
     //test matrix generation 

--- a/bin/PROtest.cxx
+++ b/bin/PROtest.cxx
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
                 x[which_spline] = which_value;
 
 
-                PROchi chi("3plus1", &config, &prop, &systs, &osc, data, nparams, systs.GetNSplines(), PROchi::BinnedChi2, physics_params);
+                PROchi chi("3plus1", &config, &prop, &systs, &osc, data, PROchi::BinnedChi2, physics_params);
                 chi.fixSpline(which_spline,which_value);
 
                 log<LOG_INFO>(L"%1% || Starting Fixed fit ") % __func__  ;

--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -28,8 +28,6 @@ namespace PROfit{
             const PROsyst *syst; 
             const PROmodel *model;
             const PROspec data;
-            int nparams;
-            int nsyst;
             EvalStrategy strat;
             std::vector<float> physics_param_fixed;
                         //Do we want to fix any param?
@@ -46,7 +44,7 @@ namespace PROfit{
         public:
 
             /*Function: Constructor bringing all objects together*/
-            PROCNP(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, int nparams, int nsyst, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
+            PROCNP(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
@@ -71,18 +69,12 @@ namespace PROfit{
             }
 
             void override_systs(const PROsyst &new_syst) {
-                nparams -= nsyst;
                 syst = &new_syst;
-                nsyst = syst->GetNSplines();
-                nparams += nsyst;
             }
 
             float Pull(const Eigen::VectorXf &systs);
 
             void fixSpline(int fix, float valin);
-
-            int nParams() const {return nparams;}
-
     };
 
 

--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -56,14 +56,18 @@ namespace PROfit{
                 return new PROCNP(*this);
             }
 
+            virtual const PROmodel &GetModel() const {
+                return *model;
+            }
+
+            virtual const PROsyst &GetSysts() const {
+                return *syst;
+            }
+
             void reset() {
                 physics_param_fixed.clear();
                 last_value = 0;
                 last_param = Eigen::VectorXf::Constant(last_param.size(), 0);
-            }
-
-            void set_physics_param_fixed(const std::vector<float> &physics_param) {
-                physics_param_fixed = physics_param;
             }
 
             void override_systs(const PROsyst &new_syst) {

--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -11,7 +11,7 @@
 #include "PROconfig.h"
 #include "PROsyst.h"
 #include "PROpeller.h"
-#include "PROsc.h"
+#include "PROmodel.h"
 #include "PROcess.h"
 #include "PROmetric.h"
 
@@ -26,7 +26,7 @@ namespace PROfit{
             const PROconfig *config;
             const PROpeller *peller;
             const PROsyst *syst; 
-            const PROsc *osc;
+            const PROmodel *model;
             const PROspec data;
             int nparams;
             int nsyst;
@@ -46,7 +46,7 @@ namespace PROfit{
         public:
 
             /*Function: Constructor bringing all objects together*/
-            PROCNP(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROsc *oscin, const PROspec &datain, int nparams, int nsyst, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
+            PROCNP(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, int nparams, int nsyst, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -1,19 +1,14 @@
 #ifndef PROCESS_H
 #define PROCESS_H
 
-// C++ include 
-#include <algorithm>
-#include <unordered_map>
-#include <string>
+#include <Eigen/Eigen>
 
 // PROfit include 
-#include "PROlog.h"
 #include "PROconfig.h"
-#include "PROsc.h"
+#include "PROmodel.h"
 #include "PROpeller.h"
 #include "PROspec.h"
 #include "PROsyst.h"
-#include "PROcreate.h"
 
 namespace PROfit{
 
@@ -22,18 +17,8 @@ namespace PROfit{
      */
 
     PROspec FillCVSpectrum(const PROconfig &inconfig, const PROpeller &inprop, bool binned = false);
-
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsc *inosc, const std::vector<float> &physparams, bool binned = false);
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROsc *inosc, const std::vector<float> &inshifts, const std::vector<float> &physparams, bool binned = false);
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROsc *inosc, const std::map<std::string, float> &inshifts, const std::vector<float> &physparams, bool binned = false);
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const std::map<std::string, float> &inshifts, bool binned = false);
-
+    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned = true);
     PROspec FillSystRandomThrow(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst);
-
-    float GetOscWeight(int rule, float le, const PROsc &inosc, const std::vector<float> &inphysparams);
-    float GetOscWeight(int ev_idx, const PROpeller &inprop, const PROsc &inosc, const std::vector<float> &inphysparams);
-    float GetSystWeight(int ev_idx, const PROpeller &inprop, const PROsyst &insyst, float inshift, std::string insystname);
-
 };
 
 #endif

--- a/inc/PROchi.h
+++ b/inc/PROchi.h
@@ -11,7 +11,7 @@
 #include "PROconfig.h"
 #include "PROsyst.h"
 #include "PROpeller.h"
-#include "PROsc.h"
+#include "PROmodel.h"
 #include "PROcess.h"
 #include "PROmetric.h"
 
@@ -37,7 +37,7 @@ namespace PROfit{
             const PROconfig *config;
             const PROpeller *peller;
             const PROsyst *syst; 
-            const PROsc *osc;
+            const PROmodel *model;
             const PROspec data;
             int nparams;
             int nsyst;
@@ -58,7 +58,7 @@ namespace PROfit{
         public:
 
             /*Function: Constructor bringing all objects together*/
-            PROchi(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROsc *oscin, const PROspec &datain, int nparams, int nsyst, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
+            PROchi(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, int nparams, int nsyst, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);

--- a/inc/PROchi.h
+++ b/inc/PROchi.h
@@ -74,8 +74,12 @@ namespace PROfit{
                 return new PROchi(*this);
             }
 
-            virtual void set_physics_param_fixed(const std::vector<float> &physics_param) {
-                physics_param_fixed = physics_param;
+            virtual const PROmodel &GetModel() const {
+                return *model;
+            }
+
+            virtual const PROsyst &GetSysts() const {
+                return *syst;
             }
 
             virtual void override_systs(const PROsyst &new_syst) {

--- a/inc/PROchi.h
+++ b/inc/PROchi.h
@@ -39,8 +39,6 @@ namespace PROfit{
             const PROsyst *syst; 
             const PROmodel *model;
             const PROspec data;
-            int nparams;
-            int nsyst;
             EvalStrategy strat;
             std::vector<float> physics_param_fixed;
                         //Do we want to fix any param?
@@ -58,7 +56,7 @@ namespace PROfit{
         public:
 
             /*Function: Constructor bringing all objects together*/
-            PROchi(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, int nparams, int nsyst, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
+            PROchi(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, EvalStrategy strat = EventByEvent, std::vector<float> physics_param_fixed = std::vector<float>());
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
@@ -83,18 +81,12 @@ namespace PROfit{
             }
 
             virtual void override_systs(const PROsyst &new_syst) {
-                nparams -= nsyst;
                 syst = &new_syst;
-                nsyst = syst->GetNSplines();
-                nparams += nsyst;
             }
             
             float Pull(const Eigen::VectorXf &systs);
 
             void fixSpline(int fix, float valin);
-
-            virtual int nParams() const {return nparams;}
-
     };
 }
 #endif

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -22,9 +22,7 @@
 #include "tinyxml2.h"
 
 // EIGEN
-#include <Eigen/Core>
-#include <Eigen/Dense>
-#include <Eigen/SVD>
+#include <Eigen/Eigen>
 
 //PROfit
 #include "PROlog.h"

--- a/inc/PROmetric.h
+++ b/inc/PROmetric.h
@@ -16,7 +16,6 @@ public:
         BinnedChi2
     };
 
-    virtual int nParams() const = 0;
     virtual void override_systs(const PROsyst &new_syst) = 0;
     virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient) = 0;
     virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd) = 0;

--- a/inc/PROmetric.h
+++ b/inc/PROmetric.h
@@ -2,6 +2,7 @@
 #define PROMETRIC_H
 
 #include "PROsyst.h"
+#include "PROmodel.h"
 
 #include <Eigen/Eigen>
 
@@ -16,12 +17,13 @@ public:
     };
 
     virtual int nParams() const = 0;
-    virtual void set_physics_param_fixed(const std::vector<float> &physics_param) = 0;
     virtual void override_systs(const PROsyst &new_syst) = 0;
     virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient) = 0;
     virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd) = 0;
     virtual void reset() = 0;
     virtual PROmetric *Clone() const = 0;
+    virtual const PROmodel &GetModel() const = 0;
+    virtual const PROsyst  &GetSysts() const = 0;
     virtual ~PROmetric() {}
 };
 

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -13,8 +13,8 @@ class PROmodel {
 public:
     size_t nparams;
     std::vector<std::string> param_names;
-    std::vector<float> lb, ub;
-    std::vector<std::function<float(std::vector<float>, float)>> model_rules;
+    Eigen::VectorXf lb, ub;
+    std::vector<std::function<float(Eigen::VectorXf, float)>> model_functions;
     std::vector<Eigen::MatrixXf> hists;
 };
 

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -14,7 +14,7 @@ public:
     size_t nparams;
     std::vector<std::string> param_names;
     Eigen::VectorXf lb, ub;
-    std::vector<std::function<float(Eigen::VectorXf, float)>> model_functions;
+    std::vector<std::function<float(const Eigen::VectorXf&, float)>> model_functions;
     std::vector<Eigen::MatrixXf> hists;
 };
 

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -1,0 +1,24 @@
+#ifndef PROMODEL_H
+#define PROMODEL_H
+
+#include <Eigen/Eigen>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace PROfit {
+
+class PROmodel {
+public:
+    size_t nparams;
+    std::vector<std::string> param_names;
+    std::vector<float> lb, ub;
+    std::vector<std::function<float(std::vector<float>, float)>> model_rules;
+    std::vector<Eigen::MatrixXf> hists;
+};
+
+}
+
+#endif
+

--- a/inc/PROsc.h
+++ b/inc/PROsc.h
@@ -33,7 +33,7 @@ namespace PROfit{
      *  Add interfacte for defining own model
      */
 
-    class PROsc : PROmodel {
+    class PROsc : public PROmodel {
         public:
 
             PROsc(const PROpeller &prop) {

--- a/inc/PROsc.h
+++ b/inc/PROsc.h
@@ -54,6 +54,8 @@ namespace PROfit{
                 
                 nparams = 2;
                 param_names = {"dmsq", "sinsq2thmm"}; 
+                lb = Eigen::VectorXf(2);
+                ub = Eigen::VectorXf(2);
                 lb << -2, -std::numeric_limits<float>::infinity();
                 ub << 2, 0;
             };

--- a/inc/PROsurf.h
+++ b/inc/PROsurf.h
@@ -33,7 +33,7 @@ int PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &systs
 class PROsurf {
 public:
     PROmetric &metric;
-    size_t nbinsx, nbinsy;
+    size_t x_idx, y_idx, nbinsx, nbinsy;
     Eigen::VectorXf edges_x, edges_y;
     Eigen::MatrixXf surface;
 
@@ -42,14 +42,14 @@ public:
         LogAxis,
     };
 
-    PROsurf(PROmetric &metric, size_t nbinsx, const Eigen::VectorXf &edges_x, size_t nbinsy, const Eigen::VectorXf &edges_y) : metric(metric), nbinsx(nbinsx), nbinsy(nbinsy), edges_x(edges_x), edges_y(edges_y), surface(nbinsx, nbinsy) { }
+    PROsurf(PROmetric &metric, size_t x_idx, size_t y_idx, size_t nbinsx, const Eigen::VectorXf &edges_x, size_t nbinsy, const Eigen::VectorXf &edges_y) : metric(metric), x_idx(x_idx), y_idx(y_idx), nbinsx(nbinsx), nbinsy(nbinsy), edges_x(edges_x), edges_y(edges_y), surface(nbinsx, nbinsy) { }
 
-    PROsurf(PROmetric &metric, size_t nbinsx, LogLin llx, float x_lo, float x_hi, size_t nbinsy, LogLin lly, float y_lo, float y_hi);
+    PROsurf(PROmetric &metric, size_t x_idx, size_t y_idx, size_t nbinsx, LogLin llx, float x_lo, float x_hi, size_t nbinsy, LogLin lly, float y_lo, float y_hi);
 
-    std::vector<surfOut> PointHelper(const PROsyst *systs, std::vector<surfOut> multi_physics_params, int start, int end);
+    std::vector<surfOut> PointHelper(std::vector<surfOut> multi_physics_params, int start, int end);
 
     void FillSurfaceStat(const PROconfig &config, std::string filename);
-    void FillSurface(const PROsyst &systs, std::string filename, int nthreads = 1);
+    void FillSurface(std::string filename, int nthreads = 1);
 
 };
 

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -10,14 +10,14 @@
 using namespace PROfit;
 
 
-PROCNP::PROCNP(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, int nparams, int nsyst, EvalStrategy strat, std::vector<float> physics_param_fixed) : PROmetric(), model_tag(tag), config(conin), peller(pin), syst(systin), model(modelin), data(datain), nparams(nparams), nsyst(nsyst), strat(strat), physics_param_fixed(physics_param_fixed), correlated_systematics(false) {
-    last_value = 0.0; last_param = Eigen::VectorXf::Zero(nparams); 
+PROCNP::PROCNP(const std::string tag, const PROconfig *conin, const PROpeller *pin, const PROsyst *systin, const PROmodel *modelin, const PROspec &datain, EvalStrategy strat, std::vector<float> physics_param_fixed) : PROmetric(), model_tag(tag), config(conin), peller(pin), syst(systin), model(modelin), data(datain), strat(strat), physics_param_fixed(physics_param_fixed), correlated_systematics(false) {
+    last_value = 0.0; last_param = Eigen::VectorXf::Zero(model->nparams+syst->GetNSplines()); 
     fixed_index = -999;
 
     // Build the correlation matrix between priors if configured to
     if (conin->m_mcgen_correlations.size()) {
         correlated_systematics = true;
-        prior_covariance = Eigen::MatrixXf::Identity(nsyst, nsyst);
+        prior_covariance = Eigen::MatrixXf::Identity(syst->GetNSplines(), syst->GetNSplines());
         for (auto const &t: conin->m_mcgen_correlations) {
           auto itA = std::find(systin->spline_names.begin(), systin->spline_names.end(), std::get<0>(t));
           if (itA == systin->spline_names.end()) {
@@ -60,6 +60,8 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
 
 float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient){
+    size_t nparams = model->nparams+syst->GetNSplines();
+    size_t nsyst = syst->GetNSplines();
 
     // Get Spectra from FillRecoSpectra
     Eigen::VectorXf subvector1 = param.segment(0, nparams - nsyst);

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -7,80 +7,45 @@
 #include <Eigen/Eigen>
 
 #include <random>
-#include <string>
 #include <vector>
 
 namespace PROfit {
     PROspec FillCVSpectrum(const PROconfig &inconfig, const PROpeller &inprop, bool binned){
-
         PROspec myspectrum(inconfig.m_num_bins_total);
 
         if(binned) {
-            for(size_t i = 0; i < inprop.hist.rows(); ++i) {
-                float le = inprop.histLE[i];
-                float systw = 1;
+            for(int i = 0; i < inprop.hist.rows(); ++i) {
                 for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                    myspectrum.Fill(k, systw * inprop.hist(i, k));
+                    myspectrum.Fill(k, inprop.hist(i, k));
                 }
             }
         } else {
             for(size_t i = 0; i<inprop.truth.size(); ++i){
-
                 float add_w = inprop.added_weights[i]; 
                 myspectrum.Fill(inprop.bin_indices[i], add_w);
             }
         }
         return myspectrum;
-
     }
 
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsc *inosc, const std::vector<float> &physparams, bool binned){
+    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned){
 
         PROspec myspectrum(inconfig.m_num_bins_total);
-
-        if(binned) {
-            for(long int i = 0; i < inprop.hist.rows(); ++i) {
-                float le = inprop.histLE[i];
-                if(physparams.size() != 0) {
-                    for(size_t j = 0; j < inosc->model_functions.size(); ++j) {
-                        float oscw = GetOscWeight(j, le, *inosc, physparams);
-                        for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                            myspectrum.Fill(k, oscw * inosc->hists[j](i, k));
-                        }
-                    }
-                } else {
-                    for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, inprop.hist(i, k));
-                    }
-                }
-            }
-        } else {
-            for(size_t i = 0; i<inprop.truth.size(); ++i){
-                float oscw  = physparams.size() != 0 ? GetOscWeight(i, inprop, *inosc, physparams) : 1;
-                float add_w = inprop.added_weights[i]; 
-                myspectrum.Fill(inprop.bin_indices[i], oscw * add_w);
-            }
-        }
-        return myspectrum;
-
-    }
-
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROsc *inosc, const std::vector<float> &inshifts, const std::vector<float> &physparams, bool binned){
-
-        PROspec myspectrum(inconfig.m_num_bins_total);
+        Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);
+        Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
 
         if(binned) {
             for(long int i = 0; i < inprop.hist.rows(); ++i) {
                 float le = inprop.histLE[i];
                 float systw = 1;
-                for(size_t j = 0; j < inshifts.size(); ++j) {
-                    systw *= insyst.GetSplineShift(j, inshifts[j], i);
+                for(int j = 0; j < shifts.size(); ++j) {
+                    systw *= insyst.GetSplineShift(j, shifts(j), i);
                 }
-                if(physparams.size() != 0) {
-                    for(size_t j = 0; j < inosc->model_functions.size(); ++j) {
-                        float oscw = GetOscWeight(j, le, *inosc, physparams);
+                if(phys.size() != 0) {
+                    for(size_t j = 0; j < inmodel.model_functions.size(); ++j) {
+                        float oscw = inmodel.model_functions[j](phys, le);
                         for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                            myspectrum.Fill(k, systw * oscw * inosc->hists[j](i, k));
+                            myspectrum.Fill(k, systw * oscw * inmodel.hists[j](i, k));
                         }
                     }
                 } else {
@@ -92,92 +57,19 @@ namespace PROfit {
         } else {
             for(size_t i = 0; i<inprop.truth.size(); ++i){
 
-                float oscw  = physparams.size() != 0 ? GetOscWeight(i, inprop, *inosc, physparams) : 1;
+                float oscw  = phys.size() != 0 ? 
+                    inmodel.model_functions[inprop.model_rule[i]](phys, inprop.baseline[i] / inprop.truth[i]) :
+                    1;
                 float add_w = inprop.added_weights[i]; 
                 const int true_bin = inprop.true_bin_indices[i]; 
                 
                 float systw = 1;
-                for(size_t j = 0; j < inshifts.size(); ++j) {
-                    systw *= insyst.GetSplineShift(j, inshifts[j], true_bin);
+                for(int j = 0; j < shifts.size(); ++j) {
+                    systw *= insyst.GetSplineShift(j, shifts(j), true_bin);
                 }
 
                 float finalw = oscw * systw * add_w;
 
-                myspectrum.Fill(inprop.bin_indices[i], finalw);
-            }
-        }
-        return myspectrum;
-
-    }
-
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROsc *inosc, const std::map<std::string, float> &inshifts, const std::vector<float> &physparams, bool binned){
-
-        PROspec myspectrum(inconfig.m_num_bins_total);
-
-        if(binned) {
-            for(long int i = 0; i < inprop.hist.rows(); ++i) {
-                float le = inprop.histLE[i];
-                float systw = 1;
-                for(const auto &[name, shift]: inshifts) {
-                    systw *= insyst.GetSplineShift(name, shift, i);
-                }
-                if(physparams.size() != 0) {
-                    for(size_t j = 0; j < inosc->model_functions.size(); ++j) {
-                        float oscw = GetOscWeight(j, le, *inosc, physparams);
-                        for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                            myspectrum.Fill(k, systw * oscw * inosc->hists[j](i, k));
-                        }
-                    }
-                } else {
-                    for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, systw * inprop.hist(i, k));
-                    }
-                }
-            }
-        } else {
-            for(size_t i = 0; i<inprop.truth.size(); ++i){
-
-                float oscw  = physparams.size() != 0 ? GetOscWeight(i, inprop, *inosc, physparams) : 1;
-                float add_w = inprop.added_weights[i]; 
-                const int true_bin = inprop.true_bin_indices[i]; 
-                
-                float systw = 1;
-                for(const auto &[name, shift]: inshifts) {
-                    systw *= insyst.GetSplineShift(name, shift, true_bin);
-                }
-
-                float finalw = oscw * systw * add_w;
-
-                myspectrum.Fill(inprop.bin_indices[i], finalw);
-            }
-        }
-        return myspectrum;
-
-    }
-
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const std::map<std::string, float> &inshifts, bool binned) {
-
-        PROspec myspectrum(inconfig.m_num_bins_total);
-
-        if(binned) {
-            for(long int i = 0; i < inprop.hist.rows(); ++i) {
-                float systw = 1;
-                for(const auto &[name, shift]: inshifts) {
-                    systw *= insyst.GetSplineShift(name, shift, i);
-                }
-                for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                    myspectrum.Fill(k, systw * inprop.hist(i, k));
-                }
-            }
-        } else {
-            for(size_t i = 0; i<inprop.truth.size(); ++i){
-                float add_w = inprop.added_weights[i]; 
-                const int true_bin = inprop.true_bin_indices[i]; 
-                float systw = 1;
-                for(const auto &[name, shift]: inshifts) {
-                    systw *= insyst.GetSplineShift(name, shift, true_bin);
-                }
-                float finalw = systw * add_w;
                 myspectrum.Fill(inprop.bin_indices[i], finalw);
             }
         }
@@ -228,23 +120,4 @@ namespace PROfit {
         
         return PROspec(final_spec, final_spec.array().sqrt());
     }
-
-    float GetOscWeight(int rule, float le, const PROsc &inosc, const std::vector<float> &inphysparams) {
-        // The model functions take L and E separately, so give E as 1 and L as L/E
-        // input here is in logspace, and the model functions also expect log space NOW 
-        return inosc.model_functions[rule](inphysparams, 1, le);
-    }
-
-    float GetOscWeight(int ev_idx, const PROpeller &inprop, const PROsc &inosc, const std::vector<float> &inphysparams) {
-
-        //get subchannel here from pdg. this will be added when we agree on convention.
-        //for now everything is numu disappearance 3+1. 
-        // inphysparams[0] is log(delta-msq)
-        // inphysparams[1] is sinsq2thmumu
-        // input here is in logspace, and the model functions also expect log space NOW std::pow(10, inphysparams[0]), std::pow(10, inphysparams[1])
-
-        float prob = inosc.model_functions[inprop.model_rule[ev_idx]](inphysparams, inprop.truth[ev_idx], inprop.baseline[ev_idx] );
-        return prob;
-    }
-
 };

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -29,10 +29,11 @@ namespace PROfit {
     }
 
     PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned){
-
         PROspec myspectrum(inconfig.m_num_bins_total);
         Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);
-        Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
+        Eigen::VectorXf shifts;
+        if((size_t)params.size() > inmodel.nparams) 
+            shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
 
         if(binned) {
             for(long int i = 0; i < inprop.hist.rows(); ++i) {

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -31,9 +31,7 @@ namespace PROfit {
     PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned){
         PROspec myspectrum(inconfig.m_num_bins_total);
         Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);
-        Eigen::VectorXf shifts;
-        if((size_t)params.size() > inmodel.nparams) 
-            shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
+        Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
 
         if(binned) {
             for(long int i = 0; i < inprop.hist.rows(); ++i) {

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -109,10 +109,10 @@ std::vector<surfOut> PROsurf::PointHelper(std::vector<surfOut> multi_physics_par
         Eigen::VectorXf ub(nparams+2);
         ub << local_metric->GetModel().ub, Eigen::VectorXf::Map(local_metric->GetSysts().spline_hi.data(), local_metric->GetSysts().spline_hi.size());
 
-        lb(x_idx) = multi_physics_params[i].grid_val[0];
-        ub(x_idx) = multi_physics_params[i].grid_val[0];
-        lb(y_idx) = multi_physics_params[i].grid_val[1];
-        ub(y_idx) = multi_physics_params[i].grid_val[1];
+        lb(x_idx) = multi_physics_params[i].grid_val[1];
+        ub(x_idx) = multi_physics_params[i].grid_val[1];
+        lb(y_idx) = multi_physics_params[i].grid_val[0];
+        ub(y_idx) = multi_physics_params[i].grid_val[0];
 
         PROfitter fitter(ub, lb, param);
         output.chi = fitter.Fit(*local_metric);
@@ -292,7 +292,7 @@ int PROfit::PROfile(const PROconfig &config, const PROpeller &prop, const PROsys
 
             PROfitter fitter(ub, lb, param);
 
-            PROchi chi("3plus1", &config, &prop, &systs, &osc, data, nparams, systs.GetNSplines(), PROchi::BinnedChi2);
+            PROchi chi("3plus1", &config, &prop, &systs, &osc, data, PROchi::BinnedChi2);
             chi.fixSpline(which_spline,which_value);
 
             fx = fitter.Fit(chi,last_bf);

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -1,8 +1,9 @@
 #include "PROsurf.h"
-#include "Eigen/src/Core/Matrix.h"
 #include "PROfitter.h"
 #include "PROCNP.h"
 #include "PROlog.h"
+
+#include <Eigen/Eigen>
 
 using namespace PROfit;
 
@@ -63,7 +64,7 @@ void PROsurf::FillSurfaceStat(const PROconfig &config, std::string filename) {
 
     for(size_t i = 0; i < nbinsx; i++) {
         for(size_t j = 0; j < nbinsy; j++) {
-            Eigen::VectorXf physics_params = {(float)edges_y(j), (float)edges_x(i)};
+            Eigen::VectorXf physics_params{{(float)edges_y(j), (float)edges_x(i)}};
             float fx = (*local_metric)(physics_params, empty_vec, false);
             surface(i, j) = fx;
             if(!filename.empty()){


### PR DESCRIPTION
Add a PROmodel class and make PROchi and PROCNP use PROmodel instead of PROsc.

No new models added.
PROsc now inherits from PROmodel, but PROsc is still numu-dis only and not full 3+1.