### PR TITLE
Add missing parentheses to delta calculation in PROchi.xx

### DIFF
--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -180,7 +180,7 @@ float PROchi::getSingleChannelChi(size_t global_channel_index, size_t var_index)
         inverted_collapsed_full_covariance = (sub_collapsed_stat_covariance).inverse();
     }
 
-    Eigen::VectorXf delta  = CollapseMatrix(config, cv.Spec()) - (shape_only ? data.Normalize(config,cv) : data.Spec()).segment(startBin, nbin);
+    Eigen::VectorXf delta  = (CollapseMatrix(config, cv.Spec()) - (shape_only ? data.Normalize(config,cv) : data.Spec())).segment(startBin, nbin);
     //float pull = Pull(subvector2);
     float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
     float value = covar_portion;//pull;


### PR DESCRIPTION
Simple fix to wrap parentheses around some matrix algebra in PROchi.cxx.