### PR TITLE
Adaptive MCMC as standard for error-bars, fixed some bugs in adaptive implementaiton

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -697,7 +697,7 @@ int main(int argc, char* argv[])
         //Metropolis mh_post(simple_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
         Metropolis mh_post(simple_target{*metric_to_use}, adaptive_proposal(*metric_to_use, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
-        std::unique_ptr<TGraphAsymmErrors> post_err_band = getMCMCErrorBand(mh_post, fitconfig.MCMCburn, fitconfig.MCMCiter, config, prop, *metric_to_use, best_fit, posteriors, spline_covariance, binwidth_scale);
+        std::unique_ptr<TGraphAsymmErrors> post_err_band = getMCMCErrorBand(mh_post, 10*fitconfig.MCMCburn, fitconfig.MCMCiter, config, prop, *metric_to_use, best_fit, posteriors, spline_covariance, binwidth_scale);
 
         std::vector<TPaveText> texts;
         TPaveText chi2text(0.59, 0.50, 0.89, 0.59, "NDC");
@@ -731,6 +731,7 @@ int main(int argc, char* argv[])
         spline_cov.Draw("colz");
         c.Print((final_output_tag+"_postfit_nuisance_covariance.pdf").c_str());
 
+        return 0;
         log<LOG_INFO>(L"%1% ||  Beginning full PROfile ") % __func__;
 
         PROfile profile(config, metric_to_use->GetSysts(), metric_to_use->GetModel(), *metric_to_use, myseed, scanFitConfig, 

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -606,7 +606,8 @@ int main(int argc, char* argv[])
 
         // TODO: Not sure I understand this covariance matrix
         log<LOG_INFO>(L"%1% || Starting a metropolis hastings chain to estimate the covariace matrix aroud the above best fit. Run and Burn is (%2%,%3%);") % __func__%fitconfig.MCMCiter % fitconfig.MCMCburn;
-        Metropolis mh(simple_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng)), best_fit, dseed(PROseed::global_rng));
+        //Metropolis mh(simple_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng)), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric_to_use}, adaptive_proposal(*metric_to_use, dseed(PROseed::global_rng)), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(nparams, nparams, 0);
         size_t count = 0;
@@ -616,6 +617,15 @@ int main(int argc, char* argv[])
         };
         mh.run(fitconfig.MCMCburn,fitconfig.MCMCiter, action);
 
+        covmat /= count;
+        Eigen::MatrixXf fraccovmat = (1.0f/best_fit.array()).matrix().asDiagonal() * covmat
+            * (1.0f/best_fit.array()).matrix().asDiagonal();
+        Eigen::MatrixXf corrmat =
+            fraccovmat.diagonal().array().sqrt().matrix().asDiagonal().inverse() * fraccovmat
+            * fraccovmat.diagonal().array().sqrt().matrix().asDiagonal().inverse();
+
+        TH2D corrhist("crh", "", nparams, 0, nparams, nparams, 0, nparams);
+        TH2D fraccovhist("fch", "", nparams, 0, nparams, nparams, 0, nparams);
         TH2D covhist("ch", "", nparams, 0, nparams, nparams, 0, nparams);
         TH2D physhist;
         if(nphys > 0) physhist = TH2D("ph","", nparams, 0, nparams, nphys, 0, nphys);
@@ -625,19 +635,31 @@ int main(int argc, char* argv[])
                 : config.m_mcgen_variation_plotname_map[metric_to_use->GetSysts().spline_names[i-metric_to_use->GetModel().nparams]].c_str();
             covhist.GetXaxis()->SetBinLabel(i+1, label.c_str());
             covhist.GetYaxis()->SetBinLabel(i+1, label.c_str());
+            fraccovhist.GetXaxis()->SetBinLabel(i+1, label.c_str());
+            fraccovhist.GetYaxis()->SetBinLabel(i+1, label.c_str());
+            corrhist.GetXaxis()->SetBinLabel(i+1, label.c_str());
+            corrhist.GetYaxis()->SetBinLabel(i+1, label.c_str());
             if(nphys > 0) physhist.GetXaxis()->SetBinLabel(i+1, label.c_str());
             if(i < metric_to_use->GetModel().nparams) physhist.GetYaxis()->SetBinLabel(i+1, label.c_str());
             for(size_t j = 0; j < nparams; ++j) {
-                covhist.SetBinContent(i+1, j+1, covmat(i,j)/count);
+                covhist.SetBinContent(i+1, j+1, covmat(i,j));
+                fraccovhist.SetBinContent(i+1, j+1, fraccovmat(i,j));
+                corrhist.SetBinContent(i+1, j+1, corrmat(i,j));
                 if(j < metric_to_use->GetModel().nparams)
-                    physhist.SetBinContent(i+1, j+1, covmat(i,j)/count);
+                    physhist.SetBinContent(i+1, j+1, covmat(i,j));
             }
         }
         TCanvas c1;
         covhist.SetMaximum(1);
         covhist.SetMinimum(-1);
+        fraccovhist.SetMaximum(1);
+        fraccovhist.SetMinimum(-1);
         covhist.Draw("colz");
         c1.Print((final_output_tag+"_postfit_cov.pdf").c_str());
+        fraccovhist.Draw("colz");
+        c1.Print((final_output_tag+"_postfit_fraccov.pdf").c_str());
+        corrhist.Draw("colz");
+        c1.Print((final_output_tag+"_postfit_corr.pdf").c_str());
         if(nphys > 0) {
             physhist.Draw("colz");
             c1.Print("phys_cov.pdf");
@@ -663,13 +685,15 @@ int main(int argc, char* argv[])
         for(size_t i = 0; i < metric_to_use->GetModel().nparams; ++i) fixed_pars.push_back(i);
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        Metropolis mh_pre(prior_only_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
+        //Metropolis mh_pre(prior_only_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_pre(prior_only_target{*metric_to_use}, adaptive_proposal(*metric_to_use, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         std::unique_ptr<TGraphAsymmErrors> err_band = 
             MCMC_prefit_errors
             ? getMCMCErrorBand(mh_pre, fitconfig.MCMCburn, fitconfig.MCMCiter, config, prop, *metric_to_use, best_fit, priors, prior_covariance)
             : getErrorBand(config, prop, systs, binwidth_scale);
 
-        Metropolis mh_post(simple_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
+        //Metropolis mh_post(simple_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric_to_use}, adaptive_proposal(*metric_to_use, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::unique_ptr<TGraphAsymmErrors> post_err_band = getMCMCErrorBand(mh_post, fitconfig.MCMCburn, fitconfig.MCMCiter, config, prop, *metric_to_use, best_fit, posteriors, spline_covariance, binwidth_scale);
 

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -732,7 +732,6 @@ int main(int argc, char* argv[])
         spline_cov.Draw("colz");
         c.Print((final_output_tag+"_postfit_nuisance_covariance.pdf").c_str());
 
-        return 0;
         log<LOG_INFO>(L"%1% ||  Beginning full PROfile ") % __func__;
 
         PROfile profile(config, metric_to_use->GetSysts(), metric_to_use->GetModel(), *metric_to_use, myseed, scanFitConfig, 

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -269,9 +269,9 @@ int main(int argc, char* argv[])
         const auto it = std::find(model->param_names.begin(), model->param_names.end(), name);
         if(it == std::end(model->param_names)) {
             log<LOG_ERROR>(L"%1% || Unrecognized model parameter name %2%.\n"
-                           L"Valid names for model %3% are %4%") %
-                           __func__% name.c_str()% config.m_model_tag.c_str()%
-                           model->param_names;
+                    L"Valid names for model %3% are %4%") %
+                __func__% name.c_str()% config.m_model_tag.c_str()%
+                model->param_names;
             return 1;
         }
         int loc = std::distance(model->param_names.begin(), it);
@@ -386,48 +386,48 @@ int main(int argc, char* argv[])
     }//if no data, use injected or fake data;
     else{
 
-      //Only for reweighting tests                                                                                                                                       
-      if (!mockreweights.empty()) {
-        log<LOG_INFO>(L"%1% || Will use reweighted MC (with any requested oscillations and parameter shifts) as data for this study") % __func__  ;
-        auto file = std::make_unique<TFile>(reweights_file.c_str());
-        log<LOG_DEBUG>(L"%1% || Set file to : %2% ") % __func__ % reweights_file.c_str();
-        log<LOG_DEBUG>(L"%1% || Size of reweights vector : %2% ") % __func__ % mockreweights.size() ;
-        for (size_t i=0; i < mockreweights.size(); ++i) {
-          log<LOG_DEBUG>(L"%1% || Mock reweight i : %2% ") % __func__ % mockreweights[i].c_str() ;
-          TH2D* rwhist = (TH2D*)file->Get(mockreweights[i].c_str());
-          //std::string newName = "rwhist_" + std::to_string(i);
-          //TH2D* clonedHist = static_cast<TH2D*>(rwhist->Clone(newName.c_str()));
-	  rwhist->SetDirectory(0);
-          weighthists.push_back(rwhist);
-          log<LOG_DEBUG>(L"%1% || Read in weight hist with %2% entries ") % __func__ % rwhist->GetEntries();
+        //Only for reweighting tests                                                                                                                                       
+        if (!mockreweights.empty()) {
+            log<LOG_INFO>(L"%1% || Will use reweighted MC (with any requested oscillations and parameter shifts) as data for this study") % __func__  ;
+            auto file = std::make_unique<TFile>(reweights_file.c_str());
+            log<LOG_DEBUG>(L"%1% || Set file to : %2% ") % __func__ % reweights_file.c_str();
+            log<LOG_DEBUG>(L"%1% || Size of reweights vector : %2% ") % __func__ % mockreweights.size() ;
+            for (size_t i=0; i < mockreweights.size(); ++i) {
+                log<LOG_DEBUG>(L"%1% || Mock reweight i : %2% ") % __func__ % mockreweights[i].c_str() ;
+                TH2D* rwhist = (TH2D*)file->Get(mockreweights[i].c_str());
+                //std::string newName = "rwhist_" + std::to_string(i);
+                //TH2D* clonedHist = static_cast<TH2D*>(rwhist->Clone(newName.c_str()));
+                rwhist->SetDirectory(0);
+                weighthists.push_back(rwhist);
+                log<LOG_DEBUG>(L"%1% || Read in weight hist with %2% entries ") % __func__ % rwhist->GetEntries();
+            }
         }
-      }
 
-      //Create CV or injected data spectrum for all subsequent steps                                                                                                          //this now will inject osc param, splines and reweight all at once                                                                                                 
-      for (size_t i=0; i < weighthists.size(); ++i) {
-        TH2D *rwhist = weighthists[i];
-        log<LOG_DEBUG>(L"%1% || Passing weight hist with %2% entries ") % __func__ % rwhist->GetEntries();
-      }
+        //Create CV or injected data spectrum for all subsequent steps                                                                                                          //this now will inject osc param, splines and reweight all at once                                                                                                 
+        for (size_t i=0; i < weighthists.size(); ++i) {
+            TH2D *rwhist = weighthists[i];
+            log<LOG_DEBUG>(L"%1% || Passing weight hist with %2% entries ") % __func__ % rwhist->GetEntries();
+        }
 
-      PROspec data_spec = osc_params.size() || injected_systs.size() || weighthists.size() ? FillRecoSpectra(config, prop, systs, *model, allparams, weighthists, !eventbyevent) :  FillCVSpectrum(config, prop, !eventbyevent);
+        PROspec data_spec = osc_params.size() || injected_systs.size() || weighthists.size() ? FillRecoSpectra(config, prop, systs, *model, allparams, weighthists, !eventbyevent) :  FillCVSpectrum(config, prop, !eventbyevent);
 
-      if(poisson_throw) data_spec = PROspec::PoissonVariation(data_spec, dseed(myseed.global_rng));
-      Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec());
-      Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
-      Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq).array().sqrt();
-      //data = PROdata(data_vec, err_vec);
-      data = PROdata(data_vec, data_vec.array().sqrt());
+        if(poisson_throw) data_spec = PROspec::PoissonVariation(data_spec, dseed(myseed.global_rng));
+        Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec());
+        Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
+        Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq).array().sqrt();
+        //data = PROdata(data_vec, err_vec);
+        data = PROdata(data_vec, data_vec.array().sqrt());
 
