### PR TITLE
Adding 3+1+decay to invisible particles

### DIFF
--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -108,7 +108,7 @@ public:
             sinsq2thmumu = 0;
         }
 
-        float sinterm = std::sin(1.27f*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = 1.0f - (sinsq2thmumu*sinterm*sinterm);
 
         if(prob<0.0 || prob >1.0 ){;//|| std::isnan(prob)){
@@ -181,7 +181,7 @@ public:
             sinsq2thmue = 0;
         }
 
-        float sinterm = std::sin(1.27f*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = sinsq2thmue*sinterm*sinterm;
 
         if(prob<0.0 || prob >1.0){
@@ -251,7 +251,7 @@ public:
             sinsq2thee = 0;
         }
 
-        float sinterm = std::sin(1.27f*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = 1.0f - (sinsq2thee*sinterm*sinterm);
 
         if(prob<0.0 || prob >1.0 ){;//|| std::isnan(prob)){
@@ -344,7 +344,7 @@ public:
             Um4sq = 0;
         }
 
-        float sinterm = std::sin(1.27f*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = 4.0f*Ue4sq*Um4sq*sinterm*sinterm;
 
         if(prob<0.0 || prob >1.0){
@@ -373,7 +373,7 @@ public:
             Um4sq = 0;
         }
 
-        float sinterm = std::sin(1.27*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = 1.0f - 4.0f*Um4sq*(1.0f-Um4sq)*sinterm*sinterm;
 
         if(prob<0.0 || prob >1.0){
@@ -400,7 +400,7 @@ public:
             Ue4sq = 0;
         }
 
-        float sinterm = std::sin(1.27*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = 1.0f - 4.0f*Ue4sq*(1.0f-Ue4sq)*sinterm*sinterm;
 
         if(prob<0.0 || prob >1.0){
@@ -432,7 +432,7 @@ public:
         model_constraint = [this](const Eigen::VectorXf &v){return this->UnitarityConstraint(v);};
 
 
-         size_t nvar = prop.variable_mc_stat_err.size();
+        size_t nvar = prop.variable_mc_stat_err.size();
         hists.resize(nvar);
         for(size_t v = 0; v <nvar ;v++){
             for(size_t m = 0; m < model_functions.size(); ++m) {
@@ -479,7 +479,7 @@ public:
             sinsq2thmue = 0;
         }
 
-        float sinterm = std::sin(1.27f*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = sinsq2thmue*sinterm*sinterm;
 
         if(prob<0.0 || prob >1.0){
@@ -499,7 +499,7 @@ public:
 
         float Um4sq=(std::exp(xi) * std::sqrt(sinsq2thmue)) / 2.0;
 
-        float sinterm = std::sin(1.27*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = 1.0f - 4.0f*Um4sq*(1.0f-Um4sq)*sinterm*sinterm;
 
         if(prob<0.0 || prob >1.0){
@@ -517,7 +517,7 @@ public:
 
         float Ue4sq=(std::exp(-xi) * std::sqrt(sinsq2thmue)) / 2.0;
 
-        float sinterm = std::sin(1.27*dmsq*(le));
+        float sinterm = std::sin(1.266932679f*dmsq*(le));
         float prob    = 1.0f - 4.0f*Ue4sq*(1.0f-Ue4sq)*sinterm*sinterm;
 
         if(prob<0.0 || prob >1.0){
@@ -529,6 +529,186 @@ public:
         return prob;
     }
 };
+
+
+class PRO3p1_decay_invis : public PROmodel {
+public:
+    PRO3p1_decay_invis(const PROpeller &prop, const std::map<std::string,int> &parameter_map) {
+        // 3+1+decay to invisible particles, example from IceCube: https://arxiv.org/pdf/2204.00612
+        // (invisible means no active or sterile-oscillating-to-active neutrinos after the decay)
+
+        model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0; });
+        model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),v(2),v(3),le); });
+        model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmue(v(0),v(1),v(2),v(3),le); });
+        model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pee(v(0),v(1),v(2),v(3),le); });
+        if(parameter_map.find("L/E") == parameter_map.end()) {
+            log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'. Make sure its in your model section of XML.") % __func__ % __LINE__;
+            throw std::runtime_error("Missing parameter: L/E");
+        }
+        ivar = parameter_map.at("L/E");
+
+        model_constraint = [this](const Eigen::VectorXf &v){return this->UnitarityConstraint(v);};
+
+        size_t nvar = prop.variable_mc_stat_err.size();
+        hists.resize(nvar);
+        for(size_t v = 0; v <nvar ;v++){
+            for(size_t m = 0; m < model_functions.size(); ++m) {
+                hists.at(v).emplace_back(Eigen::MatrixXf::Constant(prop.variable_hist_storage(ivar,v).rows(), prop.variable_hist_storage(ivar,v).cols(),0.0));
+                Eigen::MatrixXf &h = hists.at(v).back();
+                for(size_t i = 0; i < prop.NEvent(); ++i) {
+                    if(prop.model_rule[i] != (int)m) continue;
+                    int tbin = prop.VariableBinIndex(ivar, i), rbin = prop.VariableBinIndex(v, i);
+                    if(tbin<0 || rbin<0)continue;
+                    h(tbin, rbin) += prop.added_weights[i];
+                }
+            }
+        }
+
+        nparams = 4;
+        param_names = {"dmsq", "Ue4^2", "Um4^2", "g2"}; 
+        pretty_param_names = {"#Deltam^{2}", "|U_{e4}|^{2}", "|U_{#mu4}|^{2}", "g^{2}"}; 
+        pretty_param_units = {"eV^{2}", "", "", ""}; 
+        lb = Eigen::VectorXf(4);
+        ub = Eigen::VectorXf(4);
+        default_val = Eigen::VectorXf(4);
+        lb << -2, -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity();
+        ub << 2, -1e-4, -1e-4, 1;
+        default_val << -2, -8, -8, -8;
+    };
+
+    int UnitarityConstraint(const Eigen::VectorXf &v){
+        return   (pow(10,v(1))+pow(10,v(2))<1 ? 1 : 0);      
+    }
+
+    // Equations from Jesse Mendez, slide 5 bottom https://microboone-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=45475&filename=2025-10-31-mendez-sterile-deacy.pdf&version=1
+    //
+    // Derivation from references:
+    // See equation 10 here, written in terms of L_osc and L_dec: https://journals.aps.org/prd/pdf/10.1103/PhysRevD.110.075002
+    //     This is the only term in equation 9 if we set the visible decay term to zero (P_dec == 0)
+    // Using Delta = 1/4 1/(hbar c) * (m / 1 eV)^2 * ((L / 1 km) / (E / 1 GeV)) = 1/4 m^2 L/E (natural units) = 1.266932679 m^2 L / E (km and GeV units)
+    // L_osc = 2 pi E / m^2 (just after equation 10)
+    // Simplifying this term: pi L / L_osc = pi L / (2 pi E / m^2) = 1/2 m^2 L/E = 2 Delta
+    // From equation 1 of https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.129.151801: tau = 16 pi / (g^2 m)
+    // L_dec = (relativistic gamma factor) * c * tau = E/m * tau = E/m * 16 pi / (g^2 m) = 16 pi E / (g^2 m^2)
+    // Simplifying this term: L / (2 L_dec) = g^2 m^2 L / (32 pi E) = g^2 / 8 pi * (1/4 m^2 L/E) = g^2 / 8 pi * Delta
+    // Final formula: P_ab = delta_ab - 2 delta_ab |U_a4 U_b4| [1 - exp(-g^2 / 8 pi * Delta) cos(2 Delta)]
+    //                       + |U_a4 U_b4|^2 [1 - 2 exp(-g^2 / 8 pi * Delta) cos(2 Delta) + exp(-g^2 / 4 pi * Delta)]
+    //
+    // Another reference for 3+1+invisible decay: Equation 15 of https://journals.aps.org/prd/pdf/10.1103/PhysRevD.97.055017
+    //     P_aa = cos^4(theta) + 1/2 exp_term cos(2 Delta) sin^2(2 theta) + exp_term^2 sin^4(theta)
+    //          = (1 - sin^2(theta))^2 + 1/2 exp_term cos(2 Delta) (4 cos^2(theta) sin^2(theta)) + exp_term^2 sin^4(theta)
+    //          = (1 - 2 sin^2(theta) + sin^4(theta)) + 1/2 exp_term cos(2 Delta) (4 sin^2(theta) - 4 sin^4(theta)) + exp_term^2 sin^4(theta)
+    //          = 1 - 2 sin^2(theta) + sin^4(theta) + 2 exp_term cos(2 Delta) sin^2(theta) - 2 exp_term cos(2 Delta) sin^4(theta) + exp_term^2 sin^4(theta)
+    //          = 1 - 2 sin^2(theta) [1 - exp_term cos(2 Delta)] + sin^4(theta) [1 - 2 exp_term cos(2 Delta) + exp_term^2]
+    // Taking our full equation, looking at just the disappearance case, and substituting |U_a4|^2 = sin^2(theta):
+    //     P_aa = 1 - 2 |U_a4|^2 [1 - exp_term cos(2 Delta)] + |U_a4|^4 [1 - 2 exp_term cos(2 Delta) + exp_term^2]
+    //          = 1 - 2 sin^2(theta) [1 - exp_term cos(2 Delta)] + sin^4(theta) [1 - 2 exp_term cos(2 Delta) + exp_term^2]
+    // This exactly matches the equation above, confirming that the references are consistent.
+
+    float Pmue(float dmsq, float Ue4sq, float Um4sq, float g2, float le) const{
+        dmsq = std::pow(10.0f, dmsq);
+        Ue4sq = std::pow(10.0f, Ue4sq);
+        Um4sq = std::pow(10.0f, Um4sq);
+        g2 = std::pow(10.0f, g2);
+
+        if (Ue4sq > 1 || Ue4sq < 0 || Um4sq > 1 || Um4sq < 0 || g2 < 0) {
+            log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Ue4sq=%2%, Um4sq=%3%, g2=%4%, dmsq=%5%, le=%6%")
+                % __func__ % Ue4sq % Um4sq % g2 % dmsq % le;
+            if (Ue4sq > 1) Ue4sq = 1;
+            if (Ue4sq < 0) Ue4sq = 0;
+            if (Um4sq > 1) Um4sq = 1;
+            if (Um4sq < 0) Um4sq = 0;
+            if (g2 < 0) g2 = 0;
+        }
+
+        float delta = 1.266932679f*dmsq*le;
+        float costerm = std::cos(2.0f*delta);
+        float expterm = std::exp(-g2*delta/(8.0f*3.14159f));
+        float prob    = Ue4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+
+        // numerical precision issues can cause small negative probabilities
+        if(-1e-6f < prob && prob<0.0f){
+            prob = 0.0f;
+        }
+
+        if(prob<0.0 || prob >1.0 || std::isnan(prob)){
+            log<LOG_ERROR>(L"%1% || Your probability %2% is outside the 0-1 range. dmsq = %3%, Ue4sq = %4%, Um4sq = %5%, g2 = %6%, L/E = %7%") % __func__ % prob % dmsq % Ue4sq % Um4sq % g2 % le;
+            log<LOG_ERROR>(L"delta = %1%, costerm = %2%, expterm = %3%") % delta % costerm % expterm;
+            log<LOG_ERROR>(L"%1% || Terminating.") % __func__;
+            exit(EXIT_FAILURE);
+        }
+
+        return prob;
+    }
+
+    float Pmumu(float dmsq, [[maybe_unused]]float Ue4sq, float Um4sq, float g2, float le) const{
+        dmsq = std::pow(10.0f, dmsq);
+        Um4sq = std::pow(10.0f, Um4sq);
+        g2 = std::pow(10.0f, g2);
+
+        if (Um4sq > 1 || Um4sq < 0 || g2 < 0) {
+            log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Ue4sq=%2%, Um4sq=%3%, g2=%4%, dmsq=%5%, le=%6%")
+                % __func__ % Ue4sq % Um4sq % g2 % dmsq % le;
+            if (Um4sq > 1) Um4sq = 1;
+            if (Um4sq < 0) Um4sq = 0;
+            if (g2 < 0) g2 = 0;
+        }
+
+        float delta = 1.266932679f*dmsq*le;
+        float costerm = std::cos(2.0f*delta);
+        float expterm = std::exp(-g2*delta/(8.0f*3.14159f));
+        float prob    = 1.0f - 2.0f*Um4sq*(1.0f-expterm*costerm) + Um4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+
+        // numerical precision issues can cause small negative probabilities
+        if(-1e-6f < prob && prob<0.0f){
+            prob = 0.0f;
+        }
+
+        if(prob<0.0 || prob >1.0 || std::isnan(prob)){
+            log<LOG_ERROR>(L"%1% || Your probability %2% is the 0-1 range. dmsq = %3%, Um4sq = %4%, g2 = %5%, L/E = %6%") % __func__ % prob % dmsq % Um4sq % g2 % le;
+            log<LOG_ERROR>(L"delta = %1%, costerm = %2%, expterm = %3%") % delta % costerm % expterm;
+            log<LOG_ERROR>(L"%1% || Terminating.") % __func__;
+            exit(EXIT_FAILURE);
+        }
+
+        return prob;
+    }
+
+    float Pee(float dmsq, float Ue4sq, [[maybe_unused]]float Um4sq, float g2, float le) const{
+        dmsq = std::pow(10.0f, dmsq);
+        Ue4sq = std::pow(10.0f, Ue4sq);
+        g2 = std::pow(10.0f, g2);
+
+        if (Ue4sq > 1 || Ue4sq < 0 || g2 < 0) {
+            log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Ue4sq=%2%, Um4sq=%3%, g2=%4%, dmsq=%5%, le=%6%")
+                % __func__ % Ue4sq % Um4sq % g2 % dmsq % le;
+            if (Ue4sq > 1) Ue4sq = 1;
+            if (Ue4sq < 0) Ue4sq = 0;
+            if (g2 < 0) g2 = 0;
+        }
+
+        float delta = 1.266932679f*dmsq*le;
+        float costerm = std::cos(2.0f*delta);
+        float expterm = std::exp(-g2*delta/(8.0f*3.14159f));
+        float prob    = 1.0f - 2.0f*Ue4sq*(1.0f-expterm*costerm) + Ue4sq*Ue4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+
+        // numerical precision issues can cause small negative probabilities
+        if(-1e-6f < prob && prob<0.0f){
+            prob = 0.0f;
+        }
+
+        if(prob<0.0 || prob >1.0 || std::isnan(prob)){
+            log<LOG_ERROR>(L"%1% || Your probability %2% is outside the 0-1 range. dmsq = %3%, Ue4sq = %4%, g2 = %5%, L/E = %6%") % __func__ % prob % dmsq % Ue4sq % g2 % le;
+            log<LOG_ERROR>(L"delta = %1%, costerm = %2%, expterm = %3%") % delta % costerm % expterm;
+            log<LOG_ERROR>(L"term1 = %1%, term2 = %2%, term3 = %3%") % 1.0f % (-2.0f*Ue4sq*(1.0f-expterm*costerm)) % (Ue4sq*Ue4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm));
+            log<LOG_ERROR>(L"%1% || Terminating.") % __func__;
+            exit(EXIT_FAILURE);
+        }
+
+        return prob;
+    }
+};
+
 
 
 // Main interface to different models
