### PR TITLE
Do FC syst only fit at the point we are testing

### DIFF
--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -103,7 +103,8 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                          L"mc spec: %5%\ndata spec: %6%")
             % __func__ % covar_portion % pull % delta % CollapseMatrix(config, result.Spec())
             % data.Spec();
-        abort();
+        //abort();
+        throw std::runtime_error("CNP chi2 is nan.");
     }
 
 

--- a/src/PROfc.cxx
+++ b/src/PROfc.cxx
@@ -15,20 +15,22 @@ void fc_worker(fc_args args) {
     size_t nparams = model->nparams + args.systs.GetNSplines();
     Eigen::VectorXf lb_osc = Eigen::VectorXf::Constant(nparams, -3.0);
     Eigen::VectorXf ub_osc = Eigen::VectorXf::Constant(nparams, 3.0);
-    Eigen::VectorXf lb = Eigen::VectorXf::Constant(args.systs.GetNSplines(), -3.0);
-    Eigen::VectorXf ub = Eigen::VectorXf::Constant(args.systs.GetNSplines(), 3.0);
+    Eigen::VectorXf lb = Eigen::VectorXf::Constant(nparams, -3.0);
+    Eigen::VectorXf ub = Eigen::VectorXf::Constant(nparams, 3.0);
     size_t nphys = model->nparams;
     //set physics to correct values
     for(size_t j=0; j<nphys; j++){
         ub_osc(j) = model->ub(j);
         lb_osc(j) = model->lb(j); 
+        ub(j) = args.phy_params(j);
+        lb(j) = args.phy_params(j); 
     }
     //upper lower bounds for splines
     for(size_t j = nphys; j < nparams; ++j) {
         lb_osc(j) = args.systs.spline_lo[j-nphys];
         ub_osc(j) = args.systs.spline_hi[j-nphys];
-        lb(j-nphys) = args.systs.spline_lo[j-nphys];
-        ub(j-nphys) = args.systs.spline_hi[j-nphys];
+        lb(j) = args.systs.spline_lo[j-nphys];
+        ub(j) = args.systs.spline_hi[j-nphys];
     }
     std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
     Eigen::VectorXf seed_pt = Eigen::VectorXf::Zero(nparams);
@@ -50,16 +52,13 @@ void fc_worker(fc_args args) {
         PROspec newSpec = PROspec::PoissonVariation(PROspec(CollapseMatrix(args.config, shifted.Spec()) + args.L * throwC, CollapseMatrix(args.config, shifted.Error())), dseed(rng));
         PROdata data(newSpec.Spec(), newSpec.Error());
         //Metric Time
-        PROmetric *metric, *null_metric;
+        PROmetric *metric;
         if(args.chi2 == "PROchi") {
             metric = new PROchi("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
-            null_metric = new PROchi("", args.config, args.prop, &args.systs, *null_model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
         } else if(args.chi2 == "PROCNP") {
             metric = new PROCNP("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
-            null_metric = new PROCNP("", args.config, args.prop, &args.systs, *null_model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
         } else if(args.chi2 == "Poisson") {
             metric = new PROpoisson("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
-            null_metric = new PROpoisson("", args.config, args.prop, &args.systs, *null_model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
         } else {
             log<LOG_ERROR>(L"%1% || Unrecognized chi2 function %2%") % __func__ % args.chi2.c_str();
             abort();
@@ -67,7 +66,7 @@ void fc_worker(fc_args args) {
 
         // No oscillations
         PROfitter fitter(ub, lb, args.fitconfig, dseed(rng));
-        float chi2_syst = fitter.Fit(*null_metric);
+        float chi2_syst = fitter.Fit(*metric);
 
         if(fitter.best_fit.size() == (int)(nparams - nphys))
             for(size_t i = nphys; i < nparams; ++i)
@@ -88,7 +87,6 @@ void fc_worker(fc_args args) {
 
         args.dchi2s->push_back(std::abs(chi2_syst - chi2_osc ));
         delete metric;
-        delete null_metric;
     }
 };
 


### PR DESCRIPTION
Run the syst only fit for the FC at the surface point we are making universes at.

Change CNP chi2 to throw an exception on NaN chi2 values. This will cause PROfitter to try another point instead of aborting.