### PR TITLE
Fixed undefined behavior when setting spline_bin in covariance mode

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1371,7 +1371,9 @@ int main(int argc, char* argv[])
                     size_t sbi = config.GetSubchannelIndexFromVariableGlobalBin(bin,config.i_prime);
                     std::string nsubchannel = config.GetSubchannelName(sbi);
                     std::string chan_units =   config.m_channel_variable_units[config.i_prime][config.GetLocalChannelIndexFromGlobalSubchannelIndex(sbi)];
-                    std::pair<float,float> edg = config.m_variable_bin_to_edges[config.i_prime][bin];
+                    int edges_vec_sz = (int)config.m_variable_bin_to_edges[config.i_prime].size();
+                    size_t safe_bin = (edges_vec_sz>0) ? std::min((size_t)bin, (size_t)edges_vec_sz-1) : 0;
+                    std::pair<float,float> edg = config.m_variable_bin_to_edges[config.i_prime][safe_bin];
 
                     fixed_pts->SetMarkerColor(col);
                     fixed_pts->SetMarkerStyle(kFullCircle);

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -887,7 +887,7 @@ namespace PROfit {
 
             float additional_weight = syst_additional_weight.at(i);
             auto map_iter = eventweight_map.find(var_syst_objs.front()->GetSysName());
-            int spline_bin =  var_bin_indices[var_syst_objs.front()->binning];
+            int spline_bin = (var_syst_objs.front()->mode == "covariance") ? -1: var_bin_indices[var_syst_objs.front()->binning];
 
             if(var_syst_objs.front()->mode == "spline") {
                 if(spline_bin < 0) continue;


### PR DESCRIPTION
When running in covariance mode, `spline_bin` was being set to `var_bin_indices[-1]`. This is undefined behavior in c++, and was causing a crash on Nevis computers despite working fine on the Fermilab gpvms. This PR makes `spline_bin` set to -1 when in covariance mode, fixing the issue. `spline_bin` is not used when in covariance mode, so this should cause no behavior change besides avoiding this crash in certain environments.