-      for(size_t io = 0; io < config.m_num_other_vars; ++io) {
-	PROspec data_spec = osc_params.size() || injected_systs.size() || weighthists.size() 
-	  ? FillOtherRecoSpectra(config, prop, systs, *model, allparams, io, weighthists)
-	  : FillOtherCVSpectrum(config, prop, io);
+        for(size_t io = 0; io < config.m_num_other_vars; ++io) {
+            PROspec data_spec = osc_params.size() || injected_systs.size() || weighthists.size() 
+                ? FillOtherRecoSpectra(config, prop, systs, *model, allparams, io, weighthists)
+                : FillOtherCVSpectrum(config, prop, io);
 
-	Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec(), io);
-	Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
-	Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq, io).array().sqrt();
-	other_data.push_back(PROdata(data_vec, err_vec));
-      }
+            Eigen::VectorXf data_vec = CollapseMatrix(config, data_spec.Spec(), io);
+            Eigen::VectorXf err_vec_sq = data_spec.Error().array().square();
+            Eigen::VectorXf err_vec = CollapseMatrix(config, err_vec_sq, io).array().sqrt();
+            other_data.push_back(PROdata(data_vec, err_vec));
+        }
     }
 
     // Leave this after creating fake data so we can make fake data using systs that aren't
@@ -493,17 +493,17 @@ int main(int argc, char* argv[])
     for(const auto& [name, shift]: injected_systs) {
         log<LOG_INFO>(L"%1% || Injected syst: %2% shifted by %3%") % __func__ % name.c_str() % shift;
         auto it = std::find(systs.spline_names.begin(), systs.spline_names.end(), name);
-            for(const auto &[xml_name, plot_name]: config.m_mcgen_variation_plotname_map) {
-                if(name == plot_name) {
-                    it = std::find(systs.spline_names.begin(), systs.spline_names.end(), xml_name);
-                    break;
-                }
+        for(const auto &[xml_name, plot_name]: config.m_mcgen_variation_plotname_map) {
+            if(name == plot_name) {
+                it = std::find(systs.spline_names.begin(), systs.spline_names.end(), xml_name);
+                break;
             }
-            if(it == systs.spline_names.end()) {
-                log<LOG_ERROR>(L"%1% || Error: Unrecognized spline %2%. Ignoring this injected shift.") % __func__ % name.c_str();
-                continue;
-            }
-        
+        }
+        if(it == systs.spline_names.end()) {
+            log<LOG_ERROR>(L"%1% || Error: Unrecognized spline %2%. Ignoring this injected shift.") % __func__ % name.c_str();
+            continue;
+        }
+
         int idx = std::distance(systs.spline_names.begin(), it);
         allparams(idx+model->nparams) = shift;
         systparams(idx) = shift;
@@ -657,12 +657,41 @@ int main(int argc, char* argv[])
         covhist.SetMinimum(-1);
         fraccovhist.SetMaximum(100);
         fraccovhist.SetMinimum(-100);
-        covhist.Draw("colz");
-        c1.Print((final_output_tag+"_postfit_cov.pdf").c_str());
+        //covhist.Draw("colz");
+        //c1.Print((final_output_tag+"_postfit_cov.pdf").c_str());
         //fraccovhist.Draw("colz");
         //c1.Print((final_output_tag+"_postfit_fraccov.pdf").c_str());
+        const Int_t NCont = 255;
+        const Int_t NRGBs = 9;  // Reduced control points for smoother white stretch
+        Double_t stops[NRGBs] = {
+            0.0,    // -1.0 (dark blue)
+            0.075,    // -0.6 (transition to white)
+            0.3,    // -0.2 (mostly white)
+            0.4,   // -0.04 (almost pure white)
+            0.5,    //  0.0 (pure white)
+            0.6,   // +0.04 (almost pure white)
+            0.7,    // +0.2 (transition to red)
+            0.925,    // +0.6 (strong red)
+            1.0     // +1.0 (dark red)
+        };
+
+        Double_t red[NRGBs]   = {0.00,0.259,0.824, 0.949, 1.0, 0.988, 0.980, 0.918,0.839};
+        Double_t green[NRGBs] = {0.341,0.404,0.890, 0.961, 1.0, 0.933, 0.824, 0.263,0.125};
+        Double_t blue[NRGBs]  = {0.906,0.824,0.989, 0.980, 1.0, 0.929, 0.812, 0.208,0.024};
+
+        TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+        gStyle->SetNumberContours(NCont);
+        c1.SetLeftMargin(0.18);   
+        corrhist.SetTitle("Post-Fit Correlation Matrix");
         corrhist.Draw("colz");
-        c1.Print((final_output_tag+"_postfit_corr.pdf").c_str());
+        gPad->Update();
+
+        TLine line;
+        line.SetLineColor(kBlack);
+        line.SetLineWidth(2);
+        line.DrawLine(nphys, 0, nphys, nparams);
+        line.DrawLine(0, nphys, nparams, nphys);
+        c1.Print((final_output_tag+"_postfit_correlation_matrix.pdf").c_str());
         if(nphys > 0) {
             physhist.Draw("colz");
             c1.Print("phys_cov.pdf");
@@ -1159,21 +1188,21 @@ int main(int argc, char* argv[])
         std::vector<TPaveText> channel_chitexts;
         std::vector<TPaveText> other_channel_chitexts; //todo
         for(size_t im = 0; im < config.m_num_modes; im++){
-                for(size_t id =0; id < config.m_num_detectors; id++){
-                    for(size_t ic = 0; ic < config.m_num_channels; ic++){
-                        log<LOG_INFO>(L"%1% || On channel %2%:") % __func__ % global_channel_index ;
-                        double chival = allcov_metric->getSingleChannelChi(global_channel_index);
-                        int ndf = config.m_channel_num_bins[ic] - bool(opt&PlotOptions::AreaNormalized);
-                        log<LOG_INFO>(L"%1% || -- the datamc chi^2/ndof is %2%/%3% .") % __func__ % chival % ndf;
-                        TPaveText chi2text(0.59, 0.50, 0.89, 0.59, "NDC");
-                        chi2text.AddText(("#chi^{2}/ndf = "+to_string_prec(chival,2)+"/"+std::to_string(ndf)).c_str());
-                        chi2text.SetFillColor(0);
-                        chi2text.SetBorderSize(0);
-                        chi2text.SetTextAlign(12);
-                        channel_chitexts.push_back(chi2text);
-                        global_channel_index++;
-                    }
+            for(size_t id =0; id < config.m_num_detectors; id++){
+                for(size_t ic = 0; ic < config.m_num_channels; ic++){
+                    log<LOG_INFO>(L"%1% || On channel %2%:") % __func__ % global_channel_index ;
+                    double chival = allcov_metric->getSingleChannelChi(global_channel_index);
+                    int ndf = config.m_channel_num_bins[ic] - bool(opt&PlotOptions::AreaNormalized);
+                    log<LOG_INFO>(L"%1% || -- the datamc chi^2/ndof is %2%/%3% .") % __func__ % chival % ndf;
+                    TPaveText chi2text(0.59, 0.50, 0.89, 0.59, "NDC");
+                    chi2text.AddText(("#chi^{2}/ndf = "+to_string_prec(chival,2)+"/"+std::to_string(ndf)).c_str());
+                    chi2text.SetFillColor(0);
+                    chi2text.SetBorderSize(0);
+                    chi2text.SetTextAlign(12);
+                    channel_chitexts.push_back(chi2text);
+                    global_channel_index++;
                 }
+            }
         }
 
         std::unique_ptr<TGraphAsymmErrors> err_band = getErrorBand(config, prop, systs, binwidth_scale);
@@ -1390,12 +1419,12 @@ int main(int argc, char* argv[])
             if(use_phys && i < (long)metric->GetModel().nparams){
                 log<LOG_INFO>(L"%1% || %2%  :  %3% ") % __func__ % metric->GetModel().pretty_param_names[i].c_str() % global_fit_result(i);
                 global_fit_out << metric->GetModel().param_names[i]
-                               << " : " << global_fit_result(i) << "\n";
+                    << " : " << global_fit_result(i) << "\n";
             }else{
                 long idx = use_phys ? i - metric->GetModel().nparams : i;
                 log<LOG_INFO>(L"%1% || %2%  :  %3% ") % __func__ % metric->GetSysts().spline_names[idx].c_str() % global_fit_result(i);
                 global_fit_out << metric->GetSysts().spline_names[idx]
-                               << " : " << global_fit_result(i) << "\n";
+                    << " : " << global_fit_result(i) << "\n";
             }
         }
         log<LOG_INFO>(L"%1% || ################################################") % __func__;
@@ -1417,11 +1446,11 @@ int main(int argc, char* argv[])
             if(i < (long)metric->GetModel().nparams){
                 log<LOG_INFO>(L"%1% || %2%  :  %3% ") % __func__ % metric->GetModel().pretty_param_names[i].c_str() % global_fit_result(i);
                 global_fit_out << metric->GetModel().param_names[i]
-                               << " : " << global_fit_result(i) << "\n";
+                    << " : " << global_fit_result(i) << "\n";
             }else{
                 log<LOG_INFO>(L"%1% || %2%  :  %3% ") % __func__ % metric->GetSysts().spline_names[i - metric->GetModel().nparams].c_str() % global_fit_result(i);
                 global_fit_out << metric->GetSysts().spline_names[i - metric->GetModel().nparams]
-                               << " : " << global_fit_result(i) << "\n";
+                    << " : " << global_fit_result(i) << "\n";
             }
         }
         log<LOG_INFO>(L"%1% || ########################################################") % __func__;

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -650,10 +650,12 @@ int main(int argc, char* argv[])
             }
         }
         TCanvas c1;
+        corrhist.SetMaximum(1);
+        corrhist.SetMinimum(-1);
         covhist.SetMaximum(1);
         covhist.SetMinimum(-1);
-        fraccovhist.SetMaximum(1);
-        fraccovhist.SetMinimum(-1);
+        fraccovhist.SetMaximum(2);
+        fraccovhist.SetMinimum(-2);
         covhist.Draw("colz");
         c1.Print((final_output_tag+"_postfit_cov.pdf").c_str());
         fraccovhist.Draw("colz");
@@ -729,7 +731,6 @@ int main(int argc, char* argv[])
         spline_cov.Draw("colz");
         c.Print((final_output_tag+"_postfit_nuisance_covariance.pdf").c_str());
 
