### PR TITLE
Added a --plot-bounds ymax 12 ratmin 0 ratmax 2, plotting option to override dynamic

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -104,6 +104,8 @@ int main(int argc, char* argv[])
     std::vector<std::string> mockreweights;
     std::vector<TH2D*> weighthists;
 
+    std::map<std::string, float> bound_list;
+    PlotBounds pbounds; 
     size_t nuniv;
 
 
@@ -119,6 +121,7 @@ int main(int argc, char* argv[])
     app.add_option("-d, --data", data_xml, "Load from a seperate data xml/data file instead of signal injection. Only used with plot subcommand.")->default_str("");
     app.add_option("-i, --inject", osc_params, "Physics parameters to inject as true signal. Example: dmsq 3 sinsq2thmm 0.25")->expected(-1);// HOW TO
     app.add_option("-s, --seed", global_seed, "A global seed for PROseed rng. Default to -1 for hardware rng seed.")->default_val(-1);
+    app.add_option("--plot-bounds", bound_list, "Plot bounds, set by  string float pairs. Available strings are ymax,ratmin,ratmax."); 
     app.add_option("--inject-systs", injected_systs, "Systematic shifts to inject. Map of name and shift value in sigmas. Only spline systs are supported right now.");
     app.add_flag("--poisson-throw", poisson_throw, "Do a Poisson stats throw of fake data.");
     app.add_option("--scale", scale_arg, "Scale detector POT by a given value.");
@@ -202,6 +205,7 @@ int main(int argc, char* argv[])
         log_impl::EnableFileLogging(log_file,FILE_LEVEL);
     }
 
+    pbounds.Load(bound_list);
 
     log<LOG_WARNING>(L" %1% ") % getIcon().c_str()  ;
     std::string final_output_tag =analysis_tag +"_"+output_tag;
@@ -707,7 +711,7 @@ int main(int argc, char* argv[])
         PlotOptions opt = PlotOptions::DataPostfitRatio;
         if(binwidth_scale) opt |= PlotOptions::BinWidthScaled;
         if(area_normalized) opt |= PlotOptions::AreaNormalized;
-        plot_channels((final_output_tag+"_PROfile_hists.pdf"), config, cv, bf, data, err_band, post_err_band, texts, opt);
+        plot_channels((final_output_tag+"_PROfile_hists.pdf"), config, cv, bf, data, err_band, post_err_band, texts, pbounds, opt);
 
         TCanvas c;
         c.Print((final_output_tag+"_postfit_posteriors.pdf[").c_str());
@@ -1053,18 +1057,18 @@ int main(int argc, char* argv[])
         std::vector<TPaveText> notext;
         if(binwidth_scale) opt |= PlotOptions::BinWidthScaled;
         if(area_normalized) opt |= PlotOptions::AreaNormalized;
-        std::vector<PROspec> other_cvs;
+        std::vector<PROspec> variable_cvs;
         for(size_t io = 0; io < config.m_num_variables; ++io) {
-            other_cvs.push_back(FillSpectra(config, prop, variable_systs[config.i_prime],*model,CVpparams, !eventbyevent, io));
-            plot_channels(final_output_tag+"_other_"+std::to_string(io)+"_PROplot_CV.pdf", config, other_cvs.back(), {}, {}, {}, {}, notext, opt, io);
+            variable_cvs.push_back(FillSpectra(config, prop, variable_systs[config.i_prime],*model,CVpparams, !eventbyevent, io));
+            plot_channels(final_output_tag+"_other_"+std::to_string(io)+"_PROplot_CV.pdf", config, variable_cvs.back(), {}, {}, {}, {}, notext, pbounds, opt, io);
         }
 
         std::string filename = final_output_tag+"_fractional_systematics.pdf";
-        plotPriorFractionalSystematicBreakdown(config, other_cvs[config.i_prime], allcovsyst, filename,config.i_prime);
+        plotPriorFractionalSystematicBreakdown(config, variable_cvs[config.i_prime], allcovsyst, filename,config.i_prime);
         
         std::vector<std::map<std::string, std::unique_ptr<TH1D>>> other_hists;
         for(size_t io = 0; io < config.m_num_variables; ++io) {
-            other_hists.push_back(getCVHists(other_cvs[io], config, binwidth_scale, io));
+            other_hists.push_back(getCVHists(variable_cvs[io], config, binwidth_scale, io));
         }
 
         TCanvas c;
