### PR TITLE
Splines in Error Band chi2

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -520,6 +520,8 @@ int main(int argc, char* argv[])
     std::mt19937 main_rng(main_seed);
     std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
     
+    PROsyst allcovsyst = systs.allsplines2cov(config, prop, dseed(main_rng));
+
     //Some global minimizer params
     PROfitterConfig fitconfig;
     fitconfig.param.epsilon = 1e-6;
@@ -1026,7 +1028,9 @@ int main(int argc, char* argv[])
         //
         //TODO: Multiple channels
         int global_channel_index = 0;
-        double chival = metric->getSingleChannelChi(global_channel_index);
+        std::unique_ptr<PROmetric> allcov_metric(metric->Clone());
+        allcov_metric->override_systs(allcovsyst);
+        double chival = allcov_metric->getSingleChannelChi(global_channel_index);
         log<LOG_INFO>(L"%1% || On channel %2% the datamc chi^2/ndof is %3%/%4% .") % __func__ % global_channel_index % chival % config.m_channel_num_bins[global_channel_index];
         TPaveText chi2text(0.59, 0.50, 0.89, 0.59, "NDC");
         chi2text.AddText(("#chi^{2}/ndf = "+to_string_prec(chival,2)+"/"+std::to_string(config.m_channel_num_bins[global_channel_index])).c_str());

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -28,6 +28,7 @@ namespace PROfit{
     PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned = true);
     PROspec FillOtherRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, size_t other_index);
     PROspec FillSystRandomThrow(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, uint32_t seed, int other_index = -1);
+    PROspec FillSplineRandomThrow(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, int spline, uint32_t seed, int other_index = -1);
 };
 
 #endif

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -2,6 +2,7 @@
 #define PROSYST_H_
 
 //C++ include 
+#include <Eigen/Eigen>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -30,8 +31,11 @@ namespace PROfit {
             /*Function: Primary constructor from a vector of SystStructs  */
             PROsyst(const PROpeller &prop, const PROconfig &config, const std::vector<SystStruct>& systs, bool shapeonly=false, int other_index = -1);
 
-            PROsyst subset(const std::vector<std::string> &systs);
-            PROsyst excluding(const std::vector<std::string> &systs);
+            PROsyst subset(const std::vector<std::string> &systs) const;
+            PROsyst excluding(const std::vector<std::string> &systs) const;
+            PROsyst allsplines2cov(const PROconfig &config, const PROpeller &prop, uint32_t seed) const;
+
+            Eigen::MatrixXf spline2cov(int idx, const PROconfig &config, const PROpeller &prop, uint32_t seed) const;
 
             /* Function: given the systematic name, return corresponding fractional covariance matrix */
             Eigen::MatrixXf GrabMatrix(const std::string& sys) const;


### PR DESCRIPTION
Add a new function to PROsyst to make a new PROsyst object with all splines converted to covariance matrices. Then use this to include splines in the chi2 for the error band plot. Not exactly correct since it assumes the splines are linear and unbounded, but good enough for now.