### PR TITLE
New XML variation type included flat systematics for substrings

### DIFF
--- a/bin/PROfc.cxx
+++ b/bin/PROfc.cxx
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
     std::vector<SystStruct> systsstructs;
     PROcess_CAFAna(myConf, systsstructs, myprop);
 
-    PROsyst systs(myprop, systsstructs);
+    PROsyst systs(myprop, myConf, systsstructs);
     std::unique_ptr<PROmodel> model = get_model_from_string(myConf.m_model_tag, myprop);
 
     std::vector<float> pparams = {std::log10(injected_pt[0]), std::log10(injected_pt[1])};

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -185,7 +185,7 @@ int main(int argc, char* argv[])
     }
 
     //Build a PROsyst to sort and analyze all systematics
-    PROsyst systs(prop,systsstructs, shapeonly);
+    PROsyst systs(prop, config, systsstructs, shapeonly);
     std::unique_ptr<PROmodel> model = get_model_from_string(config.m_model_tag, prop);
 
     //Some eystematics might be ignored for this

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -288,6 +288,7 @@ namespace PROfit{
             std::string m_write_out_tag;
             int m_num_variation_type_covariance = 0;
             int m_num_variation_type_spline = 0;
+            int m_num_variation_type_flat = 0;
 
             int m_num_mcgen_files;
             std::vector<std::string> m_mcgen_tree_name;	

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -39,7 +39,7 @@ namespace PROfit{
 
     /*Struct: Core systeatics object, one per systematics, handels both 1D splines, Covariances and MFA
      *Notes:
-     *  
+     * 
      */
     struct SystStruct {
 

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -21,14 +21,14 @@ namespace PROfit {
             using Spline = std::vector<std::vector<std::pair<float, std::array<float, 4>>>>;
             
             enum class SystType {
-                Spline, Covariance, MFA
+                Spline, Covariance,  MFA
             };
 
             //Empty constructor
             PROsyst(){}
 
             /*Function: Primary constructor from a vector of SystStructs  */
-            PROsyst(const PROpeller &prop, const std::vector<SystStruct>& systs, bool shapeonly=false);
+            PROsyst(const PROpeller &prop, const PROconfig &config, const std::vector<SystStruct>& systs, bool shapeonly=false);
 
             PROsyst subset(const std::vector<std::string> &systs);
             PROsyst excluding(const std::vector<std::string> &systs);
@@ -64,6 +64,11 @@ namespace PROfit {
              * Note: this function is lazy. It wouldn't do anything if it found covariance matrix with the same name already in the map.
              */
             void CreateMatrix(const SystStruct& syst);
+
+            /* Function: Given a SystStruct, generate a FLAT norm fractinal covariance matrix, and correlation matrix, and add matrices to covmat_map and corrtmat_map
+             * Note: this function is lazy. It wouldn't do anything if it found covariance matrix with the same name already in the map.
+             */
+            void CreateFlatMatrix(const PROconfig& config, const SystStruct& syst);
 
             /* Function: given a syst struct with cv and variation spectra, build fractional covariance matrix for the systematics, as well as correlation matrix 
              * Return: {fractional covariance matrix, correlation covariance matrix}

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -912,9 +912,14 @@ int PROconfig::LoadFromXML(const std::string &filename){
         else if(m_mcgen_variation_type[i] == "covariance"){
             m_num_variation_type_covariance+=1;
         }
+        
+        else if(m_mcgen_variation_type[i] == "flat"){
+            m_num_variation_type_flat+=1;
+        }
     }
 
     log<LOG_INFO>(L"%1% || num_variation_type_covariance: %2% ") % __func__ % m_num_variation_type_covariance;
+    log<LOG_INFO>(L"%1% || num_variation_type_flat: %2% ") % __func__ % m_num_variation_type_flat;
     log<LOG_INFO>(L"%1% || num_variation_type_spline: %2% ") % __func__ % m_num_variation_type_spline; 
 
 

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -1000,7 +1000,8 @@ namespace PROfit {
 
             if(std::isinf(sys_weight_value) || sys_weight_value != sys_weight_value){
                 log<LOG_ERROR>(L"%1% || Input values to histogram is NAN or inf %2% !") % __func__  % sys_weight_value ;
-                throw std::runtime_error("NAN or INF in put string");
+                throw std::runtime_error("NAN or INF in pus
+                        t string");
             }
 
             int nuniv = syst.GetNUniverse();

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -277,9 +277,10 @@ namespace PROfit {
             s.SanityCheck();
 
 
-        //create 2D multi-universe spec.
+        //create 2D multi-universe spec for covariances
         for(auto& s : syst_vector){
-            s.CreateSpecs(inconfig.m_num_bins_total);	
+            if(s.mode=="covariance")
+                s.CreateSpecs(inconfig.m_num_bins_total);	
         }
 
 
@@ -560,6 +561,15 @@ namespace PROfit {
             }
         } // end fid
 
+        //Do we have any flat systeatics?
+        if(inconfig.m_num_variation_type_flat>0){
+            for(auto& allow_sys : inconfig.m_mcgen_variation_type_map){
+                if(allow_sys.second=="flat"){
+                    map_systematic_num_universe[allow_sys.first] = -1;
+                }
+            }
+        }
+
         size_t total_num_systematics = map_systematic_num_universe.size();
         log<LOG_INFO>(L"%1% || Found %2% unique variations") % __func__ % total_num_systematics;
         for(auto& sys_pair : map_systematic_num_universe){
@@ -592,6 +602,12 @@ namespace PROfit {
                 syst_vector.back().knobval = syst_vector.back().knob_index;
                 std::sort(syst_vector.back().knobval.begin(), syst_vector.back().knobval.end());
             }
+            if(sys_mode == "flat"){
+
+                log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a flat norm systematic. Processing a such. ") % __func__ % sys_name.c_str();
+
+            }
+
 
             for(size_t i = 0 ; i != inconfig.m_mcgen_weightmaps_patterns.size(); ++i){
                 if (inconfig.m_mcgen_weightmaps_uses[i] && sys_name.find(inconfig.m_mcgen_weightmaps_patterns[i]) != std::string::npos) {
@@ -617,6 +633,8 @@ namespace PROfit {
 
         //create 2D multi-universe spec.
         for(auto& s : syst_vector){
+            if(s.mode=="flat")
+                continue;	
             s.CreateSpecs(s.mode == "spline" ? inconfig.m_num_truebins_total : inconfig.m_num_bins_total);	
         }
 
@@ -1000,8 +1018,7 @@ namespace PROfit {
 
             if(std::isinf(sys_weight_value) || sys_weight_value != sys_weight_value){
                 log<LOG_ERROR>(L"%1% || Input values to histogram is NAN or inf %2% !") % __func__  % sys_weight_value ;
-                throw std::runtime_error("NAN or INF in pus
-                        t string");
+                throw std::runtime_error("NAN or INF in pushed string");
             }
 
             int nuniv = syst.GetNUniverse();
@@ -1389,7 +1406,7 @@ namespace PROfit {
                     syst_obj.FillUniverse(u, global_true_bin, mc_weight * additional_weight * static_cast<float>(map_iter->second->at(is)));
                 }
                 continue;
-            }else{
+            }else if(syst_obj.mode == "covariance"){
 
                 syst_obj.FillCV(global_bin, mc_weight);
                 for(int iuni = 0; iuni < syst_obj.GetNUniverse(); ++iuni){


### PR DESCRIPTION
New XML variation type included flat
```
<variation_list>                          
    <allowlist type="flat">nu_SBND_numu_nc:0.1</allowlist>
    <allowlist type="flat">_nc:0.2</allowlist>
    <allowlist type="covariance">expskin_Flux</allowlist>  
    <allowlist type="covariance">horncurrent_Flux</allowlist>  
    <allowlist type="covariance">kminus_Flux</allowlist>  
    <allowlist type="covariance">kzero_Flux</allowlist> 
    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_CoulombCCQE</allowlist>
    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_MFP_pi</allowlist>
    <allowlist type="spline">GENIEReWeight_SBN_v1_multisigma_RPA_CCQE</allowlist>
</variation_list>

```
So this consists of two parts, the type must be flat  and the name is then   WILDCARD:VALUE  where VALUE  is the fractional uncertainty you want, e.g 0.1 for 10%.
The WILDCARD then defines which subchannels to apply
Simplest is to name the subchannel directly. mode_detector_channel_channel
But any matching substring works
e.g _nc for all NC channels nu_SBND for all SBND or _numu_ for any matching channel name. Basically if it exists as a substring it works.
Be a bit careful with wildcards, check the LOG to see it matches what you expect. E.g if you wanted to get numu  but just wrote nu   it would match ALL due to the mode name nu.
