### PR TITLE
Feature/etw fixrw

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -370,42 +370,49 @@ int main(int argc, char* argv[])
 
     }//if no data, use injected or fake data;
     else{
-        //Create CV or injected data spectrum for all subsequent steps
-        //this now will inject osc param, splines and reweight all at once
-        PROspec data_spec = osc_params.size() || injected_systs.size() ? FillRecoSpectra(config, prop, systs, *model, allparams, !eventbyevent) :  FillCVSpectrum(config, prop, !eventbyevent);
 
-        //Only for reweighting tests
-        if (!mockreweights.empty()) {
-            log<LOG_INFO>(L"%1% || Will use reweighted MC (with any requested oscillations) as data for this study") % __func__  ;
-            log<LOG_INFO>(L"%1% || Any parameter shifts requested will be ignored (fix later?)") % __func__  ;
-            auto file = std::make_unique<TFile>(reweights_file.c_str());
-            log<LOG_DEBUG>(L"%1% || Set file to : %2% ") % __func__ % reweights_file.c_str();
-            log<LOG_DEBUG>(L"%1% || Size of reweights vector : %2% ") % __func__ % mockreweights.size() ;
-            for (size_t i=0; i < mockreweights.size(); ++i) {
-                log<LOG_DEBUG>(L"%1% || Mock reweight i : %2% ") % __func__ % mockreweights[i].c_str() ;
-                TH2D* rwhist = (TH2D*)file->Get(mockreweights[i].c_str());
-                weighthists.push_back(rwhist);
-                log<LOG_DEBUG>(L"%1% || Read in weight hist ") % __func__ ;      
-            }
-            data_spec = FillWeightedSpectrumFromHist(config, prop, weighthists, *model, allparams, !eventbyevent);
+      //Only for reweighting tests                                                                                                                                       
+      if (!mockreweights.empty()) {
+        log<LOG_INFO>(L"%1% || Will use reweighted MC (with any requested oscillations and parameter shifts) as data for this study") % __func__  ;
+        auto file = std::make_unique<TFile>(reweights_file.c_str());
+        log<LOG_DEBUG>(L"%1% || Set file to : %2% ") % __func__ % reweights_file.c_str();
+        log<LOG_DEBUG>(L"%1% || Size of reweights vector : %2% ") % __func__ % mockreweights.size() ;
+        for (size_t i=0; i < mockreweights.size(); ++i) {
+          log<LOG_DEBUG>(L"%1% || Mock reweight i : %2% ") % __func__ % mockreweights[i].c_str() ;
+          TH2D* rwhist = (TH2D*)file->Get(mockreweights[i].c_str());
+          //std::string newName = "rwhist_" + std::to_string(i);
+          //TH2D* clonedHist = static_cast<TH2D*>(rwhist->Clone(newName.c_str()));
+	  rwhist->SetDirectory(0);
+          weighthists.push_back(rwhist);
+          log<LOG_DEBUG>(L"%1% || Read in weight hist with %2% entries ") % __func__ % rwhist->GetEntries();
         }
-        if(poisson_throw) data_spec = PROspec::PoissonVariation(data_spec, dseed(myseed.global_rng));
-        Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec());
-        Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
-        Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq).array().sqrt();
-        //data = PROdata(data_vec, err_vec);
-        data = PROdata(data_vec, data_vec.array().sqrt());
+      }
 
