### PR TITLE
Global RNG

### DIFF
--- a/inc/PROseed.h
+++ b/inc/PROseed.h
@@ -33,9 +33,9 @@ namespace PROfit{
             }
 
 
+            static inline std::mt19937 global_rng; 
         private:
             static inline std::random_device rd; 
-            static inline std::mt19937 global_rng; 
             std::vector<uint32_t> thread_seeds;
             size_t n_threads;
     };


### PR DESCRIPTION
Should we just make a global rng for each thread too? Maybe make global_rng in PROseed a thread_local static member and have another `static thread_local bool seeded = false;` which indicates whether that thread's rng has been initialized.