### PR TITLE
Feature/etw fixsigmaplot

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
 
     }
 
-    PROfile(myConf, myprop, systs, *model, data, chi,filename, true, nthread, best_fit);
+    PROfile(myConf, myprop, systs, *model, data, chi,filename, true, nthread, best_fit, pparams);
 
     return 0;
 }

--- a/bin/PROmock.cxx
+++ b/bin/PROmock.cxx
@@ -256,7 +256,7 @@ int main(int argc, char* argv[])
 
     log<LOG_DEBUG>(L"%1% || Fit finished, now running PROfile") % __func__ ;    
 
-    PROfile(config, prop, systs, *model, data, chi, filename, floatosc, nthread, best_fit);
+    PROfile(config, prop, systs, *model, data, chi, filename, floatosc, nthread, best_fit, physics_params);
   }
   
   return 0;

--- a/bin/PROmock.cxx
+++ b/bin/PROmock.cxx
@@ -250,13 +250,9 @@ int main(int argc, char* argv[])
         lb(i) = systs.spline_lo[i-2];
         ub(i) = systs.spline_hi[i-2];
     }
-    log<LOG_DEBUG>(L"%1% || Set up eigenvector, nparams is %2%") % __func__ % nparams;    
     PROfitter fitter(ub, lb, param);
-    log<LOG_DEBUG>(L"%1% || fitter done") % __func__ ;
     float chi2 = fitter.Fit(chi);
-    log<LOG_DEBUG>(L"%1% || chi2 extracted") % __func__ ;    
     Eigen::VectorXf best_fit = fitter.best_fit;
-    log<LOG_DEBUG>(L"%1% || best fit extracted") % __func__ ;        
 
     log<LOG_DEBUG>(L"%1% || Fit finished, now running PROfile") % __func__ ;    
 

--- a/inc/PROsurf.h
+++ b/inc/PROsurf.h
@@ -37,7 +37,7 @@ struct profOut{
 
 class PROfile {
 
-	public:
+        public:
 	PROmetric &metric;
 
   PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &systs, const PROmodel &model, const PROspec &data, PROmetric &metric, std::string filename, bool with_osc = false, int nThreads = 1, const Eigen::VectorXf& init_seed = Eigen::VectorXf(), const Eigen::VectorXf& true_params = Eigen::VectorXf() ) ;

--- a/inc/PROsurf.h
+++ b/inc/PROsurf.h
@@ -40,7 +40,7 @@ class PROfile {
 	public:
 	PROmetric &metric;
 
-	PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &systs, const PROmodel &model, const PROspec &data, PROmetric &metric, std::string filename, bool with_osc = false, int nThreads = 1, const Eigen::VectorXf& init_seed = Eigen::VectorXf() ) ;
+  PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &systs, const PROmodel &model, const PROspec &data, PROmetric &metric, std::string filename, bool with_osc = false, int nThreads = 1, const Eigen::VectorXf& init_seed = Eigen::VectorXf(), const Eigen::VectorXf& true_params = Eigen::VectorXf() ) ;
 
     	std::vector<profOut> PROfilePointHelper(const PROsyst *systs, int start, int end, bool with_osc, const Eigen::VectorXf& init_seed = Eigen::VectorXf());
 };

--- a/inc/PROsurf.h
+++ b/inc/PROsurf.h
@@ -16,8 +16,10 @@
 #include <future>
 
 #include "TGraph.h"
+#include "TGraphAsymmErrors.h"
 #include "TMarker.h"
 #include "TLine.h"