-        for(size_t io = 0; io < config.m_num_other_vars; ++io) {
-            PROspec data_spec = osc_params.size() || injected_systs.size() 
-                ? FillOtherRecoSpectra(config, prop, systs, *model, allparams, io)
-                : FillOtherCVSpectrum(config, prop, io);
+      //Create CV or injected data spectrum for all subsequent steps                                                                                                          //this now will inject osc param, splines and reweight all at once                                                                                                 
+      for (size_t i=0; i < weighthists.size(); ++i) {
+        TH2D *rwhist = weighthists[i];
+        log<LOG_DEBUG>(L"%1% || Passing weight hist with %2% entries ") % __func__ % rwhist->GetEntries();
+      }
 
-            Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec(), io);
-            Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
-            Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq, io).array().sqrt();
-            other_data.push_back(PROdata(data_vec, err_vec));
-        }
+      PROspec data_spec = osc_params.size() || injected_systs.size() || weighthists.size() ? FillRecoSpectra(config, prop, systs, *model, allparams, weighthists, !eventbyevent) :  FillCVSpectrum(config, prop, !eventbyevent);
+
+      if(poisson_throw) data_spec = PROspec::PoissonVariation(data_spec, dseed(myseed.global_rng));
+      Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec());
+      Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
+      Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq).array().sqrt();
+      //data = PROdata(data_vec, err_vec);
+      data = PROdata(data_vec, data_vec.array().sqrt());
+
+      for(size_t io = 0; io < config.m_num_other_vars; ++io) {
+	PROspec data_spec = osc_params.size() || injected_systs.size() || weighthists.size() 
+	  ? FillOtherRecoSpectra(config, prop, systs, *model, allparams, io, weighthists)
+	  : FillOtherCVSpectrum(config, prop, io);
+
+	Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec(), io);
+	Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
+	Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq, io).array().sqrt();
+	other_data.push_back(PROdata(data_vec, err_vec));
+      }
     }
 
     // Leave this after creating fake data so we can make fake data using systs that aren't
@@ -1082,80 +1089,6 @@ int main(int argc, char* argv[])
             other_err_bands.push_back(getErrorBand(config, prop, other_systs[io], binwidth_scale, io));
             plot_channels(final_output_tag+"_PROplot_other_"+std::to_string(io)+"_ErrorBand.pdf", config, other_cvs[io], {}, other_data[io], 
                     other_err_bands.back().get(), {}, NULL, opt | PlotOptions::DataMCRatio, io);
-        }
-
-        if (!mockreweights.empty()) {
-
-            //stupid hack, must be a better way to do this
-            //Set up options:
-            std::vector<const char*> xlabel(4);
-            xlabel[0] = "Reconstructed Neutrino Energy";
-            xlabel[1] = "True Leading Proton Momentum";
-            xlabel[2] = "True Leading Proton Cos(Theta)";
-            xlabel[3] = "Check what variable you are plotting!";
-            int xi;
-            if (xmlname.find("standard") != std::string::npos) {
-                xi = 0;
-            }
-            else if (xmlname.find("pmom") != std::string::npos) {
-                xi = 1;
-            }
-            else if (xmlname.find("costh") != std::string::npos) {  
-                xi = 2;
-            }
-            else {
-                xi = 3;
-            }
-
-            TH1D hcv = spec.toTH1D_Collapsed(config,0);
-            TH1D hmock = data.toTH1D(config,0);
-            if(binwidth_scale){
-                hcv.Scale(1, "width");
-                hmock.Scale(1, "width");
-            }
-            hcv.GetYaxis()->SetTitle("Events/GeV");
-            hmock.GetYaxis()->SetTitle("Events/GeV");
-            hcv.GetXaxis()->SetTitle(xlabel[xi]);
-            hmock.GetXaxis()->SetTitle(xlabel[xi]);
-            hcv.SetTitle("");
-            hmock.SetTitle("");
-
-            TCanvas *c2 = new TCanvas((final_output_tag+"_spec_cv").c_str(), (final_output_tag+"_spec_cv").c_str(), 800, 800);
-            hmock.SetLineColor(kBlack);
-            hcv.SetLineColor(5);
-            hcv.SetFillColor(5);
-            TRatioPlot * rp = new TRatioPlot(&hcv,&hmock);
-            rp->Draw();
-            rp->GetLowerRefGraph()->SetMarkerStyle(21);
-            TGraphAsymmErrors *lowerGraph = dynamic_cast<TGraphAsymmErrors*>(rp->GetLowerRefGraph());
-            if (lowerGraph) {
-                int nPoints = lowerGraph->GetN();
-                for (int i = 0; i < nPoints; i++) {
-                    lowerGraph->SetPointError(i, 0, 0, 0, 0); // Set both x and y errors to zero
-                }
-            }
-            std::unique_ptr<TLegend> leg = std::make_unique<TLegend>(0.35,0.7,0.89,0.89);
-            leg->SetFillStyle(0);
-            leg->SetLineWidth(0);
-            leg->AddEntry(&hcv,"CV","f");
-            leg->AddEntry(&hmock,"Mock data: ", "l");
-            TObject *null = new TObject(); 
-
-            for(const auto& [name, shift]: injected_systs) {
-                char ns[6];
-                snprintf(ns, sizeof(ns),"%.2f", shift);
-                leg->AddEntry(null, (name+": "+ns+ " sigma").c_str(),"");
-            }
-
-            for (const auto& m : mockreweights) {
-                leg->AddEntry(null, m.c_str(),"");
-            }
-            for (const auto& m : osc_params) {
-                leg->AddEntry(null, ("param: "+std::to_string(m)).c_str(),"");
-            }
-
-            leg->Draw();
-            c2->SaveAs((final_output_tag+"_ReWeight_spec.pdf").c_str());
         }
 
         if(with_splines) {

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -12,6 +12,7 @@
 #include "PROsyst.h"
 
 #include "TH2D.h"
+#include <vector>
 
 namespace PROfit{
 
@@ -22,11 +23,10 @@ namespace PROfit{
     PROspec FillCVSpectrum(const PROconfig &inconfig, const PROpeller &inprop, bool binned = false);
     PROspec FillOtherCVSpectrum(const PROconfig &inconfig, const PROpeller &inprop, size_t other_index);
 
-  //ETW 1/22/2025 Add function to fill spectrum using weights from input histogram
-    PROspec FillWeightedSpectrumFromHist(const PROconfig &inconfig, const PROpeller &inprop, std::vector<TH2D*> inweighthists, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned = false);
-
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned = true);
-    PROspec FillOtherRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, size_t other_index);
+  //Added overloading for FillRecoSpectra
+  PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, const std::vector<TH2D*> inweighthists = {}, bool binned = true);
+  PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned = true);  
+  PROspec FillOtherRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, size_t other_index, const std::vector<TH2D*> inweighthists = {});
     PROspec FillSystRandomThrow(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, uint32_t seed, int other_index = -1);
     PROspec FillSplineRandomThrow(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, int spline, uint32_t seed, int other_index = -1);
 };

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -9,7 +9,7 @@
 
 #include <algorithm>
 #include <random>
