### PR TITLE
split input XML formulas at ";" semicolon instead of "," comma, due t…

### DIFF
--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1806,9 +1806,9 @@ uint32_t PROconfig::CalcHash() const{
 
 ROOTFormula::ROOTFormula(const std::string &name, const std::string &formula, TTree *t) {
     std::stringstream formula_reader(formula);
-    // split the formula at a "," into multiple values
+    // split the formula at a ";" into multiple values. used to be "," but that breaks arguments
     std::string this_formula;
-    while(std::getline(formula_reader, this_formula, ',')) {
+    while(std::getline(formula_reader, this_formula, ';')) {
         fs.push_back(std::make_unique<TTreeFormula>(name.c_str(), this_formula.c_str(), t));
     }
     treeNumber = -1;


### PR DESCRIPTION
…o it causing breaks in things like atan2(A,B)