### PR TITLE
Cleaning up log and non-log variables

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1232,7 +1232,6 @@ int main(int argc, char* argv[])
                         leg->AddEntry(cv_hist, "No Oscillations", "l");
                         std::string oscstr = "";//"#splitline{Oscilations:}{";
                         for(size_t j=0;j<model->nparams;j++){
-                            // TODO: change_log_here
                             float val_maybe_log = model->is_log10[j] ? std::pow(10.0f, fake_data_osc_param_vector(j)) : fake_data_osc_param_vector(j);
                             oscstr+=model->pretty_param_names[j]+ " : "+ to_string_prec(val_maybe_log,3) +" "+model->pretty_param_units[j] + (j==0 ? ", " : "" );
                         }

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -329,7 +329,8 @@ int main(int argc, char* argv[])
             return 1;
         }
         int loc = std::distance(model->param_names.begin(), it);
-        fake_data_osc_param_vector(loc) = std::log10(value);
+        fake_data_osc_param_vector(loc) = model->is_log10[loc] ? std::log10(value) : value;
+        log<LOG_INFO>(L"%1% Set fake data injected parameter %2% to value %3%, internally %4%") % __func__ % name.c_str() % value % fake_data_osc_param_vector(loc);
     }
 
     Eigen::VectorXf cv_osc_param_vector = model->default_val;
@@ -343,7 +344,8 @@ int main(int argc, char* argv[])
             return 1;
         }
         int loc = std::distance(model->param_names.begin(), it);
-        cv_osc_param_vector(loc) = std::log10(value);
+        cv_osc_param_vector(loc) = model->is_log10[loc] ? std::log10(value) : value;
+        log<LOG_INFO>(L"%1% Set CV injected parameter %2% to value %3%, internally %4%") % __func__ % name.c_str() % value % fake_data_osc_param_vector(loc);
     }
 
 
@@ -968,10 +970,12 @@ int main(int argc, char* argv[])
         }
 
         std::vector<float> binedges_x, binedges_y;
+        // Edges are stored in model's native space (log if is_log10, linear otherwise)
+        // Convert to linear for ROOT histogram bin edges
         for(size_t i = 0; i < surface.nbinsx+1; i++)
-            binedges_x.push_back(logx ? std::pow(10, surface.edges_x(i)) : surface.edges_x(i));
+            binedges_x.push_back(model->is_log10[xaxis_idx] ? std::pow(10, surface.edges_x(i)) : surface.edges_x(i));
         for(size_t i = 0; i < surface.nbinsy+1; i++)
-            binedges_y.push_back(logy ? std::pow(10, surface.edges_y(i)) : surface.edges_y(i));
+            binedges_y.push_back(model->is_log10[yaxis_idx] ? std::pow(10, surface.edges_y(i)) : surface.edges_y(i));
 
         if(xlabel == "") 
             xlabel = xaxis_idx < model->nparams ? model->pretty_param_names[xaxis_idx] : 