+#include "TText.h"
 
 namespace PROfit {
 

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -396,8 +396,8 @@ PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &
 	barvalues.push_back(float(count)+0.5);
 	barvalues_err.push_back(0.4);
         bfvalues.push_back(tmp[0]);
-	values1_up.push_back(tmp[1]);
-	values1_down.push_back(tmp[2]);
+	values1_down.push_back(tmp[1]);
+	values1_up.push_back(tmp[2]);
 	values1_errdown.push_back(abs(tmp[1]-tmp[0]));
         values1_errup.push_back(abs(tmp[2]-tmp[0]));
 	log<LOG_DEBUG>(L"%1% || Results of findMinAndBounds : %2% %3% %4% ") % __func__ % tmp[0] % tmp[1] % tmp[2];
@@ -422,8 +422,9 @@ PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &
     TGraphAsymmErrors *h1 = new TGraphAsymmErrors(barvalues.size(),barvalues.data(), bfvalues.data(), barvalues_err.data(), barvalues_err.data(), values1_errdown.data(), values1_errup.data());
     h1->SetFillColor(kBlue-7);
     h1->SetStats(0);
-    h1->SetMinimum(min(-1.2,minVal*1.2));
-    h1->SetMaximum(max(1.2,maxVal*1.2));
+    //h1->SetMinimum(min(-1.2,minVal*1.2));
+    h1->SetMinimum(minVal*1.2);
+    h1->SetMaximum(maxVal*1.2);
 
     h1->GetXaxis()->SetNdivisions(barvalues.size());  // Set number of tick marks
     h1->GetXaxis()->SetLabelSize(0);  // Hide default numerical labels

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -432,12 +432,13 @@ PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &
     h1->Draw("A2");
     h1->GetYaxis()->SetTitle("#sigma Shift");
 
-    float y_min = h1->GetYaxis()->GetXmin();  // Get Y-axis min value for label positioning
+    float y_min = h1->GetMinimum();
     for (size_t i = 0; i < barvalues.size(); ++i) {
-      TText* text = new TText(barvalues[i], y_min - 0.5, names[i].c_str());  // Position text below axis
-      text->SetTextAlign(31);  // Center align the text
-      text->SetTextSize(0.03); // Adjust text size
-      text->SetTextAngle(-45); //Angle the text
+      std::string label = i < model.nparams ? "Log_{10}(" + model.pretty_param_names[i]+")" : names[i];
+      TText* text = new TText(barvalues[i], y_min - 0.05, label.c_str());  // Position text below axis
+      text->SetTextAlign(13);  
+      text->SetTextSize(0.03); 
+      text->SetTextAngle(-45); 
       text->Draw();
     }
 

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -275,7 +275,7 @@ std::vector<float> findMinAndBounds(TGraph *g, float val,float range) {
 }
 
 
-PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &systs, const PROmodel &model, const PROspec &data, PROmetric &metric, std::string filename, bool with_osc, int nThreads, const Eigen::VectorXf & init_seed) : metric(metric) {
+PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &systs, const PROmodel &model, const PROspec &data, PROmetric &metric, std::string filename, bool with_osc, int nThreads, const Eigen::VectorXf & init_seed, const Eigen::VectorXf & true_params) : metric(metric) {
 
     LBFGSpp::LBFGSBParam<float> param;
     param.epsilon = 1e-6;
@@ -462,11 +462,18 @@ PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &
     l.Draw();
 
     for (int i = 0; i < nBins; ++i) {
-        TMarker* star = new TMarker(i+0.5, bfvalues[i], 29);
+	if (i < true_params.size()) {
+	  TMarker* truestar = new TMarker(i+0.5, true_params[i], 29);
+	  truestar->SetMarkerSize(0.6); 
+	  truestar->SetMarkerColor(kRed); 
+	  truestar->Draw();
+	}	  
+      TMarker* star = new TMarker(i+0.5, bfvalues[i], 29);
         star->SetMarkerSize(0.5); 
         star->SetMarkerColor(kBlack); 
         star->Draw();
     }
+
 
 
     c2->SaveAs((filename+"_1sigma.pdf").c_str(),"pdf");

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -435,9 +435,9 @@ PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &
     float y_min = h1->GetYaxis()->GetXmin();  // Get Y-axis min value for label positioning
     for (size_t i = 0; i < barvalues.size(); ++i) {
       TText* text = new TText(barvalues[i], y_min - 0.5, names[i].c_str());  // Position text below axis
-      text->SetTextAlign(22);  // Center align the text
+      text->SetTextAlign(31);  // Center align the text
       text->SetTextSize(0.03); // Adjust text size
-      text->SetTextAngle(45); //Angle the text
+      text->SetTextAngle(-45); //Angle the text
       text->Draw();
     }
 

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -431,7 +431,7 @@ PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &
 
     h1->SetTitle("");
     h1->Draw("A2");
-    h1->GetYaxis()->SetTitle("#sigma Shift");
+    //h1->GetYaxis()->SetTitle("#sigma Shift");
 
     float y_min = h1->GetMinimum();
     for (size_t i = 0; i < barvalues.size(); ++i) {
@@ -462,12 +462,19 @@ PROfile::PROfile(const PROconfig &config, const PROpeller &prop, const PROsyst &
     l.Draw();
 
     for (int i = 0; i < nBins; ++i) {
-	if (i < true_params.size()) {
+      TMarker* initstar = new TMarker(i+0.5, init_seed[i], 29);
+      initstar->SetMarkerSize(0.6); 
+      initstar->SetMarkerColor(kBlue); 
+      initstar->Draw();
+
+      if (i < true_params.size()) {
+
 	  TMarker* truestar = new TMarker(i+0.5, true_params[i], 29);
-	  truestar->SetMarkerSize(0.6); 
+	  truestar->SetMarkerSize(0.5); 
 	  truestar->SetMarkerColor(kRed); 
 	  truestar->Draw();
-	}	  
+	}
+      
       TMarker* star = new TMarker(i+0.5, bfvalues[i], 29);
         star->SetMarkerSize(0.5); 
         star->SetMarkerColor(kBlack); 


### PR DESCRIPTION
Rework the 1-sigma plot produced by PROfile using TGraphAsymmErrors. Main purpose is to fix bug where one edge of osc par fit was fixed at zero instead of the actual value. Also added  stars marking the true value and global best fit value to the plot.