-#include <vector>
+
 
 namespace PROfit {
     PROspec FillCVSpectrum(const PROconfig &inconfig, const PROpeller &inprop, bool binned){
@@ -40,7 +40,7 @@ namespace PROfit {
         return myspectrum;
     }
 
-    PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned){
+  PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, const std::vector<TH2D*> inweighthists, bool binned){
         PROspec myspectrum(inconfig.m_num_bins_total);
         Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);
         Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
@@ -65,130 +65,182 @@ namespace PROfit {
                     }
                 }
             }
+
             for(long int i = 0; i < inprop.hist.rows(); ++i) {
                 float le = inprop.histLE[i];
+
+		//Reweighting from histogram here
+		float hist_w = 1.0;
+		if (inweighthists.size() ) {
+		  size_t subchan = inconfig.GetSubchannelIndexFromGlobalTrueBin(inprop.true_bin_indices[i]);
+		  std::string name = inconfig.m_fullnames[subchan];
+		  log<LOG_DEBUG>(L"%1% || subchan = %2%") % __func__ % subchan;
+		  if (name == "nu_ICARUS_numu_numucc") {
+		    float pmom = static_cast<float>(inprop.pmom[i]);
+		    float pcosth = static_cast<float>(inprop.pcosth[i]);
+		    log<LOG_DEBUG>(L"%1% || i = %2%, pmom = %3%, pcosth = %4%") % __func__ % i % pmom % pcosth;
+		    
+		    for (size_t j = 0; j<inweighthists.size(); ++j){
+		      TH2D h = *inweighthists[j];
+		      int bin = h.FindBin(pmom,pcosth);
+		      hist_w *= h.GetBinContent(bin);
+		      log<LOG_DEBUG>(L"%1% || j = %2%, pmom = %3%, pcosth = %4%, hist_w = %5%") % __func__ % j % pmom % pcosth %  hist_w ;
+		    }
+		  }
+		}
+				  
                 for(size_t j = 0; j < inmodel.model_functions.size(); ++j) {
                     float oscw = inmodel.model_functions[j](phys, le);
                     for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, systw(k) * oscw * inmodel.hists[j](i, k));
+                        myspectrum.Fill(k, systw(k) * oscw * hist_w * inmodel.hists[j](i, k));
                     }
                 }
             }
         } else {
             for(size_t i = 0; i<inprop.trueLE.size(); ++i){
-                float oscw  =  inmodel.model_functions[inprop.model_rule[i]](phys, inprop.trueLE[i]);
-                float add_w = inprop.added_weights[i]; 
-                const int reco_bin = inprop.bin_indices[i];
 
-                float systw = 1;
-                for(int j = 0; j < shifts.size(); ++j) {
-                    int binning = insyst.spline_binnings[j];
-                    const int spline_bin = 
-                        binning == -2 ? inprop.true_bin_indices[i] :
-                        binning == -1 ? inprop.bin_indices[i]
-                                      : inprop.other_bin_indices[i][binning];
-                    systw *= insyst.GetSplineShift(j, shifts[j], spline_bin);
+	      //Reweighting from histogram here	      
+	      float hist_w = 1.0;
+	      if (inweighthists.size() ) {
+		size_t subchan = inconfig.GetSubchannelIndexFromGlobalTrueBin(inprop.true_bin_indices[i]);
+		std::string name = inconfig.m_fullnames[subchan];
+		if (name == "nu_ICARUS_numu_numucc") {
+		  float pmom = static_cast<float>(inprop.pmom[i]);
+		  float pcosth = static_cast<float>(inprop.pcosth[i]);
+		  for (size_t j = 0; j<inweighthists.size(); ++j){
+		    TH2D h = *inweighthists[j];
+		    int bin = h.FindBin(pmom,pcosth);
+		    hist_w *= h.GetBinContent(bin);
+		    log<LOG_DEBUG>(L"%1% || j = %2%, pmom = %3%, pcosth = %4%, hist_w = %5%") % __func__ % j % pmom % pcosth %  hist_w ;
+		  }
+		}
+	      }
+
+	      float oscw  =  inmodel.model_functions[inprop.model_rule[i]](phys, inprop.trueLE[i]);
+	      float add_w = inprop.added_weights[i]; 
+	      const int reco_bin = inprop.bin_indices[i];
+
+	      float systw = 1;
+	      for(int j = 0; j < shifts.size(); ++j) {
+		int binning = insyst.spline_binnings[j];
+		const int spline_bin = 
+		  binning == -2 ? inprop.true_bin_indices[i] :
+		  binning == -1 ? inprop.bin_indices[i]
+		  : inprop.other_bin_indices[i][binning];
+		systw *= insyst.GetSplineShift(j, shifts[j], spline_bin);
+	      }
+
+	      float finalw = oscw * systw * add_w * hist_w;
+
+	      myspectrum.Fill(reco_bin, finalw);
+	    }
+	}
+	return myspectrum;
+  }
+
+  //Version without the reweight option
+  PROspec FillRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned){
+        PROspec myspectrum(inconfig.m_num_bins_total);
+        Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);
+        Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
+
+	if(binned) {
+            Eigen::VectorXf systw = Eigen::VectorXf::Constant(inconfig.m_num_bins_total, 1);
+            for(int i = 0; i < shifts.size(); ++i) {
+                int binning = insyst.spline_binnings[i];
+		const Eigen::MatrixXf &hist =
+		  binning == -2 || binning == -1 ? inprop.hist
+		  : inprop.other_hists[binning];
+                for(size_t k = 0; k < inconfig.m_num_bins_total; ++k) {
+		  if(binning == -1) systw(k) *= insyst.GetSplineShift(i, shifts(i), k);
+		  else {
+		    float val = 0, unweighted = 0;
+		    for(long int j = 0; j < hist.rows(); ++j) {
+		      float binsystw = insyst.GetSplineShift(i, shifts(i), j);
+		      val += binsystw * hist(j, k);
+		      unweighted += hist(j,k);
+		    }
+		    if(unweighted > 0) systw(k) *= val/unweighted;
+		  }
                 }
-
-                float finalw = oscw * systw * add_w;
-
-                myspectrum.Fill(reco_bin, finalw);
             }
+            for(long int i = 0; i < inprop.hist.rows(); ++i) {
+                float le = inprop.histLE[i];
+		for(size_t j = 0; j < inmodel.model_functions.size(); ++j) {
+		  float oscw = inmodel.model_functions[j](phys, le);
+		  for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
+		    myspectrum.Fill(k, systw(k) * oscw * inmodel.hists[j](i, k));
+		  }
+                }
+            }
+        } else {
+	  for(size_t i = 0; i<inprop.trueLE.size(); ++i){
+	    float oscw  =  inmodel.model_functions[inprop.model_rule[i]](phys, inprop.trueLE[i]);
+	    float add_w = inprop.added_weights[i];
+	    const int reco_bin = inprop.bin_indices[i];
+
+	    float systw = 1;
+	    for(int j = 0; j < shifts.size(); ++j) {
+	      int binning = insyst.spline_binnings[j];
+	      const int spline_bin =
+		binning == -2 ? inprop.true_bin_indices[i] :
+		binning == -1 ? inprop.bin_indices[i]
+		: inprop.other_bin_indices[i][binning];
+	      systw *= insyst.GetSplineShift(j, shifts[j], spline_bin);
+	    }
+
+	    float finalw = oscw * systw * add_w;
+
+	    myspectrum.Fill(reco_bin, finalw);
+	  }
         }
         return myspectrum;