@@ -1228,7 +1232,9 @@ int main(int argc, char* argv[])
                         leg->AddEntry(cv_hist, "No Oscillations", "l");
                         std::string oscstr = "";//"#splitline{Oscilations:}{";
                         for(size_t j=0;j<model->nparams;j++){
-                            oscstr+=model->pretty_param_names[j]+ " : "+ to_string_prec(pow(10,fake_data_osc_param_vector(j)),3) +" "+model->pretty_param_units[j] + (j==0 ? ", " : "" );
+                            // TODO: change_log_here
+                            float val_maybe_log = model->is_log10[j] ? std::pow(10.0f, fake_data_osc_param_vector(j)) : fake_data_osc_param_vector(j);
+                            oscstr+=model->pretty_param_names[j]+ " : "+ to_string_prec(val_maybe_log,3) +" "+model->pretty_param_units[j] + (j==0 ? ", " : "" );
                         }
                         //oscstr+="}";
 

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace PROfit {
 
@@ -28,6 +29,28 @@ public:
     std::function<int(const Eigen::VectorXf&)> model_constraint;
     std::vector<std::vector<Eigen::MatrixXf>> hists; //2D hists for binned oscilattion, one for each model function, and the N-variables 
                                         //Todo: make this a vector of length n_variables, and fill them all. For now 1 is "special". 
+
+    std::vector<bool> is_log10; // Track whether each physics parameter is stored in log10 space.
+    // Fast lookup from parameter name to index
+    std::unordered_map<std::string, size_t> param_name_to_index;
+    inline void build_param_index() {
+        param_name_to_index.clear();
+        for(size_t i = 0; i < param_names.size(); ++i){
+            param_name_to_index[param_names[i]] = i;
+        }
+    }
+
+    // Convert a parameter to linear space if it is stored as log10, using its name.
+    inline float maybe_convert_log(const std::string &param_name, float value) const {
+        auto it = param_name_to_index.find(param_name);
+        if(it == param_name_to_index.end()){
+            log<LOG_ERROR>(L"%1% || Parameter name '%2%' not found in this model. Terminating.") % __func__ % param_name.c_str();
+            exit(EXIT_FAILURE);
+        }
+        size_t idx = it->second;
+        return is_log10[idx] ? std::pow(10.0f, value) : value;
+    }
+
 };
 
 class NullModel : public PROmodel {
@@ -50,6 +73,7 @@ public:
                 }
             }
         }
+        is_log10.clear();
     }
 };
 
@@ -84,6 +108,8 @@ public:
         param_names = {"dmsq", "sinsq2thmm"}; 
         pretty_param_names = {"#Deltam^{2}", "sin^{2}2#theta_{#mu#mu}"}; 
         pretty_param_units = {"eV^{2}", ""}; 
+        is_log10 = {true, true};
+        build_param_index();
         lb = Eigen::VectorXf(2);
         ub = Eigen::VectorXf(2);
         default_val = Eigen::VectorXf(2);