@@ -1165,7 +1169,7 @@ int main(int argc, char* argv[])
         }
 
         //Now some covariances
-        std::map<std::string, std::unique_ptr<TH2D>> matrices = covarianceTH2D(allcovsyst, config, other_cvs[config.i_prime]);
+        std::map<std::string, std::unique_ptr<TH2D>> matrices = covarianceTH2D(allcovsyst, config, variable_cvs[config.i_prime]);
         c.Print((final_output_tag+"_PROplot_Covar.pdf" + "[").c_str(), "pdf");
         for(const auto &[name, mat]: matrices) {
 
@@ -1200,7 +1204,7 @@ int main(int argc, char* argv[])
                         TPaveText chi2text(0.59, 0.50, 0.89, 0.59, "NDC");
                         if(io==config.i_prime){
                             log<LOG_INFO>(L"%1% || On channel %2%:") % __func__ % global_channel_index ;
-                            double chival = allcov_metric->getSingleChannelChi(global_channel_index, other_cvs[io], io);
+                            double chival = allcov_metric->getSingleChannelChi(global_channel_index, variable_cvs[io], io);
                             int ndf = config.m_channel_variable_bins[ic][io].NBinsAlong(0) - bool(opt&PlotOptions::AreaNormalized);
                             log<LOG_INFO>(L"%1% || -- the datamc chi^2/ndof is %2%/%3% .") % __func__ % chival % ndf;
                             chi2text.AddText(("#chi^{2}/ndf = "+to_string_prec(chival,2)+"/"+std::to_string(ndf)).c_str());
@@ -1222,9 +1226,9 @@ int main(int argc, char* argv[])
         std::vector<PROerrorbar> other_err_bands;
         for(size_t io = 0; io < config.m_num_variables; ++io) {
             if(!config.m_channel_variable_plot_bool.at(io))continue;// For now skip the L/E 250 bin. 
-            other_err_bands.push_back(getErrorBand(config, prop, variable_systs[io], *model, other_cvs[io], CVpparams, binwidth_scale, io));
-            plot_channels(final_output_tag+"_PROplot_other_"+std::to_string(io)+"_ErrorBand.pdf", config, other_cvs[io], {}, variable_data[io], 
-                    other_err_bands.back(), {}, other_channel_chitexts[io], opt | PlotOptions::DataMCRatio, io);
+            other_err_bands.push_back(getErrorBand(config, prop, variable_systs[io], *model, variable_cvs[io], CVpparams, binwidth_scale, io));
+            plot_channels(final_output_tag+"_PROplot_Variable_"+std::to_string(io)+"_ErrorBand.pdf", config, variable_cvs[io], {}, variable_data[io], 
+                    other_err_bands.back(), {}, other_channel_chitexts[io], pbounds, opt | PlotOptions::DataMCRatio, io);
         }
 
 
@@ -1270,7 +1274,7 @@ int main(int argc, char* argv[])
         int io = 0;
         for(const auto &other: other_hists) {
             for(const auto &[name, hist]: other) {
-                hist->Write(("other_"+std::to_string(io)+name).c_str());
+                hist->Write(("Variable_"+std::to_string(io)+name).c_str());
             }
             io++;
         }
@@ -1558,7 +1562,7 @@ int main(int argc, char* argv[])
         PlotOptions opt = PlotOptions::DataPostfitRatio;
         if(binwidth_scale) opt |= PlotOptions::BinWidthScaled;
         if(area_normalized) opt |= PlotOptions::AreaNormalized;
-        plot_channels((final_output_tag+"_PROfile_hists.pdf"), config, cv, bf, data, err_band, post_err_band, texts, opt);
+        plot_channels((final_output_tag+"_PROfile_hists.pdf"), config, cv, bf, data, err_band, post_err_band, texts, pbounds,opt);
 
 
     }

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -35,6 +35,74 @@
 #include "TLine.h"
 namespace PROfit{
 
+    struct PlotBounds {
+        float xmin,xmax = -9999;
+        float ymin,ymax = -9999;
+        float ratmin,ratmax = -9999;
+
+        int Load(std::map<std::string, float> bound_list){
+            log<LOG_INFO>(L"%1% || Loading Bounds for plot_channels ") % __func__;
+            for(const auto &[bound_name, value]: bound_list) {
+                log<LOG_INFO>(L"%1% || --on bound %2% val %3% ") % __func__ % bound_name.c_str() % value;
+                if(bound_name == "xmin") {
+                    xmin=value;
+                }else if(bound_name == "xmax") {
+                    xmax=value;
+                }else if(bound_name == "ymin") {
+                    ymin=value;
+                }else if(bound_name == "ymax") {
+                    ymax=value;
+                }else if(bound_name == "ratmin") {
+                    ratmin=value;
+                }else if(bound_name == "ratmax") {
+                    ratmax=value;
+                }else{
+                    log<LOG_ERROR>(L"%1% || ERROR! you passed a plot-bounds string that is not allowed (%2%). Needs to be xmin,xmax,ymin,ymax,ratmin,ratmax. ") % __func__ % bound_name.c_str();
+                    throw std::invalid_argument(std::string("Invalid plot-bounds ")+bound_name );
+                }
+            }
+        return 1;
+        };
+        bool hasBound(std::string bound_name){
+                if(bound_name == "xmin") {
+                    return xmin!=-9999? true : false;
+                }else if(bound_name == "xmax") {
+                    return xmax!=-9999? true : false;
+                }else if(bound_name == "ymin") {
+                    return ymin!=-9999? true : false;
+                }else if(bound_name == "ymax") {
+                    return ymax!=-9999? true : false;
+                }else if(bound_name == "ratmin") {
+                    return ratmin!=-9999? true : false;
+                }else if(bound_name == "ratmax") {
+                    return ratmax!=-9999? true : false;
+                }else{
+                    log<LOG_ERROR>(L"%1% || ERROR! you passed a plot-bounds string that is not allowed (%2%). Needs to be ymax,ratmin,ratmax. ") % __func__ % bound_name.c_str();
+                    throw std::invalid_argument(std::string("Invalid plot-bounds ")+bound_name );
+                }
+        return false;
+        };
+        float getBound(std::string bound_name){
+                if(bound_name == "xmin") {
+                    return xmin;
+                }else if(bound_name == "xmax") {
+                    return xmax;
+                }else if(bound_name == "ymin") {
+                    return ymin;
+                }else if(bound_name == "ymax") {
+                    return ymax;
+                }else if(bound_name == "ratmin") {
+                    return ratmin;
+                }else if(bound_name == "ratmax") {
+                    return ratmax;
+                }else{
+                    log<LOG_ERROR>(L"%1% || ERROR! you passed a plot-bounds string that is not allowed (%2%). Needs to be ymax,ratmin,ratmax. ") % __func__ % bound_name.c_str();
+                    throw std::invalid_argument(std::string("Invalid plot-bounds ")+bound_name );
+                }
+        return -999;
+        };
+    };
+    
     enum class PlotOptions {
         Default = 0,
         CVasStack = 1 << 0,
@@ -62,7 +130,7 @@ namespace PROfit{
 
 
 
-    void plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotOptions opt = PlotOptions::Default, int var_index = 0);
+    void plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotBounds &bounds, PlotOptions opt = PlotOptions::Default, int var_index = 0);
 
     //some helper functions for PROplot
     std::map<std::string, std::unique_ptr<TH1D>> getCVHists(const PROspec & spec, const PROconfig& inconfig, bool scale = false, int var_index = 0);
@@ -73,7 +141,7 @@ namespace PROfit{
     int plotPriorFractionalSystematicBreakdown(const PROconfig &config, const PROspec &spec, const PROsyst &allsplinesyst, std::string filename, int var_index = 0);
 
     template<class T, class P>
-    PROerrorbar getMCMCErrorBand(Metropolis<T, P> met, size_t burnin, size_t iterations, const PROconfig &config, const PROpeller &prop, PROmetric &metric, const Eigen::VectorXf &best_fit, std::vector<TH1D> &posteriors, Eigen::MatrixXf &post_covar,  bool scale = false,int var_index=0) {
+        PROerrorbar getMCMCErrorBand(Metropolis<T, P> met, size_t burnin, size_t iterations, const PROconfig &config, const PROpeller &prop, PROmetric &metric, const Eigen::VectorXf &best_fit, std::vector<TH1D> &posteriors, Eigen::MatrixXf &post_covar,  bool scale = false,int var_index=0) {
             for(size_t i = 0; i < metric.GetSysts().GetNSplines(); ++i)
                 posteriors.emplace_back("", (";"+config.m_mcgen_variation_plotname_map.at(metric.GetSysts().spline_names[i])).c_str(), 60, -3, 3);
 
@@ -110,42 +178,42 @@ namespace PROfit{
             log<LOG_INFO>(L"%1% || Acceptance rate %2%") % __func__ % ((float)accepted / iterations);
 
             cv = CollapseMatrix(config, cv);
- 
-        std::vector<float> centers;
-        size_t global_channel_index = 0;
-        for(size_t mode = 0; mode < config.m_num_modes; ++mode) {
-            for(size_t det = 0; det < config.m_num_detectors; ++det) {
-                for(size_t channel = 0; channel < config.m_num_channels; ++channel) {
-                    std::vector<float> tedges =  config.GetChannelVariableBins(global_channel_index, var_index).Edges();
-                    global_channel_index++;
-                    for(size_t p=0; p<tedges.size(); p++){
-                        if(p<tedges.size()-1){
-                            centers.push_back((tedges[p+1]+tedges[p])/2.0);
+
+            std::vector<float> centers;
+            size_t global_channel_index = 0;
+            for(size_t mode = 0; mode < config.m_num_modes; ++mode) {
+                for(size_t det = 0; det < config.m_num_detectors; ++det) {
+                    for(size_t channel = 0; channel < config.m_num_channels; ++channel) {
+                        std::vector<float> tedges =  config.GetChannelVariableBins(global_channel_index, var_index).Edges();
+                        global_channel_index++;
+                        for(size_t p=0; p<tedges.size(); p++){
+                            if(p<tedges.size()-1){
+                                centers.push_back((tedges[p+1]+tedges[p])/2.0);
+                            }
                         }
+
                     }
-                    
                 }
             }
-        }
 
-        PROerrorbar ebar(cv.size());
-        for(int i = 0; i < cv.size(); ++i) {
-            std::vector<float> binconts(specs.size());
-            for(size_t j = 0; j < specs.size(); ++j) {
-                binconts[j] = specs[j](i);
+            PROerrorbar ebar(cv.size());
+            for(int i = 0; i < cv.size(); ++i) {
+                std::vector<float> binconts(specs.size());
+                for(size_t j = 0; j < specs.size(); ++j) {
+                    binconts[j] = specs[j](i);
+                }
+                float scale_factor = scale ? 1.0/config.collapsed_bin_widths.at(var_index)(i) :  1.0;
+                if(std::isnan(scale_factor)) scale_factor = 1;
+                std::sort(binconts.begin(), binconts.end());
+                float ehi = std::abs((binconts[int(0.840*specs.size())] - cv(i))*scale_factor);
+                float elo = std::abs((cv(i) - binconts[int(0.160*specs.size())])*scale_factor);
+                ebar.error_up(i) =  ehi;
+                ebar.error_down(i) =  elo;
+                ebar.error_point(i) = cv(i)*scale_factor;
+                log<LOG_DEBUG>(L"%1% || ErrorBand bin %2% %3% %4% %5% %6% ") % __func__ % i % cv(i) % ehi % elo % scale_factor ;
             }
-            float scale_factor = scale ? 1.0/config.collapsed_bin_widths.at(var_index)(i) :  1.0;
-            if(std::isnan(scale_factor)) scale_factor = 1;
-            std::sort(binconts.begin(), binconts.end());
-            float ehi = std::abs((binconts[int(0.840*specs.size())] - cv(i))*scale_factor);
-            float elo = std::abs((cv(i) - binconts[int(0.160*specs.size())])*scale_factor);
-            ebar.error_up(i) =  ehi;
-            ebar.error_down(i) =  elo;
-            ebar.error_point(i) = cv(i)*scale_factor;
-            log<LOG_DEBUG>(L"%1% || ErrorBand bin %2% %3% %4% %5% %6% ") % __func__ % i % cv(i) % ehi % elo % scale_factor ;
+            return ebar;
         }
-        return ebar;
-    }
 
 
 };

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -247,7 +247,7 @@ getSplineGraphs(const PROsyst &systs, const PROconfig &config) {
     }
 
 
-    void plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotOptions opt, int other_index) {
+    void plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotBounds &bounds, PlotOptions opt, int other_index) {
         TCanvas c;
         c.Print((filename+"[").c_str());
 
@@ -457,12 +457,12 @@ getSplineGraphs(const PROsyst &systs, const PROconfig &config) {
 
                     if(cv) {
                         if(bool(opt&PlotOptions::CVasStack)) {
-                            cvstack->SetMaximum(std::max(top_modifier*cvstack->GetMaximum(),top_modifier*data_hist.GetMaximum()));
+                            cvstack->SetMaximum(  bounds.hasBound("ymax") ? bounds.getBound("ymax") : std::max(top_modifier*cvstack->GetMaximum(), top_modifier*data_hist.GetMaximum()));
                             cvstack->Draw("hist");
                             cv_hist.Draw("same hist");
 
                         } else {
-                            cv_hist.SetMaximum(top_modifier*cv_hist.GetMaximum());
+                            cv_hist.SetMaximum( bounds.hasBound("ymax") ? bounds.getBound("ymax") :  top_modifier*cv_hist.GetMaximum());
 
                             cv_hist.Draw("hist");
                             cv_hist.GetYaxis()->SetTitleSize(0.06);  
@@ -506,7 +506,7 @@ getSplineGraphs(const PROsyst &systs, const PROconfig &config) {
 
                         if(cv || best_fit) {
                             g->Draw("PE1 same");
-                            cv_hist.SetMaximum(std::max(cv_hist.GetMaximum(),top_modifier*datmax));
+                            cv_hist.SetMaximum( bounds.hasBound("ymax") ? bounds.getBound("ymax") : std::max(cv_hist.GetMaximum(),top_modifier*datmax));
 
                         } else {
                             g->Draw("PE1");
@@ -582,14 +582,12 @@ getSplineGraphs(const PROsyst &systs, const PROconfig &config) {
                         float yhigh = ymax + 0.05 * yrange; // 15% padding above
 
                         if(!posterrband){
-                            //one->SetMinimum(std::max(0.5f,std::min(ylow,0.85f)));
-                            //one->SetMaximum(std::min(1.5f,std::max(yhigh,1.148f)));
-                            one->SetMinimum(std::min(ylow,0.85f));
-                            one->SetMaximum(std::max(yhigh,1.148f));
+                            one->SetMinimum(  bounds.hasBound("ratmin") ? bounds.getBound("ratmin") : std::min(ylow,0.85f));
+                            one->SetMaximum(  bounds.hasBound("ratmax") ? bounds.getBound("ratmax") : std::max(yhigh,1.148f));
 
                         }else{
-                            one->SetMinimum(std::min(ylow,0.85f));
-                            one->SetMaximum(std::max(yhigh,1.148f));
+                            one->SetMinimum(  bounds.hasBound("ratmin") ? bounds.getBound("ratmin") :std::min(ylow,0.85f));
+                            one->SetMaximum( bounds.hasBound("ratmax") ? bounds.getBound("ratmax") : std::max(yhigh,1.148f));
 
                         }
 


### PR DESCRIPTION
usage `--plot-options <string float.`
E.g
 `--plot-options ymax 1200 ratmin 0 ratmax 2.`
 
 Currently overrules ALL channels/plots. Usable strings are

-  ymax (max for upper data/mc plots)

- ratmin/ratmax (max/min for ratio plot)