-    }
-
-    PROspec FillOtherRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, size_t other_index){
+  }
+	    
+			    ///////			    
+  PROspec FillOtherRecoSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, size_t other_index, std::vector<TH2D*> inweighthists){
         PROspec myspectrum(inconfig.m_num_other_bins_total[other_index]);
         Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);
         Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
 
         for(size_t i = 0; i<inprop.trueLE.size(); ++i){
-            float oscw  =  inmodel.model_functions[inprop.model_rule[i]](phys, inprop.trueLE[i]);
-            float add_w = inprop.added_weights[i]; 
-            float systw = 1;
-            for(int j = 0; j < shifts.size(); ++j) {
-                int binning = insyst.spline_binnings[j];
-                const int spline_bin = 
-                    binning == -2 ? inprop.true_bin_indices[i] :
-                    binning == -1 ? inprop.bin_indices[i]
-                                  : inprop.other_bin_indices[i][binning];
-                systw *= insyst.GetSplineShift(j, shifts[j], spline_bin);
-            }
 
-            float finalw = oscw * systw * add_w;
+	  //Reweighting from histogram here                                                                                                                        
+	  float hist_w = 1.0;
+	  if (inweighthists.size() ) {
+	    size_t subchan = inconfig.GetSubchannelIndexFromGlobalTrueBin(inprop.true_bin_indices[i]);
+	    std::string name = inconfig.m_fullnames[subchan];
+	    if (name == "nu_ICARUS_numu_numucc") {
+	      float pmom = static_cast<float>(inprop.pmom[i]);
+	      float pcosth = static_cast<float>(inprop.pcosth[i]);
+	      for (size_t j = 0; j<inweighthists.size(); ++j){
+		TH2D h = *inweighthists[j];
+		int bin = h.FindBin(pmom,pcosth);
+		hist_w *= h.GetBinContent(bin);
+		log<LOG_DEBUG>(L"%1% || in other: j = %2%, pmom = %3%, pcosth = %4%, hist_w = %5%") % __func__ % j % pmom % pcosth %  hist_w ;
+	      }
+	    }
+	  }
 
-            if(inprop.other_bin_indices[i][other_index] >= 0)
-                myspectrum.Fill(inprop.other_bin_indices[i][other_index], finalw);
+	  float oscw  =  inmodel.model_functions[inprop.model_rule[i]](phys, inprop.trueLE[i]);
+	  float add_w = inprop.added_weights[i]; 
+	  float systw = 1;
+	  for(int j = 0; j < shifts.size(); ++j) {
+	    int binning = insyst.spline_binnings[j];
+	    const int spline_bin = 
+	      binning == -2 ? inprop.true_bin_indices[i] :
+	      binning == -1 ? inprop.bin_indices[i]
+	      : inprop.other_bin_indices[i][binning];
+	    systw *= insyst.GetSplineShift(j, shifts[j], spline_bin);
+	  }
+	  
+	  float finalw = oscw * systw * add_w * hist_w;
+
+	  if(inprop.other_bin_indices[i][other_index] >= 0)
+	    myspectrum.Fill(inprop.other_bin_indices[i][other_index], finalw);
         }
         return myspectrum;