@@ -95,8 +121,8 @@ public:
 
     /* Function: 3+1 numu->numue disapperance prob in SBL approx */
     float Pmumu(float dmsq, float sinsq2thmumu, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        sinsq2thmumu = std::pow(10.0f, sinsq2thmumu);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        sinsq2thmumu = maybe_convert_log("sinsq2thmm", sinsq2thmumu);
 
         if(sinsq2thmumu > 1) {
             //log<LOG_ERROR>(L"%1% || sinsq2thmumu is %2% which is greater than 1. Setting to 1.")     % __func__ % sinsq2thmumu;
@@ -152,6 +178,8 @@ public:
         param_names = {"dmsq", "sinsq2thme"}; 
         pretty_param_names = {"#Deltam^{2}", "sin^{2}2#theta_{#mue}"}; 
         pretty_param_units = {"eV^{2}", ""}; 
+        is_log10 = {true, true};
+        build_param_index();
         lb = Eigen::VectorXf(2);
         ub = Eigen::VectorXf(2);
         default_val = Eigen::VectorXf(2);
@@ -168,8 +196,8 @@ public:
     };
 
     float Pmue(float dmsq, float sinsq2thmue, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        sinsq2thmue = std::pow(10.0f, sinsq2thmue);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        sinsq2thmue = maybe_convert_log("sinsq2thme", sinsq2thmue);
 
         if(sinsq2thmue > 1) {
             //log<LOG_ERROR>(L"%1% || sinsq2thmue is %2% which is greater than 1. Setting to 1.")  % __func__ % sinsq2thmue;
@@ -227,6 +255,8 @@ public:
         param_names = {"dmsq", "sinsq2thee"}; 
         pretty_param_names = {"#Deltam^{2}", "sin^{2}2#theta_{ee}"}; 
         pretty_param_units = {"eV^{2}", ""}; 
+        is_log10 = {true, true};
+        build_param_index();
         lb = Eigen::VectorXf(2);
         ub = Eigen::VectorXf(2);
         default_val = Eigen::VectorXf(2);
@@ -238,8 +268,8 @@ public:
 
     /* Function: 3+1 nue->nue disapperance prob in SBL approx */
     float Pee(float dmsq, float sinsq2thee, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        sinsq2thee = std::pow(10.0f, sinsq2thee);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        sinsq2thee = maybe_convert_log("sinsq2thee", sinsq2thee);
 
         if(sinsq2thee > 1) {
             //log<LOG_ERROR>(L"%1% || sinsq2thee is %2% which is greater than 1. Setting to 1.")     % __func__ % sinsq2thee;
@@ -285,7 +315,7 @@ public:
         model_constraint = [this](const Eigen::VectorXf &v){return this->UnitarityConstraint(v);};
 
 
-         size_t nvar = prop.variable_mc_stat_err.size();
+        size_t nvar = prop.variable_mc_stat_err.size();
         hists.resize(nvar);
         for(size_t v = 0; v <nvar ;v++){
             for(size_t m = 0; m < model_functions.size(); ++m) {
@@ -305,6 +335,8 @@ public:
         param_names = {"dmsq", "Ue4^2", "Um4^2"}; 
         pretty_param_names = {"#Deltam^{2}", "|U_{e4}|^{2}", "|U_{#mu4}|^{2}"}; 
         pretty_param_units = {"eV^{2}", "",""}; 
+        is_log10 = {true, true, true};
+        build_param_index();
         lb = Eigen::VectorXf(3);
         ub = Eigen::VectorXf(3);
         default_val = Eigen::VectorXf(3);
@@ -315,13 +347,15 @@ public:
     };
 
     int UnitarityConstraint(const Eigen::VectorXf &v){
-        return   (pow(10,v(1))+pow(10,v(2))<1 ? 1 : 0);      
+        const float Ue4sq = maybe_convert_log("Ue4^2", v(param_name_to_index.at("Ue4^2")));
+        const float Um4sq = maybe_convert_log("Um4^2", v(param_name_to_index.at("Um4^2")));
+        return   ((Ue4sq+Um4sq)<1 ? 1 : 0);      
     }
 
     float Pmue(float dmsq, float Ue4sq, float Um4sq, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        Ue4sq = std::pow(10.0f, Ue4sq);
-        Um4sq = std::pow(10.0f, Um4sq);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        Ue4sq = maybe_convert_log("Ue4^2", Ue4sq);
+        Um4sq = maybe_convert_log("Um4^2", Um4sq);
 
         if(Ue4sq > 1) {
             log<LOG_ERROR>(L"%1% || Ue4sq is %2% which is greater than 1. Setting to 1.") 
@@ -359,8 +393,8 @@ public:
     }
 
     float Pmumu(float dmsq, [[maybe_unused]]float Ue4sq, float Um4sq, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        Um4sq = std::pow(10.0f, Um4sq);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        Um4sq = maybe_convert_log("Um4^2", Um4sq);
 
         if(Um4sq > 1) {
             log<LOG_ERROR>(L"%1% || Um4sq is %2% which is greater than 1. Setting to 1.")
@@ -386,8 +420,8 @@ public:
     }
 
     float Pee(float dmsq, float Ue4sq, [[maybe_unused]]float Um4sq, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        Ue4sq = std::pow(10.0f, Ue4sq);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        Ue4sq = maybe_convert_log("Ue4^2", Ue4sq);
 
         if(Ue4sq > 1) {
             log<LOG_ERROR>(L"%1% || Ue4sq is %2% which is greater than 1. Setting to 1.")
@@ -451,6 +485,9 @@ public:
         nparams = 3;
         param_names = {"dmsq", "sinsq2thmue", "xi"}; 
         pretty_param_names = {"#Deltam^{2}", "sin^{2}2#theta_{#mue}", "#xi"}; 
+        pretty_param_units = {"eV^{2}", "", ""};
+        is_log10 = {true, true, true};
+        build_param_index();
         lb = Eigen::VectorXf(3);
         ub = Eigen::VectorXf(3);
         default_val = Eigen::VectorXf(3);
@@ -461,12 +498,14 @@ public:
     };
 
     int UnitarityConstraint(const Eigen::VectorXf &v){
-        return   (sqrt(pow(10,v(1)))*cosh(v(2))<0.999 ? 1 : 0);      
+        const float sinsq2thmue = maybe_convert_log("sinsq2thmue", v(param_name_to_index.at("sinsq2thmue")));
+        const float xi = maybe_convert_log("xi", v(param_name_to_index.at("xi")));
+        return   (std::sqrt(sinsq2thmue)*std::cosh(xi)<0.999 ? 1 : 0);      
     }
 
     float Pmue(float dmsq, float sinsq2thmue, [[maybe_unused]]float xi, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        sinsq2thmue = std::pow(10.0f, sinsq2thmue);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        sinsq2thmue = maybe_convert_log("sinsq2thmue", sinsq2thmue);
         
         if(sinsq2thmue > 1) {
             log<LOG_ERROR>(L"%1% || sinsq2thmue is %2% which is greater than 1. Setting to 1.")
@@ -494,8 +533,8 @@ public:
     }
 
     float Pmumu(float dmsq, float sinsq2thmue, float xi, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        sinsq2thmue = std::pow(10.0f, sinsq2thmue);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        sinsq2thmue = maybe_convert_log("sinsq2thmue", sinsq2thmue);
 
         float Um4sq=(std::exp(xi) * std::sqrt(sinsq2thmue)) / 2.0;
 
@@ -512,8 +551,8 @@ public:
     }
 
     float Pee(float dmsq, float sinsq2thmue, float xi, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        sinsq2thmue = std::pow(10.0f, sinsq2thmue);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        sinsq2thmue = maybe_convert_log("sinsq2thmue", sinsq2thmue);
 
         float Ue4sq=(std::exp(-xi) * std::sqrt(sinsq2thmue)) / 2.0;
 
@@ -568,16 +607,22 @@ public:
         param_names = {"dmsq", "Ue4^2", "Um4^2", "g2"}; 
         pretty_param_names = {"#Deltam^{2}", "|U_{e4}|^{2}", "|U_{#mu4}|^{2}", "g^{2}"}; 
         pretty_param_units = {"eV^{2}", "", "", ""}; 
+        is_log10 = {true, true, true, false};
+        build_param_index();
         lb = Eigen::VectorXf(4);
         ub = Eigen::VectorXf(4);
         default_val = Eigen::VectorXf(4);
-        lb << -2, -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity();
-        ub << 2, -1e-4, -1e-4, 1;
-        default_val << -2, -8, -8, -8;
+        lb << -2, -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), 0;
+        ub << 2, -1e-4, -1e-4, 10;
+        default_val << -2, -8, -8, 0;
     };
 
     int UnitarityConstraint(const Eigen::VectorXf &v){
-        return   (pow(10,v(1))+pow(10,v(2))<1 ? 1 : 0);      
+        // ensures positive g2 in addition to the usual unitarity constraints
+        const float Ue4sq = maybe_convert_log("Ue4^2", v(param_name_to_index.at("Ue4^2")));
+        const float Um4sq = maybe_convert_log("Um4^2", v(param_name_to_index.at("Um4^2")));
+        const float g2 = maybe_convert_log("g2", v(param_name_to_index.at("g2")));
+        return   ((Ue4sq+Um4sq)<1 && g2>0 ? 1 : 0);      
     }
 
     // Equations from Jesse Mendez, slide 5 bottom https://microboone-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=45475&filename=2025-10-31-mendez-sterile-deacy.pdf&version=1
@@ -606,10 +651,10 @@ public:
     // This exactly matches the equation above, confirming that the references are consistent.
 
     float Pmue(float dmsq, float Ue4sq, float Um4sq, float g2, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        Ue4sq = std::pow(10.0f, Ue4sq);
-        Um4sq = std::pow(10.0f, Um4sq);
-        g2 = std::pow(10.0f, g2);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        Ue4sq = maybe_convert_log("Ue4^2", Ue4sq);
+        Um4sq = maybe_convert_log("Um4^2", Um4sq);
+        g2 = maybe_convert_log("g2", g2);
 
         if (Ue4sq > 1 || Ue4sq < 0 || Um4sq > 1 || Um4sq < 0 || g2 < 0) {
             log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Ue4sq=%2%, Um4sq=%3%, g2=%4%, dmsq=%5%, le=%6%")
@@ -619,12 +664,14 @@ public:
             if (Um4sq > 1) Um4sq = 1;
             if (Um4sq < 0) Um4sq = 0;
             if (g2 < 0) g2 = 0;
+            exit(EXIT_FAILURE);
         }
 
         float delta = 1.266932679f*dmsq*le;
         float costerm = std::cos(2.0f*delta);
         float expterm = std::exp(-g2*delta/(8.0f*3.14159f));
         float prob    = Ue4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+        //exit(0);
 
         // numerical precision issues can cause small negative probabilities
         if(-1e-6f < prob && prob<0.0f){
@@ -642,16 +689,17 @@ public:
     }
 
     float Pmumu(float dmsq, [[maybe_unused]]float Ue4sq, float Um4sq, float g2, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        Um4sq = std::pow(10.0f, Um4sq);
-        g2 = std::pow(10.0f, g2);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        Um4sq = maybe_convert_log("Um4^2", Um4sq);
+        g2 = maybe_convert_log("g2", g2);
 
         if (Um4sq > 1 || Um4sq < 0 || g2 < 0) {
-            log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Ue4sq=%2%, Um4sq=%3%, g2=%4%, dmsq=%5%, le=%6%")
-                % __func__ % Ue4sq % Um4sq % g2 % dmsq % le;
+            log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Um4sq=%2%, g2=%3%, dmsq=%4%, le=%5%")
+                % __func__ % Um4sq % g2 % dmsq % le;
             if (Um4sq > 1) Um4sq = 1;
             if (Um4sq < 0) Um4sq = 0;
             if (g2 < 0) g2 = 0;
+            exit(EXIT_FAILURE);
         }
 
         float delta = 1.266932679f*dmsq*le;
@@ -675,16 +723,17 @@ public:
     }
 
     float Pee(float dmsq, float Ue4sq, [[maybe_unused]]float Um4sq, float g2, float le) const{
-        dmsq = std::pow(10.0f, dmsq);
-        Ue4sq = std::pow(10.0f, Ue4sq);
-        g2 = std::pow(10.0f, g2);
+        dmsq = maybe_convert_log("dmsq", dmsq);
+        Ue4sq = maybe_convert_log("Ue4^2", Ue4sq);
+        g2 = maybe_convert_log("g2", g2);
 
         if (Ue4sq > 1 || Ue4sq < 0 || g2 < 0) {
-            log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Ue4sq=%2%, Um4sq=%3%, g2=%4%, dmsq=%5%, le=%6%")
-                % __func__ % Ue4sq % Um4sq % g2 % dmsq % le;
+            log<LOG_ERROR>(L"%1% || Parameter(s) out of bounds. Setting to limits. Values: Ue4sq=%2%, g2=%3%, dmsq=%4%, le=%5%")
+                % __func__ % Ue4sq % g2 % dmsq % le;
             if (Ue4sq > 1) Ue4sq = 1;
             if (Ue4sq < 0) Ue4sq = 0;
             if (g2 < 0) g2 = 0;
+            exit(EXIT_FAILURE);
         }
 
         float delta = 1.266932679f*dmsq*le;

--- a/pybind/profit.cxx
+++ b/pybind/profit.cxx
@@ -139,10 +139,12 @@ void savePROsurf(const PROfit::PROsurf &surface,
     const std::string &rootfile="", const std::string &pdffile="") {
 
   std::vector<float> binedges_x, binedges_y;
+  // Edges are stored in model's native space (log if is_log10, linear otherwise)
+  // Convert to linear for ROOT histogram bin edges
   for(size_t i = 0; i < surface.nbinsx+1; i++)
-    binedges_x.push_back(logx ? std::pow(10, surface.edges_x(i)) : surface.edges_x(i));
+    binedges_x.push_back(surface.metric.GetModel().is_log10[surface.x_idx] ? std::pow(10, surface.edges_x(i)) : surface.edges_x(i));
   for(size_t i = 0; i < surface.nbinsy+1; i++)
-    binedges_y.push_back(logy ? std::pow(10, surface.edges_y(i)) : surface.edges_y(i));
+    binedges_y.push_back(surface.metric.GetModel().is_log10[surface.y_idx] ? std::pow(10, surface.edges_y(i)) : surface.edges_y(i));
   
   TH2D surf("surf", (";"+xlabel+";"+ylabel).c_str(), surface.nbinsx, binedges_x.data(), surface.nbinsy, binedges_y.data());
 

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -152,7 +152,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 // If this new gradient evaluation point violates unitarity, set the gradient to a large value
                 if(model.model_constraint){
                     if(!model.model_constraint(param_plus)){
-                        log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                        //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
                         gradient(i) = sign * 1e10;
                         continue;
                     }
@@ -403,7 +403,7 @@ void PROCNP::print(const Eigen::VectorXf &param){
         // If this new gradient evaluation point violates unitarity, set the gradient to a large value
         if(model.model_constraint){
             if(!model.model_constraint(subvector1)){
-                log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
                 gradient(i) = sgn * 1e10;
                 continue;
             }

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -149,6 +149,15 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 Eigen::VectorXf param_plus = param;
                 param_plus(i) = param(i) + sign*h;
 
+                // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                if(model.model_constraint){
+                    if(!model.model_constraint(param_plus)){
+                        log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                        gradient(i) = sign * 1e10;
+                        continue;
+                    }
+                }
+
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
                 PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
@@ -189,8 +198,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 // Calculate chi2 at both points
                 float chi2_plus, chi2_minus;
 
-                // Plus point
-                {
+                // plus point
+                if(model.model_constraint && !model.model_constraint(param_plus)){
+                    // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                    chi2_plus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
@@ -213,8 +226,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     chi2_plus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
                 }
 
-                // Minus point
-                {
+                // minus point
+                if(model.model_constraint && !model.model_constraint(param_minus)){
+                    // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                    chi2_minus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
@@ -382,6 +399,16 @@ void PROCNP::print(const Eigen::VectorXf &param){
         //log<LOG_DEBUG>(L"%1% || Created physics subvector with size %2%") % __func__ % subvector1.size();
         Eigen::VectorXf subvector2 = tmpParams.segment(model.nparams, syst->GetNSplines());
         //log<LOG_DEBUG>(L"%1% || Created spline subvector with size %2%") % __func__ % subvector2.size();
+
+        // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+        if(model.model_constraint){
+            if(!model.model_constraint(subvector1)){
+                log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                gradient(i) = sgn * 1e10;
+                continue;
+            }
+        }
+
         PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, strat != EventByEvent);
         // Calcuate Full Covariance matrix
         Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -145,6 +145,15 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 Eigen::VectorXf param_plus = param;
                 param_plus(i) = param(i) + sign*h;
 
+                // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+                if(model.model_constraint){
+                    if(!model.model_constraint(param_plus.segment(0, model.nparams))){
+                        //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                        gradient(i) = sign * 1e10;
+                        continue;
+                    }
+                }
+
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
                 PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
@@ -177,7 +186,10 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 float chi2_plus, chi2_minus;
 
                 // Plus point
-                {
+                if(model.model_constraint && !model.model_constraint(param_plus.segment(0, model.nparams))){
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (plus) violates unitarity. Setting chi2_plus to large value.") % __func__;
+                    chi2_plus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
                     Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
@@ -192,10 +204,13 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 }
 
                 // Minus point
-                {
+                if(model.model_constraint && !model.model_constraint(param_minus.segment(0, model.nparams))){
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (minus) violates unitarity. Setting chi2_minus to large value.") % __func__;
+                    chi2_minus = 1e10;
+                } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
 
-
+                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
                     Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (collapsed_stat_covariance + collapsed_full_covariance).inverse();

--- a/src/PROfc.cxx
+++ b/src/PROfc.cxx
@@ -81,7 +81,6 @@ void fc_worker(fc_args args) {
 
         args.out->push_back({
                 chi2_syst, chi2_osc, 
-                // TODO: change_log_here
                 (model->is_log10[0] ? std::pow(10.0f, fitter_osc.best_fit(0)) : fitter_osc.best_fit(0)),
                 (model->is_log10[1] ? std::pow(10.0f, fitter_osc.best_fit(1)) : fitter_osc.best_fit(1)),
                 fitter.best_fit.segment(2, nparams - 2) , 

--- a/src/PROfc.cxx
+++ b/src/PROfc.cxx
@@ -81,8 +81,9 @@ void fc_worker(fc_args args) {
 
         args.out->push_back({
                 chi2_syst, chi2_osc, 
-                std::pow(10.0f, fitter_osc.best_fit(0)), 
-                std::pow(10.0f, fitter_osc.best_fit(1)), 
+                // TODO: change_log_here
+                (model->is_log10[0] ? std::pow(10.0f, fitter_osc.best_fit(0)) : fitter_osc.best_fit(0)),
+                (model->is_log10[1] ? std::pow(10.0f, fitter_osc.best_fit(1)) : fitter_osc.best_fit(1)),
                 fitter.best_fit.segment(2, nparams - 2) , 
                 fitter_osc.best_fit.segment(2, nparams-2),t  });
 

--- a/src/PROpoisson.cxx
+++ b/src/PROpoisson.cxx
@@ -102,6 +102,16 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
             
             Eigen::VectorXf subvector1 = tmpParams.segment(0, nparams - nsyst);
             Eigen::VectorXf subvector2 = tmpParams.segment(nparams - nsyst, nsyst);
+
+            // If this new gradient evaluation point violates unitarity, set the gradient to a large value
+            if(model.model_constraint){
+                if(!model.model_constraint(subvector1)){
+                    //log<LOG_ERROR>(L"%1% || WARNING In PROpoisson: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
+                    gradient(i) = sgn * 1e10;
+                    continue;
+                }
+            }
+
             PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, strat != EventByEvent);
 
             const Eigen::VectorXf vdata = shape_only 

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -83,6 +83,8 @@ std::vector<float> combined_sparse_seed(float Amin, float Amax, std::vector<floa
 
 
 PROsurf::PROsurf(PROmetric &metric,  size_t x_idx, size_t y_idx, size_t nbinsx, LogLin llx, float x_lo, float x_hi, size_t nbinsy, LogLin lly, float y_lo, float y_hi) : metric(metric), x_idx(x_idx), y_idx(y_idx), nbinsx(nbinsx), nbinsy(nbinsy), edges_x(Eigen::VectorXf::Constant(nbinsx + 1, 0)), edges_y(Eigen::VectorXf::Constant(nbinsy + 1, 0)), surface(nbinsx, nbinsy) {
+          
+    // If it's a log axis, we always convert to log space in order to define the grid
     if(llx == LogAxis) {
         x_lo = std::log10(x_lo);
         x_hi = std::log10(x_hi);
@@ -91,10 +93,31 @@ PROsurf::PROsurf(PROmetric &metric,  size_t x_idx, size_t y_idx, size_t nbinsx, 
         y_lo = std::log10(y_lo);
         y_hi = std::log10(y_hi);
     }
+    
+    for(size_t i = 0; i < nbinsx + 1; i++) {
+        float edge_val = x_lo + i * (x_hi - x_lo) / nbinsx;
+        if (llx == LogAxis) edge_val = std::pow(10, edge_val); // Now bin edges are back to linear space
+        if (metric.GetModel().is_log10[x_idx])
+            edges_x(i) = std::log10(edge_val);
+        else
+            edges_x(i) = edge_val;
+    }
+    for(size_t i = 0; i < nbinsy + 1; i++) {
+        float edge_val = y_lo + i * (y_hi - y_lo) / nbinsy;
+        if (lly == LogAxis) edge_val = std::pow(10, edge_val); // Now bin edges are back to linear space
+        if (metric.GetModel().is_log10[y_idx])
+            edges_y(i) = std::log10(edge_val);
+        else
+            edges_y(i) = edge_val;
+    }
+
+    /*
     for(size_t i = 0; i < nbinsx + 1; i++)
-        edges_x(i) = x_lo + i * (x_hi - x_lo) / nbinsx;
+        log<LOG_ERROR>(L"%1% || xbin edge %2%: %3%") % __func__ % i % edges_x(i);
     for(size_t i = 0; i < nbinsy + 1; i++)
-        edges_y(i) = y_lo + i * (y_hi - y_lo) / nbinsy;
+        log<LOG_ERROR>(L"%1% || ybin edge %2%: %3%") % __func__ % i % edges_y(i);
+    */
+
 }
 
 void PROsurf::FillSurfaceStat(const PROconfig &config, const PROfitterConfig &fitconfig, std::string filename) {
@@ -455,10 +478,12 @@ std::vector<surfOut> PROsurf::FillCurve(const PROfitterConfig &fitconfig, PROsee
 void PROsurf::PlotCurve(const PROconfig &config, const PROmodel &model, const PROsyst &syst, const std::vector<surfOut> & cpoints, std::string final_output_tag, bool logx, bool logy, size_t xaxis_idx,size_t yaxis_idx, std::vector<float> &A, std::vector<float> &B, size_t n_points){
 
     std::vector<float> binedges_x, binedges_y;
+    // Edges are stored in model's native space (log if is_log10, linear otherwise)
+    // Convert to linear for ROOT histogram bin edges
     for(size_t i = 0; i < this->nbinsx+1; i++)
-        binedges_x.push_back(logx ? std::pow(10, this->edges_x(i)) : this->edges_x(i));
+        binedges_x.push_back(model.is_log10[xaxis_idx] ? std::pow(10, this->edges_x(i)) : this->edges_x(i));
     for(size_t i = 0; i < this->nbinsy+1; i++)
-        binedges_y.push_back(logy ? std::pow(10, this->edges_y(i)) : this->edges_y(i));
+        binedges_y.push_back(model.is_log10[yaxis_idx] ? std::pow(10, this->edges_y(i)) : this->edges_y(i));
 
      std::string xlabel = xaxis_idx < model.nparams ? model.pretty_param_names.at(xaxis_idx) : 
             config.m_mcgen_variation_plotname_map.at(syst.spline_names.at(xaxis_idx));


### PR DESCRIPTION
Previously, there was a bug when using --linx to make a surface with a linear scale, and the results wouldn't match the surface with a log scale axis. This fixes this issue and makes the log/linear scale for each variable more clear.

There are now three independent sets of log/linear variables to think about:

1. Whether variables are log or linear during the minimization. This is set in new `is_log10` variables in each model within PROmodel.h.
2. Whether a plotting surface uses log/linear variables, for display and for the grid used. This is set with --linx and --liny when calling the surface command.
3. The injected CV or fake data points set when calling the command. These will always be the linear value and never the log value, despite the linear/log setting for options 1 and 2 above.

This PR is built on top of [PR 336](https://github.com/markrosslonergan/Elephant_Vanishes/pull/336), so it should have a smaller diff if that is merged first. 

This is a breaking change within PROmodel.h, so similar `is_log10` variables should be added to any other models during merging.


This also uses a new `param_name_to_index` map within PROmodel.h, which could be useful in the future for more ergonomic and less bug-prone settings of variables for each name, for example:
```
// current example:
lb << -2, -std::numeric_limits<float>::infinity();

// potential future example:
set_lower_bound("dmsq", -2);
set_lower_bound("sinsq2thmm", -std::numeric_limits<float>::infinity());
```