@@ -546,6 +726,8 @@ std::unique_ptr<PROmodel> get_model_from_string(const PROconfig& config, const P
         return std::unique_ptr<PROmodel>(new PRO3p1(prop,config.m_model_parameter_map));
     } else if(name == "3+1_3C") {
         return std::unique_ptr<PROmodel>(new PRO3p1_3C(prop,config.m_model_parameter_map));
+    } else if(name == "3+1_decay") {
+        return std::unique_ptr<PROmodel>(new PRO3p1_decay_invis(prop,config.m_model_parameter_map));
     }
     log<LOG_ERROR>(L"%1% || Unrecognized model name %2%. Try numudis, nueapp, nuedis, 3+1 or 3+1_3C for now. Terminating.") % __func__ % name.c_str();
     exit(EXIT_FAILURE);

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -726,7 +726,7 @@ std::unique_ptr<PROmodel> get_model_from_string(const PROconfig& config, const P
         return std::unique_ptr<PROmodel>(new PRO3p1(prop,config.m_model_parameter_map));
     } else if(name == "3+1_3C") {
         return std::unique_ptr<PROmodel>(new PRO3p1_3C(prop,config.m_model_parameter_map));
-    } else if(name == "3+1_decay") {
+    } else if(name == "3+1_decay_invis") {
         return std::unique_ptr<PROmodel>(new PRO3p1_decay_invis(prop,config.m_model_parameter_map));
     }
     log<LOG_ERROR>(L"%1% || Unrecognized model name %2%. Try numudis, nueapp, nuedis, 3+1 or 3+1_3C for now. Terminating.") % __func__ % name.c_str();


### PR DESCRIPTION
Added the 3+1+decay to invisible particles model. This model assumes that when a sterile neutrino decays, the decay products do not contain any active neutrinos or sterile neutrinos that could oscillate to active neutrinos. 

This does not include 3+1+decay to visible particles, where there is another neutrino in the final state after the neutrino decays; that model has neutrinos smear to lower energies, and is therefore not a function of L/E, and would be somewhat more complicated to implement.

This 3+1+decay to invisibles model has been studied by [IceCube](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.129.151801), and uses equations described in https://journals.aps.org/prd/pdf/10.1103/PhysRevD.110.075002 (equation 10) and https://journals.aps.org/prd/pdf/10.1103/PhysRevD.97.055017 (equation 15). The equivalence between these equations is described in comments in PROmodel.h.

I also substituted a more precise value for oscillation frequency, 1.27 -> [1.266932679](https://www.wolframalpha.com/input?i=1%2F4+*+1+%2F+%286.582119569e-16+eV*s+*+299792458+m%2Fs%29+*+1+eV%5E2+*+%281+km+%2F+1+GeV%29)