-    }
-
-    PROspec FillWeightedSpectrumFromHist(const PROconfig &inconfig, const PROpeller &inprop, std::vector<TH2D*> inweighthists, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned){
-        PROspec myspectrum(inconfig.m_num_bins_total);
-        Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);
-        Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
-
-        if (binned) {
-            for(long int i = 0; i < inprop.hist.rows(); ++i) {
-                float le = inprop.histLE[i];
-                float hist_w = 1.0 ;
-
-                //Figure out what subchannel the event is in
-                size_t subchan = inconfig.GetSubchannelIndexFromGlobalTrueBin(inprop.true_bin_indices[i]);
-                std::string name = inconfig.m_fullnames[subchan];
-
-                //Put name for ICARUS study here. How to handle more generically?
-                if (name == "nu_ICARUS_numu_numucc") {
-
-                    float pmom = static_cast<float>(inprop.pmom[i]);
-                    float pcosth = static_cast<float>(inprop.pcosth[i]);
-                    for (size_t j = 0; j<inweighthists.size(); ++j){
-                        TH2D h = *inweighthists[j];
-                        int bin = h.FindBin(pmom,pcosth);
-                        hist_w *= h.GetBinContent(bin);
-                    }
-                }
-
-                for(size_t j = 0; j < inmodel.model_functions.size(); ++j) {
-                    float oscw = inmodel.model_functions[j](phys, le);
-                    for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, hist_w * oscw * inmodel.hists[j](i, k));
-                    }
-                }
-            }
-        }
-        else {
-            for(size_t i = 0; i<inprop.trueLE.size(); ++i){
-
-                float oscw  = phys.size() != 0 ? 
-                    inmodel.model_functions[inprop.model_rule[i]](phys, inprop.trueLE[i]) :
-                    1;	
-                float add_w = inprop.added_weights[i];
-                float hist_w = 1.0 ;
-
-                //Figure out what subchannel the event is in
-                size_t subchan = inconfig.GetSubchannelIndexFromGlobalTrueBin(inprop.true_bin_indices[i]);
-                std::string name = inconfig.m_fullnames[subchan];
-
-                //Put name for ICARUS study here. How to handle more generically?
-                if (name == "nu_ICARUS_numu_numucc") {
-                    float pmom = static_cast<float>(inprop.pmom[i]);
-                    float pcosth = static_cast<float>(inprop.pcosth[i]);
-
-                    for (size_t j = 0; j<inweighthists.size(); ++j){
-                        TH2D h = *inweighthists[j];
-                        int bin = h.FindBin(pmom,pcosth);
-                        hist_w *= h.GetBinContent(bin);
-                    }
-                }
-
-                float finalw = oscw * add_w * hist_w;
-                myspectrum.Fill(inprop.bin_indices[i], finalw);
-            }
-        }
-        return myspectrum;
-    }
+}
 
     PROspec FillSystRandomThrow(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, uint32_t seed, int other_index) {
         int nbins = other_index < 0 ? inconfig.m_num_bins_total : inconfig.m_num_other_bins_total[other_index],


### PR DESCRIPTION
This fixes the reweighting by integrating it into FillRecoSpectra, so it should now be treated equivalently to the systematic reweights, including being able to do both at once (though that is kind of dodgy from a physics perspective). I overloaded FillRecoSpectra to avoid breaking everything else - is there a better way to handle this? I also included the same functionality in FillOtherRecoSpectra.

Also note I'm not sure if I did the branching right - this originally based on 1.0.2 I think.

I tested plot and profile and things look correct to me, but maybe Jacob should also check this doesn't break anything. I am not super clear on how "other" spectra work