### PR TITLE
Adding model constraint checks in the gradient calculations

### DIFF
--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -149,6 +149,15 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 Eigen::VectorXf param_plus = param;
                 param_plus(i) = param(i) + sign*h;
 
+                // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                if(model.model_constraint){
+                    if(!model.model_constraint(param_plus)){
+                        log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                        gradient(i) = sign * 1e10;
+                        continue;
+                    }
+                }
+
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
                 PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
@@ -189,8 +198,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 // Calculate chi2 at both points
                 float chi2_plus, chi2_minus;
 
-                // Plus point
-                {
+                // plus point
+                if(model.model_constraint && !model.model_constraint(param_plus)){
+                    // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                    chi2_plus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
@@ -213,8 +226,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     chi2_plus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
                 }
 
-                // Minus point
-                {
+                // minus point
+                if(model.model_constraint && !model.model_constraint(param_minus)){
+                    // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                    chi2_minus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
@@ -382,6 +399,16 @@ void PROCNP::print(const Eigen::VectorXf &param){
         //log<LOG_DEBUG>(L"%1% || Created physics subvector with size %2%") % __func__ % subvector1.size();
         Eigen::VectorXf subvector2 = tmpParams.segment(model.nparams, syst->GetNSplines());
         //log<LOG_DEBUG>(L"%1% || Created spline subvector with size %2%") % __func__ % subvector2.size();
+
+        // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+        if(model.model_constraint){
+            if(!model.model_constraint(subvector1)){
+                //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                gradient(i) = sgn * 1e10;
+                continue;
+            }
+        }
+
         PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, strat != EventByEvent);
         // Calcuate Full Covariance matrix
         Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -145,6 +145,15 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 Eigen::VectorXf param_plus = param;
                 param_plus(i) = param(i) + sign*h;
 
+                // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                if(model.model_constraint){
+                    if(!model.model_constraint(param_plus.segment(0, model.nparams))){
+                        //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                        gradient(i) = sign * 1e10;
+                        continue;
+                    }
+                }
+
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
                 PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
@@ -177,7 +186,10 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 float chi2_plus, chi2_minus;
 
                 // Plus point
-                {
+                if(model.model_constraint && !model.model_constraint(param_plus.segment(0, model.nparams))){
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (plus) violates unitarity. Setting chi2_plus to large value.") % __func__;
+                    chi2_plus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
                     Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
@@ -192,10 +204,13 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 }
 
                 // Minus point
-                {
+                if(model.model_constraint && !model.model_constraint(param_minus.segment(0, model.nparams))){
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (minus) violates unitarity. Setting chi2_minus to large value.") % __func__;
+                    chi2_minus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
 
-
+                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
                     Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (collapsed_stat_covariance + collapsed_full_covariance).inverse();

--- a/src/PROpoisson.cxx
+++ b/src/PROpoisson.cxx
@@ -102,6 +102,16 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
             
             Eigen::VectorXf subvector1 = tmpParams.segment(0, nparams - nsyst);
             Eigen::VectorXf subvector2 = tmpParams.segment(nparams - nsyst, nsyst);
+
+            // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+            if(model.model_constraint){
+                if(!model.model_constraint(subvector1)){
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROpoisson: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                    gradient(i) = sgn * 1e10;
+                    continue;
+                }
+            }
+            
             PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, strat != EventByEvent);
 
             const Eigen::VectorXf vdata = shape_only 


### PR DESCRIPTION
If a gradient computed point is fails model_constraint (often a unitarity check), then we do not try to calculate probabilities on this unphysical point and instead manually set the gradient to a high value (or high negative value if it was computing the gradient with a negative step).

Also, this fixes a bug in the PROchi.cxx minus point gradient calculation, now updating diag from the result at the new point.