-        return 0;
         log<LOG_INFO>(L"%1% ||  Beginning full PROfile ") % __func__;
 
         PROfile profile(config, metric_to_use->GetSysts(), metric_to_use->GetModel(), *metric_to_use, myseed, scanFitConfig, 

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -697,7 +697,7 @@ int main(int argc, char* argv[])
         //Metropolis mh_post(simple_target{*metric_to_use}, simple_proposal(*metric_to_use, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
         Metropolis mh_post(simple_target{*metric_to_use}, adaptive_proposal(*metric_to_use, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
-        std::unique_ptr<TGraphAsymmErrors> post_err_band = getMCMCErrorBand(mh_post, 10*fitconfig.MCMCburn, fitconfig.MCMCiter, config, prop, *metric_to_use, best_fit, posteriors, spline_covariance, binwidth_scale);
+        std::unique_ptr<TGraphAsymmErrors> post_err_band = getMCMCErrorBand(mh_post, fitconfig.MCMCburn, fitconfig.MCMCiter, config, prop, *metric_to_use, best_fit, posteriors, spline_covariance, binwidth_scale);
 
         std::vector<TPaveText> texts;
         TPaveText chi2text(0.59, 0.50, 0.89, 0.59, "NDC");

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -618,11 +618,12 @@ int main(int argc, char* argv[])
         mh.run(fitconfig.MCMCburn,fitconfig.MCMCiter, action);
 
         covmat /= count;
-        Eigen::MatrixXf fraccovmat = (1.0f/best_fit.array()).matrix().asDiagonal() * covmat
-            * (1.0f/best_fit.array()).matrix().asDiagonal();
-        Eigen::MatrixXf corrmat =
-            fraccovmat.diagonal().array().sqrt().matrix().asDiagonal().inverse() * fraccovmat
-            * fraccovmat.diagonal().array().sqrt().matrix().asDiagonal().inverse();
+        Eigen::VectorXf inv_best_fit = best_fit.array().abs().max(1e-10f).inverse();
+        Eigen::MatrixXf fraccovmat = inv_best_fit.asDiagonal() * covmat * inv_best_fit.asDiagonal();
+
+        Eigen::VectorXf inv_sqrt_diag = fraccovmat.diagonal().array().abs().max(1e-10f).sqrt().inverse();
+        Eigen::MatrixXf corrmat = inv_sqrt_diag.asDiagonal() * fraccovmat * inv_sqrt_diag.asDiagonal();
+
 
         TH2D corrhist("crh", "", nparams, 0, nparams, nparams, 0, nparams);
         TH2D fraccovhist("fch", "", nparams, 0, nparams, nparams, 0, nparams);
@@ -654,12 +655,12 @@ int main(int argc, char* argv[])
         corrhist.SetMinimum(-1);
         covhist.SetMaximum(1);
         covhist.SetMinimum(-1);
-        fraccovhist.SetMaximum(2);
-        fraccovhist.SetMinimum(-2);
+        fraccovhist.SetMaximum(100);
+        fraccovhist.SetMinimum(-100);
         covhist.Draw("colz");
         c1.Print((final_output_tag+"_postfit_cov.pdf").c_str());
-        fraccovhist.Draw("colz");
-        c1.Print((final_output_tag+"_postfit_fraccov.pdf").c_str());
+        //fraccovhist.Draw("colz");
+        //c1.Print((final_output_tag+"_postfit_fraccov.pdf").c_str());
         corrhist.Draw("colz");
         c1.Print((final_output_tag+"_postfit_corr.pdf").c_str());
         if(nphys > 0) {

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -729,6 +729,7 @@ int main(int argc, char* argv[])
         spline_cov.Draw("colz");
         c.Print((final_output_tag+"_postfit_nuisance_covariance.pdf").c_str());
 
+        return 0;
         log<LOG_INFO>(L"%1% ||  Beginning full PROfile ") % __func__;
 
         PROfile profile(config, metric_to_use->GetSysts(), metric_to_use->GetModel(), *metric_to_use, myseed, scanFitConfig, 

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -36,11 +36,11 @@ namespace PROfit {
                     float u = uniform(rng);
 
                     if(u <= acceptance) {
-                       // log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                        // log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                         current = p;
                         return true;
                     }else{
-                       // log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                        // log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                     }
                     return false;
                 }
@@ -210,7 +210,7 @@ namespace PROfit {
         Eigen::VectorXf mean;
         Eigen::MatrixXf cov;
         size_t tune_calls = 0;
-        float scale = 0.75*5.66;
+        float scale = 5.66;
         float diag_scale = 0.01;
         float beta = 1.0;
         Eigen::MatrixXf diagL;
@@ -235,10 +235,11 @@ namespace PROfit {
                 if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) {
                     throw1(i) = 0;
                     throw2(i) = 0;
+                }else{
+                    std::normal_distribution<float> nd(0, 1);
+                    throw1(i) = nd(rng);
+                    throw2(i) = nd(rng);
                 }
-                std::normal_distribution<float> nd(0, 1);
-                throw1(i) = nd(rng);
-                throw2(i) = nd(rng);
             }
             //Eigen::LLT<Eigen::MatrixXf> llt(scale * width);
             //Eigen::MatrixXf L = llt.matrixL();
@@ -290,6 +291,11 @@ namespace PROfit {
                 if (tune_calls > 1) {
                     cov += (delta * (last_proposed - mean).transpose() - cov) / tune_calls;
                 }
+                for (int idx : fixed) {
+                    cov.row(idx).setZero();
+                    cov.col(idx).setZero();
+                }
+
                 if(tune_calls > (size_t)(2*last_proposed.size())) {
                     Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
                     for(int i = 0; i < cov_pd.rows(); ++i)

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -203,7 +203,8 @@ namespace PROfit {
         PROmetric &metric;
         uint32_t seed;
         Eigen::MatrixXf width;
-        std::vector<int> fixed;
+        std::vector<int> fixed;//fixed and active are opposite. usually active is 
+        std::vector<int> active;
         std::mt19937 rng;
         static constexpr bool has_tune = true;
         std::vector<Eigen::VectorXf> proposed;
@@ -212,19 +213,17 @@ namespace PROfit {
         Eigen::MatrixXf cov;
         size_t tune_calls = 0;
         float scale = 5.66;
-        float diag_scale = 0.01;
         float beta = 1.0;
+        
+        float diag_scale = 0.01;
         Eigen::MatrixXf diagL;
+        Eigen::MatrixXf sub_diagL;
 
         // Adaptive scaling state
         std::vector<bool> accept_history;
         size_t adapt_window = 1000;  // window size for adaptation
         float target_accept = 0.234; 
         float adapt_factor = 1.02;   
-
-
-       Eigen::MatrixXf sub_diagL;
-       std::vector<int> active;
 
         adaptive_proposal(PROmetric &metric, uint32_t seed, std::vector<int> fixed = {}) 
             : metric(metric), seed(seed), fixed(fixed), rng(seed) {
@@ -243,8 +242,9 @@ namespace PROfit {
                         active.push_back(i);
                     }
                 }
+                //grab the bits that correspond to the active only.
                 sub_diagL = Eigen::MatrixXf::Identity(active.size(), active.size());
-                sub_diagL = diagL(active, active);  // Magical Eigen indexing
+                sub_diagL = diagL(active, active);  
 
             }
 
@@ -260,8 +260,7 @@ namespace PROfit {
             
             Eigen::MatrixXf inp = scale*width;//fulldim
 
-            Eigen::MatrixXf sub_inp = inp(active, active);  // Magic Eigen indexing?!
-            Eigen::MatrixXf sub_L = ComputeSquareRootCovariance(sub_inp,false);
+            Eigen::MatrixXf sub_L = ComputeSquareRootCovariance( inp(active, active)); //magic eigen indexing
 
             last_proposed = current;//fulldim
             last_proposed(active) += (1.0f - beta) * sub_L * sub_throw1 + beta * sub_diagL * sub_throw2; //More index nonsesne?!
@@ -320,9 +319,9 @@ namespace PROfit {
             }
 
             if(tune_calls > (size_t)(4*last_proposed.size())) {
-                Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
+                Eigen::MatrixXf cov_pd = cov;
                 for(int i = 0; i < cov_pd.rows(); ++i)
-                    cov_pd(i, i) += 1e-12;
+                    cov_pd(i, i) += 1e-8;
                 width = cov_pd;
                 beta = tune_calls > (size_t)(100*last_proposed.size()) ? 0.05 : 0.5;
             }

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -13,287 +13,294 @@
 #include <optional>
 namespace PROfit {
 
-template<class Target_FN, class Proposal_FN>
-class Metropolis {
-private:
-    std::mt19937 rng;
-    std::uniform_real_distribution<float> uniform;
-    uint32_t seed;
+    template<class Target_FN, class Proposal_FN>
+        class Metropolis {
+            private:
+                std::mt19937 rng;
+                std::uniform_real_distribution<float> uniform;
+                uint32_t seed;
 
-public:
-    Target_FN target;
-    Proposal_FN proposal;
-    Eigen::VectorXf current;
+            public:
+                Target_FN target;
+                Proposal_FN proposal;
+                Eigen::VectorXf current;
 
-    Metropolis(Target_FN target, Proposal_FN proposal, const Eigen::VectorXf &initial, uint32_t seed) 
-        : seed(seed), target(target), proposal(proposal), current(initial) {
-        rng.seed(seed);
-    }
-
-    bool step() {
-        Eigen::VectorXf p = proposal(current);
-        float acceptance = proposal.within_bound(p) ? std::min(1.0f, target(p)/target(current) * proposal.P(current, p)/proposal.P(p, current)) : 0;
-        float u = uniform(rng);
-        if(u <= acceptance) {
-            current = p;
-            return true;
-        }
-        return false;
-    }
-
-    void run(size_t burnin, size_t steps, std::optional<std::function<void(const Eigen::VectorXf&)>> action = {}) {
-        for(size_t i = 0; i < burnin; i++) {
-            if constexpr(Proposal_FN::has_tune) {
-                proposal.tune(step());
-            } else {
-                step();
-            }
-        }
-        for(size_t i = 0; i < steps; i++) {
-            if(step() && action) (*action)(current);
-        }
-    }
-
-};
-
-struct simple_target {
-    PROmetric &metric;
-
-    float operator()(Eigen::VectorXf &value) {
-        Eigen::VectorXf empty;
-        return std::exp(-0.5f*metric(value, empty, false));
-    }
-};
-
-struct prior_only_target {
-    PROmetric &metric;
-
-    float operator()(Eigen::VectorXf &value) {
-        Eigen::VectorXf nuisance = value.segment(metric.GetModel().nparams, metric.GetSysts().GetNSplines());
-        return std::exp(-0.5f*metric.Pull(nuisance));
-    }
-};
-
-struct simple_proposal {
-    PROmetric &metric;
-    uint32_t seed;
-    float width;
-    std::vector<int> fixed;
-    std::mt19937 rng;
-    static constexpr bool has_tune = true;
-    std::vector<bool> accepted_list;
-    size_t tune_calls = 0;
-    float last_acceptance = -1;
-    float last_shift;
-
-    simple_proposal(PROmetric &metric, uint32_t seed, float width = 0.2, std::vector<int> fixed = {}) 
-        : metric(metric), seed(seed), width(width), fixed(fixed), rng(seed), last_shift(width) {
-        accepted_list = std::vector(1000, false);
-    }
-
-    Eigen::VectorXf operator()(Eigen::VectorXf &current) {
-        Eigen::VectorXf ret = current;
-        int nparams = metric.GetModel().nparams;
-        for(int i = 0; i < ret.size(); ++i) {
-            if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
-            if(i < nparams) {
-                float lo = ret(i) - width;
-                float hi = ret(i) + width;
-                std::uniform_real_distribution<float> ud(lo, hi);
-                ret(i) = ud(rng);
-            } else if(metric.GetSysts().spline_lo[i-nparams] == 0) {
-                // Currently there's some weird behavior with the 0-1 systematics
-                // which using a uniform distribution seems to fix
-                // TODO: How to use width with a uniform distribution
-                //float lo = metric.GetSysts().spline_lo[i-nparams];
-                //float hi = metric.GetSysts().spline_hi[i-nparams];
-                float lo = ret(i) - width;
-                float hi = ret(i) + width;
-                std::uniform_real_distribution<float> ud(lo, hi);
-                ret(i) = ud(rng);
-            } else {
-                std::normal_distribution<float> nd(current(i), width);
-                float proposed_value = nd(rng);
-                ret(i) = proposed_value;
-                //ret(i) = std::clamp(proposed_value, metric.GetSysts().spline_lo[i-nparams], metric.GetSysts().spline_hi[i-nparams]);
-            }
-        }
-        return ret;
-    }
-
-    float P(const Eigen::VectorXf &value, const Eigen::VectorXf &given) {
-        float prob = 1.0;
-        int nparams = metric.GetModel().nparams;
-        for(int i = 0; i < value.size(); ++i) {
-            if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
-            if(i < nparams) {
-                //float diff = metric.GetModel().ub(i) - metric.GetModel().lb(i);
-                //if(std::isinf(diff)) diff = 5;
-                //prob *= 1.0f / diff;
-                prob *= 1.0f / (2 * width);
-            }else if(metric.GetSysts().spline_lo[i-nparams] == 0) {
-                //float lo = metric.GetSysts().spline_lo[i-nparams];
-                //float hi = metric.GetSysts().spline_hi[i-nparams];
-                //prob *= 1.0f / (hi - lo);
-                prob *= 1.0f / (2 * width);
-            } else {
-                //if(value(i) <= metric.GetSysts().spline_lo[i-nparams] || value(i) >= metric.GetSysts().spline_hi[i-nparams] || 
-                //   given(i) <= metric.GetSysts().spline_lo[i-nparams] || given(i) >= metric.GetSysts().spline_hi[i-nparams]) {
-                //    // Due to bounds, use CDF to get total probability value is <= bound
-                //    // Symmetry makes this work for upper bound as well
-                //    float v = std::clamp(value(i), metric.GetSysts().spline_lo[i-nparams], metric.GetSysts().spline_hi[i-nparams]);
-                //    float g = std::clamp(given(i), metric.GetSysts().spline_lo[i-nparams], metric.GetSysts().spline_hi[i-nparams]);
-                //    prob *= 0.5f * (1.0f + std::erff((v - g)/(std::sqrt(2.0f)*width)));
-                //    //prob = 0;
-                //} else {
-                    prob *= (1.0f / std::sqrt(2 * M_PI * width * width))
-                            * std::exp(-(value(i) - given(i))*(value(i) - given(i))/(2 * width * width));
-                //}
-            }
-        }
-        return prob;
-    }
-
-    bool within_bound(Eigen::VectorXf &value) {
-        int nparams = metric.GetModel().nparams;
-        for(int i = 0; i < value.size(); ++i) {
-            if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
-            if(i < nparams) {
-                if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
-                    return false;
-            } else if(metric.GetSysts().spline_lo[i-nparams] == 0) {
-                return value(i) >= -metric.GetSysts().spline_hi[i-nparams] && value(i) <= metric.GetSysts().spline_hi[i-nparams];
-            } else {
-                if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
-                    return false;
-            }
-        }
-        return true;
-    }
-
-    void tune(bool accepted) {
-        accepted_list[tune_calls % 1000] = accepted;
-        if(++tune_calls % 1000 == 0) {
-            float acceptance = std::count(accepted_list.begin(), accepted_list.end(), true) / 1000.0f;
-            if(acceptance < 0.20 || acceptance > 0.30) {
-                if(std::abs(acceptance - 0.234) < std::abs(last_acceptance - 0.234)) {
-                    if(last_acceptance < 0) {
-                        width *= 1.25; // Default first step
-                        last_shift = 0.25 * width;
-                    } else {
-                        width += last_shift;
+                Metropolis(Target_FN target, Proposal_FN proposal, const Eigen::VectorXf &initial, uint32_t seed) 
+                    : seed(seed), target(target), proposal(proposal), current(initial) {
+                        rng.seed(seed);
                     }
-                } else { // Moved too far
-                    width += -0.5 * last_shift;
-                    last_shift *= -0.5;
+
+                bool step() {
+                    Eigen::VectorXf p = proposal(current);
+                    float acceptance = proposal.within_bound(p) ? std::min(1.0f, target(p)/target(current) * proposal.P(current, p)/proposal.P(p, current)) : 0;
+                    float u = uniform(rng);
+
+                    if(u <= acceptance) {
+                        //log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                        current = p;
+                        return true;
+                    }else{
+                        //log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                    }
+                    return false;
+                }
+
+                void run(size_t burnin, size_t steps, std::optional<std::function<void(const Eigen::VectorXf&)>> action = {}) {
+                    for(size_t i = 0; i < burnin; i++) {
+                        if constexpr(Proposal_FN::has_tune) {
+                            proposal.tune(step());
+                        } else {
+                            step();
+                        }
+                    }
+                    for(size_t i = 0; i < steps; i++) {
+                        if(step() && action) (*action)(current);
+                    }
+                }
+
+        };
+
+    struct simple_target {
+        PROmetric &metric;
+
+        float operator()(Eigen::VectorXf &value) {
+            Eigen::VectorXf empty;
+            return std::exp(-0.5f*metric(value, empty, false));
+        }
+    };
+
+    struct prior_only_target {
+        PROmetric &metric;
+
+        float operator()(Eigen::VectorXf &value) {
+            Eigen::VectorXf nuisance = value.segment(metric.GetModel().nparams, metric.GetSysts().GetNSplines());
+            return std::exp(-0.5f*metric.Pull(nuisance));
+        }
+    };
+
+    struct simple_proposal {
+        PROmetric &metric;
+        uint32_t seed;
+        float width;
+        std::vector<int> fixed;
+        std::mt19937 rng;
+        static constexpr bool has_tune = true;
+        std::vector<bool> accepted_list;
+        size_t tune_calls = 0;
+        float last_acceptance = -1;
+        float last_shift;
+
+        simple_proposal(PROmetric &metric, uint32_t seed, float width = 0.2, std::vector<int> fixed = {}) 
+            : metric(metric), seed(seed), width(width), fixed(fixed), rng(seed), last_shift(width) {
+                accepted_list = std::vector(1000, false);
+            }
+
+        Eigen::VectorXf operator()(Eigen::VectorXf &current) {
+            Eigen::VectorXf ret = current;
+            int nparams = metric.GetModel().nparams;
+            for(int i = 0; i < ret.size(); ++i) {
+                if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
+                if(i < nparams) {
+                    float lo = ret(i) - width;
+                    float hi = ret(i) + width;
+                    std::uniform_real_distribution<float> ud(lo, hi);
+                    ret(i) = ud(rng);
+                } else if(metric.GetSysts().spline_lo[i-nparams] == 0) {
+                    // Currently there's some weird behavior with the 0-1 systematics
+                    // which using a uniform distribution seems to fix
+                    // TODO: How to use width with a uniform distribution
+                    //float lo = metric.GetSysts().spline_lo[i-nparams];
+                    //float hi = metric.GetSysts().spline_hi[i-nparams];
+                    float lo = ret(i) - width;
+                    float hi = ret(i) + width;
+                    std::uniform_real_distribution<float> ud(lo, hi);
+                    ret(i) = ud(rng);
+                } else {
+                    std::normal_distribution<float> nd(current(i), width);
+                    float proposed_value = nd(rng);
+                    ret(i) = proposed_value;
+                    //ret(i) = std::clamp(proposed_value, metric.GetSysts().spline_lo[i-nparams], metric.GetSysts().spline_hi[i-nparams]);
                 }
             }
-            for(size_t i = 0; i < 1000; ++i) accepted_list[i] = false;
-            last_acceptance = acceptance;
+            return ret;
         }
-    }
-};
 
-struct adaptive_proposal {
-    PROmetric &metric;
-    uint32_t seed;
-    Eigen::MatrixXf width;
-    std::vector<int> fixed;
-    std::mt19937 rng;
-    static constexpr bool has_tune = true;
-    std::vector<Eigen::VectorXf> proposed;
-    Eigen::VectorXf last_proposed;
-    Eigen::VectorXf mean;
-    Eigen::MatrixXf cov;
-    size_t tune_calls = 0;
-    float scale = 5.66;
-    float diag_scale = 0.01;
-    //float beta = 0.05;
-    float beta = 1.0;
-    Eigen::MatrixXf diagL;
-
-    adaptive_proposal(PROmetric &metric, uint32_t seed, std::vector<int> fixed = {}) 
-        : metric(metric), seed(seed), fixed(fixed), rng(seed) {
-        int nparams = metric.GetModel().nparams + metric.GetSysts().GetNSplines();
-        scale /= nparams - fixed.size();
-        diag_scale /= nparams - fixed.size();
-        width = Eigen::MatrixXf::Identity(nparams, nparams);
-        mean = Eigen::VectorXf::Constant(nparams, 0);
-        cov = Eigen::MatrixXf::Identity(nparams, nparams);
-        Eigen::MatrixXf diag = Eigen::MatrixXf::Identity(nparams, nparams);
-        Eigen::LLT<Eigen::MatrixXf> llt(diag_scale * diag);
-        diagL = llt.matrixL();
-    }
-
-    Eigen::VectorXf operator()(Eigen::VectorXf &current) {
-        Eigen::VectorXf throw1 = current;
-        Eigen::VectorXf throw2 = current;
-        for(int i = 0; i < throw1.size(); ++i) {
-            if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) {
-                throw1(i) = 0;
-                throw2(i) = 0;
+        float P(const Eigen::VectorXf &value, const Eigen::VectorXf &given) {
+            float prob = 1.0;
+            int nparams = metric.GetModel().nparams;
+            for(int i = 0; i < value.size(); ++i) {
+                if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
+                if(i < nparams) {
+                    //float diff = metric.GetModel().ub(i) - metric.GetModel().lb(i);
+                    //if(std::isinf(diff)) diff = 5;
+                    //prob *= 1.0f / diff;
+                    prob *= 1.0f / (2 * width);
+                }else if(metric.GetSysts().spline_lo[i-nparams] == 0) {
+                    //float lo = metric.GetSysts().spline_lo[i-nparams];
+                    //float hi = metric.GetSysts().spline_hi[i-nparams];
+                    //prob *= 1.0f / (hi - lo);
+                    prob *= 1.0f / (2 * width);
+                } else {
+                    //if(value(i) <= metric.GetSysts().spline_lo[i-nparams] || value(i) >= metric.GetSysts().spline_hi[i-nparams] || 
+                    //   given(i) <= metric.GetSysts().spline_lo[i-nparams] || given(i) >= metric.GetSysts().spline_hi[i-nparams]) {
+                    //    // Due to bounds, use CDF to get total probability value is <= bound
+                    //    // Symmetry makes this work for upper bound as well
+                    //    float v = std::clamp(value(i), metric.GetSysts().spline_lo[i-nparams], metric.GetSysts().spline_hi[i-nparams]);
+                    //    float g = std::clamp(given(i), metric.GetSysts().spline_lo[i-nparams], metric.GetSysts().spline_hi[i-nparams]);
+                    //    prob *= 0.5f * (1.0f + std::erff((v - g)/(std::sqrt(2.0f)*width)));
+                    //    //prob = 0;
+                    //} else {
+                    prob *= (1.0f / std::sqrt(2 * M_PI * width * width))
+                        * std::exp(-(value(i) - given(i))*(value(i) - given(i))/(2 * width * width));
+                    //}
+                }
             }
-            std::normal_distribution<float> nd(0, 1);
-            throw1(i) = nd(rng);
-            throw2(i) = nd(rng);
+            return prob;
         }
-        //Eigen::LLT<Eigen::MatrixXf> llt(scale * width);
-        //Eigen::MatrixXf L = llt.matrixL();
-        //if(llt.info() != Eigen::Success) {
-        //    log<LOG_ERROR>(L"%1% || LLT decomp failed. Width is %2%.") % __func__ % width;
-        //    exit(1);
-        //}
-        Eigen::LDLT<Eigen::MatrixXf> ldlt(scale * width);
-        if(ldlt.info() != Eigen::Success) {
-            log<LOG_ERROR>(L"%1% || LDLT decomp failed. Width is %2%.") % __func__ % width;
-            exit(1);
+
+        bool within_bound(Eigen::VectorXf &value) {
+            int nparams = metric.GetModel().nparams;
+            for(int i = 0; i < value.size(); ++i) {
+                if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
+                if(i < nparams) {
+                    if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
+                        return false;
+                } else if(metric.GetSysts().spline_lo[i-nparams] == 0) {
+                    return value(i) >= -metric.GetSysts().spline_hi[i-nparams] && value(i) <= metric.GetSysts().spline_hi[i-nparams];
+                } else {
+                    if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
+                        return false;
+                }
+            }
+            return true;
         }
-        Eigen::MatrixXf Lp = ldlt.matrixL();
-        Eigen::VectorXf D_sqrt = ldlt.vectorD().array().sqrt();
-        Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
-        Eigen::MatrixXf L = P * Lp * D_sqrt.asDiagonal();
-        last_proposed = current + (1.0f - beta) * L * throw1 + beta * diagL * throw2;
-        return last_proposed;
-    }
 
-    float P(const Eigen::VectorXf &, const Eigen::VectorXf &) {
-        return 1;
-    }
-
-    bool within_bound(Eigen::VectorXf &value) {
-        int nparams = metric.GetModel().nparams;
-        for(int i = 0; i < value.size(); ++i) {
-            if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
-            if(i < nparams) {
-                if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
-                    return false;
-            } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
-                return value(i) >= -1 || value(i) <= 1;
-            } else {
-                if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
-                    return false;
+        void tune(bool accepted) {
+            accepted_list[tune_calls % 1000] = accepted;
+            if(++tune_calls % 1000 == 0) {
+                float acceptance = std::count(accepted_list.begin(), accepted_list.end(), true) / 1000.0f;
+                if(acceptance < 0.20 || acceptance > 0.30) {
+                    if(std::abs(acceptance - 0.234) < std::abs(last_acceptance - 0.234)) {
+                        if(last_acceptance < 0) {
+                            width *= 1.25; // Default first step
+                            last_shift = 0.25 * width;
+                        } else {
+                            width += last_shift;
+                        }
+                    } else { // Moved too far
+                        width += -0.5 * last_shift;
+                        last_shift *= -0.5;
+                    }
+                }
+                for(size_t i = 0; i < 1000; ++i) accepted_list[i] = false;
+                last_acceptance = acceptance;
             }
         }
-        return true;
-    }
+    };
 
-    void tune(bool accepted) {
-        if(accepted) {
-            proposed.push_back(last_proposed);
-            mean = (mean * (proposed.size() - 1) + last_proposed) / proposed.size();
-            cov *= 0;
-            for(const auto &v: proposed)
-                cov += (v - mean) * (v - mean).transpose();
-            cov /= proposed.size();
-            for(int idx : fixed) if(cov(idx,idx) == 0) cov(idx,idx) = 1;
+    struct adaptive_proposal {
+        PROmetric &metric;
+        uint32_t seed;
+        Eigen::MatrixXf width;
+        std::vector<int> fixed;
+        std::mt19937 rng;
+        static constexpr bool has_tune = true;
+        std::vector<Eigen::VectorXf> proposed;
+        Eigen::VectorXf last_proposed;
+        Eigen::VectorXf mean;
+        Eigen::MatrixXf cov;
+        size_t tune_calls = 0;
+        float scale = 0.5*5.66;
+        float diag_scale = 0.01;
+        float beta = 1.0;
+        Eigen::MatrixXf diagL;
+
+        adaptive_proposal(PROmetric &metric, uint32_t seed, std::vector<int> fixed = {}) 
+            : metric(metric), seed(seed), fixed(fixed), rng(seed) {
+                int nparams = metric.GetModel().nparams + metric.GetSysts().GetNSplines();
+                scale /= nparams - fixed.size();
+                diag_scale /= nparams - fixed.size();
+                width = Eigen::MatrixXf::Identity(nparams, nparams);
+                mean = Eigen::VectorXf::Constant(nparams, 0);
+                cov = Eigen::MatrixXf::Identity(nparams, nparams);
+                Eigen::MatrixXf diag = Eigen::MatrixXf::Identity(nparams, nparams);
+                Eigen::LLT<Eigen::MatrixXf> llt(diag_scale * diag);
+                diagL = llt.matrixL();
+            }
+
+        Eigen::VectorXf operator()(Eigen::VectorXf &current) {
+            Eigen::VectorXf throw1 = current;
+            Eigen::VectorXf throw2 = current;
+            for(int i = 0; i < throw1.size(); ++i) {
+                if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) {
+                    throw1(i) = 0;
+                    throw2(i) = 0;
+                }
+                std::normal_distribution<float> nd(0, 1);
+                throw1(i) = nd(rng);
+                throw2(i) = nd(rng);
+            }
+            //Eigen::LLT<Eigen::MatrixXf> llt(scale * width);
+            //Eigen::MatrixXf L = llt.matrixL();
+            //if(llt.info() != Eigen::Success) {
+            //    log<LOG_ERROR>(L"%1% || LLT decomp failed. Width is %2%.") % __func__ % width;
+            //    exit(1);
+            //}
+            Eigen::LDLT<Eigen::MatrixXf> ldlt(scale * width);
+            if(ldlt.info() != Eigen::Success) {
+                log<LOG_ERROR>(L"%1% || LDLT decomp failed. Width is %2%.") % __func__ % width;
+                exit(1);
+            }
+            Eigen::MatrixXf Lp = ldlt.matrixL();
+            Eigen::VectorXf D_sqrt = ldlt.vectorD().array().sqrt();
+            Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
+            Eigen::MatrixXf L = P * Lp * D_sqrt.asDiagonal();
+            last_proposed = current + (1.0f - beta) * L * throw1 + beta * diagL * throw2;
+            return last_proposed;
         }
-        if(tune_calls++ > (size_t)(2*last_proposed.size())) {
-            width = cov;
-            beta = 0.05;
+
+        float P(const Eigen::VectorXf &, const Eigen::VectorXf &) {
+            return 1;
         }
-    }
+
+
+        bool within_bound(const Eigen::VectorXf &value) {
+            int nparams = metric.GetModel().nparams;
+            for(int i = 0; i < value.size(); ++i) {
+                if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
+                if(i < nparams) {
+                    if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
+                        return false;
+                } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
+                    if(value(i) < -1 || value(i) > 1) return false;
+                } else {
+                    if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
+                        return false;
+                }
+            }
+            return true;
+        }
+
+
+        void tune(bool /*accepted*/) {
+            ++tune_calls;
+            Eigen::VectorXf delta = last_proposed - mean;
+            mean += delta / tune_calls;
+            if (tune_calls > 1) {
+                cov += (delta * (last_proposed - mean).transpose() - cov) / tune_calls;
+            }
+            if(tune_calls > (size_t)(2*last_proposed.size())) {
+                Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
+                for(int i = 0; i < cov_pd.rows(); ++i)
+                    cov_pd(i, i) += 1e-6;
+                width = cov_pd;
+                beta = 0.05;
+            }
+        }
+
+
+    };
 };
-}
 
 #endif
 

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -175,8 +175,8 @@ struct simple_proposal {
         accepted_list[tune_calls % 1000] = accepted;
         if(++tune_calls % 1000 == 0) {
             float acceptance = std::count(accepted_list.begin(), accepted_list.end(), true) / 1000.0f;
-            if(acceptance < 0.25 || acceptance > 0.35) {
-                if(std::abs(acceptance - 0.3) < std::abs(last_acceptance - 0.3)) {
+            if(acceptance < 0.20 || acceptance > 0.30) {
+                if(std::abs(acceptance - 0.234) < std::abs(last_acceptance - 0.234)) {
                     if(last_acceptance < 0) {
                         width *= 1.25; // Default first step
                         last_shift = 0.25 * width;
@@ -208,7 +208,8 @@ struct adaptive_proposal {
     size_t tune_calls = 0;
     float scale = 5.66;
     float diag_scale = 0.01;
-    float beta = 0.05;
+    //float beta = 0.05;
+    float beta = 1.0;
     Eigen::MatrixXf diagL;
 
     adaptive_proposal(PROmetric &metric, uint32_t seed, std::vector<int> fixed = {}) 
@@ -236,8 +237,21 @@ struct adaptive_proposal {
             throw1(i) = nd(rng);
             throw2(i) = nd(rng);
         }
-        Eigen::LLT<Eigen::MatrixXf> llt(scale * width);
-        Eigen::MatrixXf L = llt.matrixL();
+        //Eigen::LLT<Eigen::MatrixXf> llt(scale * width);
+        //Eigen::MatrixXf L = llt.matrixL();
+        //if(llt.info() != Eigen::Success) {
+        //    log<LOG_ERROR>(L"%1% || LLT decomp failed. Width is %2%.") % __func__ % width;
+        //    exit(1);
+        //}
+        Eigen::LDLT<Eigen::MatrixXf> ldlt(scale * width);
+        if(ldlt.info() != Eigen::Success) {
+            log<LOG_ERROR>(L"%1% || LDLT decomp failed. Width is %2%.") % __func__ % width;
+            exit(1);
+        }
+        Eigen::MatrixXf Lp = ldlt.matrixL();
+        Eigen::VectorXf D_sqrt = ldlt.vectorD().array().sqrt();
+        Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
+        Eigen::MatrixXf L = P * Lp * D_sqrt.asDiagonal();
         last_proposed = current + (1.0f - beta) * L * throw1 + beta * diagL * throw2;
         return last_proposed;
     }
@@ -253,6 +267,8 @@ struct adaptive_proposal {
             if(i < nparams) {
                 if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
                     return false;
+            } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
+                return value(i) >= -1 || value(i) <= 1;
             } else {
                 if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
                     return false;
@@ -269,9 +285,11 @@ struct adaptive_proposal {
             for(const auto &v: proposed)
                 cov += (v - mean) * (v - mean).transpose();
             cov /= proposed.size();
+            for(int idx : fixed) if(cov(idx,idx) == 0) cov(idx,idx) = 1;
         }
-        if(tune_calls++ > 1000) {
+        if(tune_calls++ > (size_t)(2*last_proposed.size())) {
             width = cov;
+            beta = 0.05;
         }
     }
 };

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -13,6 +13,7 @@
 #include <optional>
 namespace PROfit {
 
+        
     template<class Target_FN, class Proposal_FN>
         class Metropolis {
             private:
@@ -36,7 +37,7 @@ namespace PROfit {
                     float u = uniform(rng);
 
                     if(u <= acceptance) {
-                          //                      log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                        //                      log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                         current = p;
                         return true;
                     }else{
@@ -222,6 +223,8 @@ namespace PROfit {
         float adapt_factor = 1.02;   
 
 
+       Eigen::MatrixXf sub_diagL;
+       std::vector<int> active;
 
         adaptive_proposal(PROmetric &metric, uint32_t seed, std::vector<int> fixed = {}) 
             : metric(metric), seed(seed), fixed(fixed), rng(seed) {
@@ -234,41 +237,34 @@ namespace PROfit {
                 Eigen::MatrixXf diag = Eigen::MatrixXf::Identity(nparams, nparams);
                 Eigen::LLT<Eigen::MatrixXf> llt(diag_scale * diag);
                 diagL = llt.matrixL();
+
+                for (int i = 0; i < nparams; ++i) {
+                    if (std::find(fixed.begin(), fixed.end(), i) == fixed.end()) {
+                        active.push_back(i);
+                    }
+                }
+                sub_diagL = Eigen::MatrixXf::Identity(active.size(), active.size());
+                sub_diagL = diagL(active, active);  // Magical Eigen indexing
+
             }
 
         Eigen::VectorXf operator()(Eigen::VectorXf &current) {
-            Eigen::VectorXf throw1 = current;
-            Eigen::VectorXf throw2 = current;
-            for(int i = 0; i < throw1.size(); ++i) {
-                if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) {
-                    throw1(i) = 0.0;
-                    throw2(i) = 0.0;
-                }else{
-                    std::normal_distribution<float> nd(0, 1);
-                    throw1(i) = nd(rng);
-                    throw2(i) = nd(rng);
-                }
-            }
-            //Eigen::LLT<Eigen::MatrixXf> llt(scale * width);
-            //Eigen::MatrixXf L = llt.matrixL();
-            //if(llt.info() != Eigen::Success) {
-            //    log<LOG_ERROR>(L"%1% || LLT decomp failed. Width is %2%.") % __func__ % width;
-            //    exit(1);
-            //}
-            Eigen::LDLT<Eigen::MatrixXf> ldlt(scale * width);
-            if(ldlt.info() != Eigen::Success) {
-                log<LOG_ERROR>(L"%1% || LDLT decomp failed. Width is %2%.") % __func__ % width;
-                exit(1);
-            }
-            Eigen::MatrixXf Lp = ldlt.matrixL();
-            Eigen::VectorXf D_sqrt = ldlt.vectorD().array().sqrt();
-            Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
-            Eigen::MatrixXf L = P * Lp * D_sqrt.asDiagonal();
-            last_proposed = current + (1.0f - beta) * L * throw1 + beta * diagL * throw2;
 
-            for (int idx : fixed) {
-                last_proposed(idx) = current(idx);
+            Eigen::VectorXf sub_throw1(active.size());
+            Eigen::VectorXf sub_throw2(active.size());
+            std::normal_distribution<float> nd(0.0f, 1.0f);
+            for (int i = 0; i < active.size(); ++i) {
+                sub_throw1(i) = nd(rng);
+                sub_throw2(i) = nd(rng);
             }
+            
+            Eigen::MatrixXf inp = scale*width;//fulldim
+
+            Eigen::MatrixXf sub_inp = inp(active, active);  // Magic Eigen indexing?!
+            Eigen::MatrixXf sub_L = ComputeSquareRootCovariance(sub_inp,false);
+
+            last_proposed = current;//fulldim
+            last_proposed(active) += (1.0f - beta) * sub_L * sub_throw1 + beta * sub_diagL * sub_throw2; //More index nonsesne?!
 
             return last_proposed;
         }
@@ -310,27 +306,27 @@ namespace PROfit {
                 }
 
             }
-                accept_history.push_back(accepted);
-                if (accept_history.size() == adapt_window) {
-                    float acc_rate = std::count(accept_history.begin(), accept_history.end(), true) / float(adapt_window);
+            accept_history.push_back(accepted);
+            if (accept_history.size() == adapt_window) {
+                float acc_rate = std::count(accept_history.begin(), accept_history.end(), true) / float(adapt_window);
 
-                    if (acc_rate > target_accept) {
-                        scale *= adapt_factor;
-                    } else {
-                        scale /= adapt_factor;
-                    }
-                    accept_history.clear();
-                    log<LOG_DEBUG>(L"%1% || Adaptive scale updated to %2%, acceptance rate = %3%") % __func__ % scale % acc_rate;
+                if (acc_rate > target_accept) {
+                    scale *= adapt_factor;
+                } else {
+                    scale /= adapt_factor;
                 }
+                accept_history.clear();
+                log<LOG_DEBUG>(L"%1% || Adaptive scale updated to %2%, acceptance rate = %3%") % __func__ % scale % acc_rate;
+            }
 
-                if(tune_calls > (size_t)(4*last_proposed.size())) {
-                    Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
-                    for(int i = 0; i < cov_pd.rows(); ++i)
-                        cov_pd(i, i) += 1e-12;
-                    width = cov_pd;
-                    beta = tune_calls > (size_t)(100*last_proposed.size()) ? 0.05 : 0.5;
-                }
-            
+            if(tune_calls > (size_t)(4*last_proposed.size())) {
+                Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
+                for(int i = 0; i < cov_pd.rows(); ++i)
+                    cov_pd(i, i) += 1e-12;
+                width = cov_pd;
+                beta = tune_calls > (size_t)(100*last_proposed.size()) ? 0.05 : 0.5;
+            }
+
 
         }
 

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -36,11 +36,11 @@ namespace PROfit {
                     float u = uniform(rng);
 
                     if(u <= acceptance) {
-                        //log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                       // log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                         current = p;
                         return true;
                     }else{
-                        //log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                       // log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                     }
                     return false;
                 }
@@ -158,15 +158,15 @@ namespace PROfit {
             return prob;
         }
 
-        bool within_bound(Eigen::VectorXf &value) {
+        bool within_bound(const Eigen::VectorXf &value) {
             int nparams = metric.GetModel().nparams;
             for(int i = 0; i < value.size(); ++i) {
                 if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
                 if(i < nparams) {
                     if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
                         return false;
-                } else if(metric.GetSysts().spline_lo[i-nparams] == 0) {
-                    return value(i) >= -metric.GetSysts().spline_hi[i-nparams] && value(i) <= metric.GetSysts().spline_hi[i-nparams];
+                } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
+                    if(value(i) < -1 || value(i) > 1) return false;
                 } else {
                     if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
                         return false;
@@ -210,7 +210,7 @@ namespace PROfit {
         Eigen::VectorXf mean;
         Eigen::MatrixXf cov;
         size_t tune_calls = 0;
-        float scale = 0.5*5.66;
+        float scale = 0.75*5.66;
         float diag_scale = 0.01;
         float beta = 1.0;
         Eigen::MatrixXf diagL;
@@ -282,22 +282,24 @@ namespace PROfit {
         }
 
 
-        void tune(bool /*accepted*/) {
-            ++tune_calls;
-            Eigen::VectorXf delta = last_proposed - mean;
-            mean += delta / tune_calls;
-            if (tune_calls > 1) {
-                cov += (delta * (last_proposed - mean).transpose() - cov) / tune_calls;
+        void tune(bool accepted) {
+            if (accepted) {
+                ++tune_calls;
+                Eigen::VectorXf delta = last_proposed - mean;
+                mean += delta / tune_calls;
+                if (tune_calls > 1) {
+                    cov += (delta * (last_proposed - mean).transpose() - cov) / tune_calls;
+                }
+                if(tune_calls > (size_t)(2*last_proposed.size())) {
+                    Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
+                    for(int i = 0; i < cov_pd.rows(); ++i)
+                        cov_pd(i, i) += 1e-6;
+                    width = cov_pd;
+                    beta = 0.05;
+                }
             }
-            if(tune_calls > (size_t)(2*last_proposed.size())) {
-                Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
-                for(int i = 0; i < cov_pd.rows(); ++i)
-                    cov_pd(i, i) += 1e-6;
-                width = cov_pd;
-                beta = 0.05;
-            }
-        }
 
+        }
 
     };
 };

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -36,11 +36,11 @@ namespace PROfit {
                     float u = uniform(rng);
 
                     if(u <= acceptance) {
-                        // log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+ //                        log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                         current = p;
                         return true;
                     }else{
-                        // log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+   //                      log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                     }
                     return false;
                 }
@@ -163,7 +163,7 @@ namespace PROfit {
             for(int i = 0; i < value.size(); ++i) {
                 if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
                 if(i < nparams) {
-                    if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
+                    if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i) || value(i) < -5.0f)
                         return false;
                 } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
                     if(value(i) < -1 || value(i) > 1) return false;
@@ -233,8 +233,8 @@ namespace PROfit {
             Eigen::VectorXf throw2 = current;
             for(int i = 0; i < throw1.size(); ++i) {
                 if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) {
-                    throw1(i) = 0;
-                    throw2(i) = 0;
+                    throw1(i) = 0.0;
+                    throw2(i) = 0.0;
                 }else{
                     std::normal_distribution<float> nd(0, 1);
                     throw1(i) = nd(rng);
@@ -257,6 +257,11 @@ namespace PROfit {
             Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
             Eigen::MatrixXf L = P * Lp * D_sqrt.asDiagonal();
             last_proposed = current + (1.0f - beta) * L * throw1 + beta * diagL * throw2;
+            
+            for (int idx : fixed) {
+                    last_proposed(idx) = current(idx);
+                }
+            
             return last_proposed;
         }
 
@@ -270,7 +275,7 @@ namespace PROfit {
             for(int i = 0; i < value.size(); ++i) {
                 if(std::find(fixed.begin(), fixed.end(), i) != std::end(fixed)) continue;
                 if(i < nparams) {
-                    if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i))
+                    if(value(i) > metric.GetModel().ub(i) || value(i) < std::max(metric.GetModel().lb(i),-5.0f))
                         return false;
                 } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
                     if(value(i) < -1 || value(i) > 1) return false;

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -36,11 +36,11 @@ namespace PROfit {
                     float u = uniform(rng);
 
                     if(u <= acceptance) {
- //                        log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                          //                      log<LOG_DEBUG>(L"%1% || APPROVED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                         current = p;
                         return true;
                     }else{
-   //                      log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
+                        //                      log<LOG_DEBUG>(L"%1% || REJECTED acc %2%, rng %3% and proposal: %4%  ") % __func__ % acceptance % u %p;
                     }
                     return false;
                 }
@@ -215,6 +215,14 @@ namespace PROfit {
         float beta = 1.0;
         Eigen::MatrixXf diagL;
 
+        // Adaptive scaling state
+        std::vector<bool> accept_history;
+        size_t adapt_window = 1000;  // window size for adaptation
+        float target_accept = 0.234; 
+        float adapt_factor = 1.02;   
+
+
+
         adaptive_proposal(PROmetric &metric, uint32_t seed, std::vector<int> fixed = {}) 
             : metric(metric), seed(seed), fixed(fixed), rng(seed) {
                 int nparams = metric.GetModel().nparams + metric.GetSysts().GetNSplines();
@@ -257,11 +265,11 @@ namespace PROfit {
             Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
             Eigen::MatrixXf L = P * Lp * D_sqrt.asDiagonal();
             last_proposed = current + (1.0f - beta) * L * throw1 + beta * diagL * throw2;
-            
+
             for (int idx : fixed) {
-                    last_proposed(idx) = current(idx);
-                }
-            
+                last_proposed(idx) = current(idx);
+            }
+
             return last_proposed;
         }
 
@@ -301,14 +309,28 @@ namespace PROfit {
                     cov.col(idx).setZero();
                 }
 
-                if(tune_calls > (size_t)(2*last_proposed.size())) {
+            }
+                accept_history.push_back(accepted);
+                if (accept_history.size() == adapt_window) {
+                    float acc_rate = std::count(accept_history.begin(), accept_history.end(), true) / float(adapt_window);
+
+                    if (acc_rate > target_accept) {
+                        scale *= adapt_factor;
+                    } else {
+                        scale /= adapt_factor;
+                    }
+                    accept_history.clear();
+                    log<LOG_DEBUG>(L"%1% || Adaptive scale updated to %2%, acceptance rate = %3%") % __func__ % scale % acc_rate;
+                }
+
+                if(tune_calls > (size_t)(4*last_proposed.size())) {
                     Eigen::MatrixXf cov_pd = cov;//numerical stability apparrently
                     for(int i = 0; i < cov_pd.rows(); ++i)
-                        cov_pd(i, i) += 1e-6;
+                        cov_pd(i, i) += 1e-12;
                     width = cov_pd;
-                    beta = 0.05;
+                    beta = tune_calls > (size_t)(100*last_proposed.size()) ? 0.05 : 0.5;
                 }
-            }
+            
 
         }
 

--- a/inc/PROfitter.h
+++ b/inc/PROfitter.h
@@ -12,8 +12,8 @@ namespace PROfit {
         LBFGSpp::LBFGSBParam<float> param;
         int n_multistart = 1500, n_swarm_particles = 1, n_swarm_iterations=1, n_localfit=3;
         size_t n_max_local_retries = 3;
-        size_t MCMCiter = 50'000;
-        size_t MCMCburn = 10'000;
+        size_t MCMCiter = 20'000;
+        size_t MCMCburn = 25'000;
 
         PROfitterConfig(){};
         PROfitterConfig(std::map<std::string, float> input_fit_options, std::string fit_preset, bool isScan){

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -86,7 +86,7 @@ public:
         float sinterm = std::sin(1.27f*dmsq*(le));
         float prob    = 1.0f - (sinsq2thmumu*sinterm*sinterm);
 
-        if(prob<0.0 || prob >1.0){
+        if(prob<0.0 || prob >1.0 ){;//|| std::isnan(prob)){
             log<LOG_ERROR>(L"%1% || Your probability %2% is outside the bounds of math."
                            L"dmsq = %3%, sinsq2thmumu = %4%, L/E = %5%")
                 % __func__ % prob % dmsq % sinsq2thmumu % le;

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -95,7 +95,7 @@ namespace PROfit{
                 Eigen::VectorXf splines = value.segment(nphys, nspline);
                 Eigen::VectorXf diff = splines-splines_bf;
                 post_covar += diff * diff.transpose();
-                bool print_autocorrelation_values = true;
+                bool print_autocorrelation_values = false;
                 if(print_autocorrelation_values){
                     log<LOG_INFO>(L"%1% || AUTO  %2% : %3%") % __func__ % accepted % value;
                 }

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -95,7 +95,10 @@ namespace PROfit{
                 Eigen::VectorXf splines = value.segment(nphys, nspline);
                 Eigen::VectorXf diff = splines-splines_bf;
                 post_covar += diff * diff.transpose();
-                log<LOG_DEBUG>(L"%1% || AUTO  %2% : %3%") % __func__ % accepted % value;
+                bool print_autocorrelation_values = false;
+                if(print_autocorrelation_values){
+                    log<LOG_INFO>(L"%1% || AUTO  %2% : %3%") % __func__ % accepted % value;
+                }
             };
             met.run(burnin, iterations, action);
             post_covar /= accepted;

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -95,6 +95,7 @@ namespace PROfit{
                 Eigen::VectorXf splines = value.segment(nphys, nspline);
                 Eigen::VectorXf diff = splines-splines_bf;
                 post_covar += diff * diff.transpose();
+                log<LOG_DEBUG>(L"%1% || AUTO  %2% : %3%") % __func__ % accepted % value;
             };
             met.run(burnin, iterations, action);
             post_covar /= accepted;

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -30,7 +30,7 @@
 #include "TRatioPlot.h"
 #include "TPaveText.h"
 #include "TTree.h"
-
+#include "TLine.h"
 namespace PROfit{
 
     enum class PlotOptions {

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -98,6 +98,7 @@ namespace PROfit{
             };
             met.run(burnin, iterations, action);
             post_covar /= accepted;
+            log<LOG_INFO>(L"%1% || Acceptance rate %2%") % __func__ % ((float)accepted / iterations);
 
             //TODO: Only works with 1 mode/detector/channel
             cv = CollapseMatrix(config, cv);
@@ -115,6 +116,7 @@ namespace PROfit{
                 for(size_t j = 0; j < specs.size(); ++j) {
                     binconts[j] = specs[j](i);
                 }
+                if(!binconts.size()) continue;
                 float scale_factor = tmphist.GetBinContent(i+1)/cv(i);
                 if(std::isnan(scale_factor)) scale_factor = 1;
                 std::sort(binconts.begin(), binconts.end());

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -95,7 +95,7 @@ namespace PROfit{
                 Eigen::VectorXf splines = value.segment(nphys, nspline);
                 Eigen::VectorXf diff = splines-splines_bf;
                 post_covar += diff * diff.transpose();
-                bool print_autocorrelation_values = false;
+                bool print_autocorrelation_values = true;
                 if(print_autocorrelation_values){
                     log<LOG_INFO>(L"%1% || AUTO  %2% : %3%") % __func__ % accepted % value;
                 }

--- a/inc/PROtocall.h
+++ b/inc/PROtocall.h
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <string>
 #include <iomanip>
+#include <stdexcept>
+
 // PROfit include 
 #include "PROlog.h"
 #include "PROconfig.h"
@@ -82,6 +84,8 @@ namespace PROfit{
       out <<std::fixed<< std::setprecision(n) << a_value;
       return out.str();
     }
+
+    Eigen::MatrixXf ComputeSquareRootCovariance(const Eigen::MatrixXf& covariance, bool use_ldlt = true, float svd_tol = -1.0);
 
 };
 

--- a/other/auto_corr_studies.ipynb
+++ b/other/auto_corr_studies.ipynb
@@ -2,31 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "ae89c08f-c79a-482c-b4b9-f0804c76ce9e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_660384/1510030591.py:10: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
-      "  df = pd.read_csv(filename, delim_whitespace=True, header=0)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved plots to mcmc_diagnostics.pdf\n"
-     ]
-    }
-   ],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 37,
    "id": "8b26c7e7-a44c-4e00-9211-1fe13fe34055",
    "metadata": {},
    "outputs": [
@@ -34,7 +10,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_660384/997162973.py:9: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "/tmp/ipykernel_660384/2087552858.py:9: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
       "  df = pd.read_csv(filename, delim_whitespace=True, header=0)\n"
      ]
     },
@@ -53,17 +29,14 @@
     "from statsmodels.tsa.stattools import acf\n",
     "from matplotlib.backends.backend_pdf import PdfPages\n",
     "\n",
-    "# --- 1. Load data from text file ---\n",
     "filename = '/home/mark/work/PROfit_Dev/working_dir/MCMC/testMCMC'  # Replace with your file path\n",
+    "# its a \n",
     "df = pd.read_csv(filename, delim_whitespace=True, header=0)\n",
     "N = df.shape[1]\n",
     "\n",
-    "# Optional: set column names\n",
-    "# df.columns = [f\"param_{i}\" for i in range(N)]\n",
-    "\n",
     "with PdfPages('mcmc_diagnostics.pdf') as pdf:\n",
     "\n",
-    "    # --- 2. Hairy trace plots ---\n",
+    "    # Hairy Catapillar plots\n",
     "    fig, axes = plt.subplots(N, 1, figsize=(8, 2*N), sharex=True)\n",
     "    for i in range(N):\n",
     "        axes[i].plot(df.iloc[:, i])\n",
@@ -74,7 +47,7 @@
     "    pdf.savefig(fig)\n",
     "    plt.close(fig)\n",
     "\n",
-    "    # --- 3. Individual autocorrelation plots ---\n",
+    "    # Individual autocorrelation plots\n",
     "    max_lag = 50\n",
     "    fig, axes = plt.subplots(N, 1, figsize=(8, 2*N))\n",
     "    for i in range(N):\n",
@@ -87,7 +60,7 @@
     "    pdf.savefig(fig)\n",
     "    plt.close(fig)\n",
     "\n",
-    "    # --- 4. Combined autocorrelation line plot ---\n",
+    "    #  Combined autocorrelation line plot\n",
     "    fig, ax = plt.subplots(figsize=(10, 6))\n",
     "    for i in range(N):\n",
     "        acorr = acf(df.iloc[:, i], nlags=max_lag, fft=True)\n",

--- a/other/auto_corr_studies.ipynb
+++ b/other/auto_corr_studies.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "ae89c08f-c79a-482c-b4b9-f0804c76ce9e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_660384/1510030591.py:10: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(filename, delim_whitespace=True, header=0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved plots to mcmc_diagnostics.pdf\n"
+     ]
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "8b26c7e7-a44c-4e00-9211-1fe13fe34055",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_660384/997162973.py:9: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\\s+'`` instead\n",
+      "  df = pd.read_csv(filename, delim_whitespace=True, header=0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved plots to mcmc_diagnostics.pdf\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from statsmodels.tsa.stattools import acf\n",
+    "from matplotlib.backends.backend_pdf import PdfPages\n",
+    "\n",
+    "# --- 1. Load data from text file ---\n",
+    "filename = '/home/mark/work/PROfit_Dev/working_dir/MCMC/testMCMC'  # Replace with your file path\n",
+    "df = pd.read_csv(filename, delim_whitespace=True, header=0)\n",
+    "N = df.shape[1]\n",
+    "\n",
+    "# Optional: set column names\n",
+    "# df.columns = [f\"param_{i}\" for i in range(N)]\n",
+    "\n",
+    "with PdfPages('mcmc_diagnostics.pdf') as pdf:\n",
+    "\n",
+    "    # --- 2. Hairy trace plots ---\n",
+    "    fig, axes = plt.subplots(N, 1, figsize=(8, 2*N), sharex=True)\n",
+    "    for i in range(N):\n",
+    "        axes[i].plot(df.iloc[:, i])\n",
+    "        axes[i].set_title(df.columns[i])\n",
+    "    axes[-1].set_xlabel('Sample')\n",
+    "    fig.suptitle('Trace plots (hairy caterpillars)', y=1.02)\n",
+    "    plt.tight_layout()\n",
+    "    pdf.savefig(fig)\n",
+    "    plt.close(fig)\n",
+    "\n",
+    "    # --- 3. Individual autocorrelation plots ---\n",
+    "    max_lag = 50\n",
+    "    fig, axes = plt.subplots(N, 1, figsize=(8, 2*N))\n",
+    "    for i in range(N):\n",
+    "        acorr = acf(df.iloc[:, i], nlags=max_lag, fft=True)\n",
+    "        axes[i].stem(range(len(acorr)), acorr)\n",
+    "        axes[i].set_ylabel('ACF')\n",
+    "        axes[i].set_title(f'Autocorrelation: {df.columns[i]}')\n",
+    "    axes[-1].set_xlabel('Lag')\n",
+    "    plt.tight_layout()\n",
+    "    pdf.savefig(fig)\n",
+    "    plt.close(fig)\n",
+    "\n",
+    "    # --- 4. Combined autocorrelation line plot ---\n",
+    "    fig, ax = plt.subplots(figsize=(10, 6))\n",
+    "    for i in range(N):\n",
+    "        acorr = acf(df.iloc[:, i], nlags=max_lag, fft=True)\n",
+    "        ax.plot(range(len(acorr)), acorr, label=df.columns[i])\n",
+    "    ax.set_xlabel('Lag')\n",
+    "    ax.set_ylabel('Autocorrelation')\n",
+    "    ax.set_title('Autocorrelation Comparison Across Parameters')\n",
+    "    ax.legend(loc='upper right', fontsize='small', ncol=2)\n",
+    "    ax.grid(True)\n",
+    "    plt.tight_layout()\n",
+    "    pdf.savefig(fig)\n",
+    "    plt.close(fig)\n",
+    "\n",
+    "print(\"Saved plots to mcmc_diagnostics.pdf\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "050efadf-13d7-452f-952d-9a4c3c47118f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18654883-e1ce-469c-aa5a-4d2a51de8325",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81fe068a-8582-4726-9f88-72a2952e82cb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc1082db-8ce7-4a26-9878-e0118e72f7b9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35988f2c-2d0d-46e3-a8c2-efed7c10de20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d8667a7-1fb9-41ab-a84e-e475ea13f911",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/other/auto_corr_studies.ipynb
+++ b/other/auto_corr_studies.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "id": "8b26c7e7-a44c-4e00-9211-1fe13fe34055",
    "metadata": {},
    "outputs": [

--- a/other/auto_corr_studies.ipynb
+++ b/other/auto_corr_studies.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "id": "8b26c7e7-a44c-4e00-9211-1fe13fe34055",
    "metadata": {},
    "outputs": [

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -135,6 +135,7 @@ namespace PROfit {
 	      myspectrum.Fill(reco_bin, finalw);
 	    }
 	}
+    
 	return myspectrum;
   }
 
@@ -170,6 +171,14 @@ namespace PROfit {
 		  float oscw = inmodel.model_functions[j](phys, le);
 		  for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
 		    myspectrum.Fill(k, systw(k) * oscw * inmodel.hists[j](i, k));
+            if( std::isnan(systw(k) * oscw * inmodel.hists[j](i, k))){
+
+                //log<LOG_DEBUG>(L"%1% || systw(k) %2% oscw %3% model %4% k %5% (phs  %6% || le %7%)") % __func__ % systw(k) % oscw % inmodel.hists[j](i, k)% k % phys % le;
+                //log<LOG_DEBUG>(L"%1% || params %2% ") % __func__ % params;
+                //exit(EXIT_FAILURE);
+
+
+            }
 		  }
                 }
             }
@@ -194,6 +203,16 @@ namespace PROfit {
 	    myspectrum.Fill(reco_bin, finalw);
 	  }
         }
+for(int j=0; j<myspectrum.GetNbins(); j++){
+        if(std::isnan(myspectrum.GetBinContent(j)) || myspectrum.GetBinContent(j)!=myspectrum.GetBinContent(j)){
+            for(int k=0; k<myspectrum.GetNbins(); k++){
+    		  //  log<LOG_DEBUG>(L"%1% || i: %2% GetBinContent() %3%") % __func__ % k % myspectrum.GetBinContent(k);
+            }
+    		//log<LOG_DEBUG>(L"%1% || params %2% ") % __func__ % params;
+            //exit(EXIT_FAILURE);
+
+        }
+    }
         return myspectrum;
   }
 	    

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -171,14 +171,6 @@ namespace PROfit {
 		  float oscw = inmodel.model_functions[j](phys, le);
 		  for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
 		    myspectrum.Fill(k, systw(k) * oscw * inmodel.hists[j](i, k));
-            if( std::isnan(systw(k) * oscw * inmodel.hists[j](i, k))){
-
-                //log<LOG_DEBUG>(L"%1% || systw(k) %2% oscw %3% model %4% k %5% (phs  %6% || le %7%)") % __func__ % systw(k) % oscw % inmodel.hists[j](i, k)% k % phys % le;
-                //log<LOG_DEBUG>(L"%1% || params %2% ") % __func__ % params;
-                //exit(EXIT_FAILURE);
-
-
-            }
 		  }
                 }
             }
@@ -203,16 +195,6 @@ namespace PROfit {
 	    myspectrum.Fill(reco_bin, finalw);
 	  }
         }
-for(int j=0; j<myspectrum.GetNbins(); j++){
-        if(std::isnan(myspectrum.GetBinContent(j)) || myspectrum.GetBinContent(j)!=myspectrum.GetBinContent(j)){
-            for(int k=0; k<myspectrum.GetNbins(); k++){
-    		  //  log<LOG_DEBUG>(L"%1% || i: %2% GetBinContent() %3%") % __func__ % k % myspectrum.GetBinContent(k);
-            }
-    		//log<LOG_DEBUG>(L"%1% || params %2% ") % __func__ % params;
-            //exit(EXIT_FAILURE);
-
-        }
-    }
         return myspectrum;
   }
 	    

--- a/src/PROdata.cxx
+++ b/src/PROdata.cxx
@@ -207,7 +207,7 @@ Eigen::VectorXf PROdata::eigenvector_division(const Eigen::VectorXf& a, const Ei
                 log<LOG_ERROR>(L"Terminating.");
                 exit(EXIT_FAILURE);
             }else{
-                log<LOG_DEBUG>(L"%1% || Both numerator and denominator are zero, setting the ratio to 1.") % __func__;
+                //log<LOG_DEBUG>(L"%1% || Both numerator and denominator are zero, setting the ratio to 1.") % __func__;
                 ratio_spec(i) = 1.0;
             }
         }else

--- a/src/PROspec.cxx
+++ b/src/PROspec.cxx
@@ -254,7 +254,7 @@ Eigen::VectorXf PROspec::eigenvector_division(const Eigen::VectorXf& a, const Ei
                 log<LOG_ERROR>(L"Terminating.");
                 exit(EXIT_FAILURE);
             }else{
-                log<LOG_DEBUG>(L"%1% || Both numerator and denominator are zero, setting the ratio to 1.") % __func__;
+                //log<LOG_DEBUG>(L"%1% || Both numerator and denominator are zero, setting the ratio to 1.") % __func__;
                 ratio_spec(i) = 1.0;
             }
         }else

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -734,12 +734,12 @@ namespace PROfit {
         const auto& U = svd.matrixU();
         const auto& S = svd.singularValues();
 
-        log<LOG_DEBUG>(L"%1% | Singular values: %2% ") % __func__ % svd.singularValues();
+        //log<LOG_DEBUG>(L"%1% | Singular values: %2% ") % __func__ % svd.singularValues();
 
         Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(coll);
           int rank = lu_decomp.rank();
           int size = coll.rows();
-          log<LOG_DEBUG>(L"%1% | Matrix is Rank %2% and size %3%") % __func__ % rank % size ;
+          //log<LOG_DEBUG>(L"%1% | Matrix is Rank %2% and size %3%") % __func__ % rank % size ;
 
         float tol = 1e-8f * S.maxCoeff(); // Some cutoff? is this value impactful on out matricies? need to test
         std::vector<int> keep;

--- a/src/PROtocall.cxx
+++ b/src/PROtocall.cxx
@@ -104,7 +104,7 @@ namespace PROfit{
 
     Eigen::MatrixXf CollapseMatrix(const PROconfig &inconfig, const Eigen::MatrixXf& full_matrix){
         Eigen::MatrixXf collapsing_matrix = inconfig.GetCollapsingMatrix();
-        
+
         int num_bin_before_collapse = collapsing_matrix.rows();
         if(full_matrix.rows() != num_bin_before_collapse || full_matrix.cols() != num_bin_before_collapse){
             log<LOG_ERROR>(L"%1% || Matrix dimension doesn't match expected size. Provided matrix: %2% x %3%. Expected matrix size: %4% x %5%") % __func__ % full_matrix.rows() % full_matrix.cols() % num_bin_before_collapse% num_bin_before_collapse;
@@ -130,7 +130,7 @@ namespace PROfit{
 
     Eigen::MatrixXf CollapseMatrix(const PROconfig &inconfig, const Eigen::MatrixXf& full_matrix, int other_index){
         Eigen::MatrixXf collapsing_matrix = inconfig.GetCollapsingMatrix(other_index);
-        
+
         int num_bin_before_collapse = collapsing_matrix.rows();
         if(full_matrix.rows() != num_bin_before_collapse || full_matrix.cols() != num_bin_before_collapse){
             log<LOG_ERROR>(L"%1% || Matrix dimension doesn't match expected size. Provided matrix: %2% x %3%. Expected matrix size: %4% x %5%") % __func__ % full_matrix.rows() % full_matrix.cols() % num_bin_before_collapse% num_bin_before_collapse;
@@ -153,6 +153,50 @@ namespace PROfit{
         Eigen::VectorXf result_vector = collapsing_matrix.transpose() * full_vector;
         return result_vector;
     }
+    
+    Eigen::MatrixXf ComputeSquareRootCovariance(
+            const Eigen::MatrixXf& covariance,
+            bool use_ldlt,  float svd_tol  ) {
+
+        if (use_ldlt) {
+            // --- LDLT decomposition (faster for symmetric matrices) ---
+            Eigen::LDLT<Eigen::MatrixXf> ldlt(covariance);
+            if (ldlt.info() != Eigen::Success) {
+                throw std::runtime_error("LDLT decomposition failed.");
+            }
+
+            // L = P^T * L_p * D^{1/2}
+             Eigen::MatrixXf Lp = ldlt.matrixL();
+             Eigen::VectorXf D_sqrt = ldlt.vectorD().array().sqrt();
+             Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
+             return  P.transpose() * Lp * D_sqrt.asDiagonal();
+        } else {
+
+        Eigen::JacobiSVD<Eigen::MatrixXf> svd(covariance, Eigen::ComputeThinU | Eigen::ComputeThinV);
+        const auto& U = svd.matrixU();
+        const auto& S = svd.singularValues();
+        int size = covariance.rows();
+        Eigen::VectorXf S_sqrt = S.array().sqrt();
+
+        //float tol = 1e-8f * S.maxCoeff(); // Some cutoff? is this value impactful on out matricies? need to test
+        //std::vector<int> keep;
+        //for (int i = 0; i < S.size(); ++i) {
+        //    if (S(i) > tol) keep.push_back(i);
+        //}
+
+        //if (keep.empty()) {
+        //    log<LOG_ERROR>(L"%1% | All singular values are below tolerance, cannot sample. Blarg.") % __func__;
+        //    exit(EXIT_FAILURE);
+        //}
+        //going to keep only the singular values that give meaningful variance
+        //Eigen::MatrixXf fallback_sampler = Eigen::MatrixXf::Zero(covariance.rows(), covariance.cols());
+        //for (size_t i = 0; i < keep.size(); ++i) {
+        //        fallback_sampler.col(i) = U.col(keep[i]) * std::sqrt(S(keep[i]));
+        //}
+            return U*S_sqrt.asDiagonal();
+        }
+    }
+
 
     std::string getIcon(){
 
@@ -209,8 +253,8 @@ namespace PROfit{
          =@@@@:            =@@@@-     +@@@@+.   -*%@@@@@@@@@@%+:       %@@@=      :@@@@.    =%@@@@@@*         
          :===-.            :====.      -====.     .:-=++++=-:.         -===:      .===-.     .-=++=-:         
     )";                                                                                                                                                                                    
-                                                                                                                                                                                    
-                                                                                                                                                                                    
-               return icon;
+
+
+        return icon;
     };
 };


### PR DESCRIPTION
Built off Jacobs branch for implementing adaptive MCMC in error band construction

- Implemented scale adaption to help get toward 23.4% acceptance
- Implemented both SVD and LDLT sampling for the chain
- Autocorrelation plotting in other/jupyter-notebook. Need to enable command line on/off. currently hard coded in inc/PROplot.h
- Fixed bug in physics parameters physical bounds. Note, currently sin^2thetamm > 1e-5 hard code. 
- Fixed bug for fixed physics parameters and adaptive covariance not decomposing correctly. 