### PR TITLE
Unifying probability calculations to increase speed

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1828,7 +1828,7 @@ int main(int argc, char* argv[])
         log<LOG_INFO>(L"%1% || PROtest. Place anything here, a playground for testing things.") % __func__;
         //PrintVariableInfo(config);
         auto start = std::chrono::high_resolution_clock::now();
-        int N=3;
+        int N=1000;
         for(int i=0; i< N; i++){
             FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), fakeDataParams , true,config.i_prime);
         }

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1227,7 +1227,7 @@ int main(int argc, char* argv[])
     }
     if(*proplot_command){
 
-        log<LOG_INFO>(L"%1% || Making a PROsyst thats full covarinace for future error bar creation (might be slow) ")% __func__ ;
+        log<LOG_INFO>(L"%1% || Making a PROsyst thats full covariance for future error bar creation (might be slow) ")% __func__ ;
         PROsyst allcovsyst = variable_systs[config.i_prime].allsplines2cov(config, prop, *model, CVParams, dseed(PROseed::global_rng));
 
         PlotOptions opt = PlotOptions::CVasStack;

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1823,6 +1823,22 @@ int main(int argc, char* argv[])
     //******************** TEST AREA TEST AREA     **************************
     //***********************************************************************
     //***********************************************************************
+
+    if(*protest_command){
+        log<LOG_INFO>(L"%1% || PROtest. Place anything here, a playground for testing things.") % __func__;
+        //PrintVariableInfo(config);
+        auto start = std::chrono::high_resolution_clock::now();
+        int N=1000;
+        for(int i=0; i< N; i++){
+            FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), fakeDataParams , true,config.i_prime);
+        }
+        auto end = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> duration = end - start;
+        log<LOG_INFO>(L"%1% || PROtest took %2% seconds total, or %3% per call of FillSpectra; ") % __func__ % duration.count() % float(duration.count()/(double(N)));
+        //***************************** END *********************************
+    }
+
+    /*
     if(*protest_command){
         log<LOG_INFO>(L"%1% || PROtest. Place anything here, a playground for testing things .") % __func__;
         //PrintVariableInfo(config);
@@ -1839,6 +1855,7 @@ int main(int argc, char* argv[])
 
         //***************************** END *********************************
     }
+    */
 
     std::ofstream global_fit_out;
     if(global_fit_result.size() > 0) {

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1828,7 +1828,7 @@ int main(int argc, char* argv[])
         log<LOG_INFO>(L"%1% || PROtest. Place anything here, a playground for testing things.") % __func__;
         //PrintVariableInfo(config);
         auto start = std::chrono::high_resolution_clock::now();
-        int N=1000;
+        int N=3;
         for(int i=0; i< N; i++){
             FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), fakeDataParams , true,config.i_prime);
         }

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -1118,7 +1118,7 @@ public:
         return prob;
     }
 
-    /*
+    
     std::vector<std::vector<float>> get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
         //log<LOG_ERROR>(L"%1% || Using unified, optimized get_probs function for model") % __func__;
 
@@ -1156,7 +1156,7 @@ public:
 
         return probs;
     }
-    */
+    
 };
 
 class PRO3p2 : public PROmodel {

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -649,6 +649,7 @@ public:
                 return this->Pee(v(0), v(1), v(2), le);
             }
         );
+        prob_types = {0, 1, 2, 3};
 
         // -----------------------------------------
         // 2) L/E variable index
@@ -1177,6 +1178,7 @@ public:
             [this](const Eigen::VectorXf &v, float le) { return this->Pmue(v, le); });
         model_functions.push_back(
             [this](const Eigen::VectorXf &v, float le) { return this->Pee(v, le); });
+        prob_types = {0, 1, 2, 3};
 
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'. Make sure its in your model section of XML.")

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -35,14 +35,14 @@ public:
     std::vector<bool> is_log10; // Track whether each physics parameter is stored in log10 space.
 
     // Compute oscillation probabilities for all L/E values and all probability types
-    // Returns probs[le_index][prob_type_index]
+    // Returns probs(le_index, prob_type_index) as an Eigen::MatrixXf for cache-friendly access
     // Can be overridden for faster computation, computing multiple types of probabilities at multiple L/E values together
-    virtual std::vector<std::vector<float>> get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const {
+    virtual Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const {
         //log<LOG_ERROR>(L"%1% || Using non-unified get_probs function for model") % __func__;
-        std::vector<std::vector<float>> probs(le_arr.size(), std::vector<float>(prob_types.size()));
+        Eigen::MatrixXf probs(le_arr.size(), prob_types.size());
         for(size_t i = 0; i < le_arr.size(); ++i) {
             for(size_t j = 0; j < prob_types.size(); ++j) {
-                probs[i][j] = model_functions[j](phys, le_arr[i]);
+                probs(i, j) = model_functions[j](phys, le_arr[i]);
             }
         }
 
@@ -170,7 +170,7 @@ public:
         return prob;
     }
 
-    std::vector<std::vector<float>> get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
+    Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
         //log<LOG_ERROR>(L"%1% || Using unified, optimized get_probs function for model") % __func__;
         // Precompute physics parameters once
         float dmsq = maybe_convert_log("dmsq", phys(0));
@@ -181,16 +181,16 @@ public:
         if(sinsq2thmumu > 1) sinsq2thmumu = 1;
         if(sinsq2thmumu < 0) sinsq2thmumu = 0;
 
-        std::vector<std::vector<float>> probs(le_arr.size(), std::vector<float>(model_functions.size()));
+        Eigen::MatrixXf probs(le_arr.size(), model_functions.size());
 
         for(size_t i = 0; i < le_arr.size(); ++i) {
 
             // no oscillation
-            probs[i][0] = 1.0f;
+            probs(i, 0) = 1.0f;
 
             // P_mumu
             float sinterm = std::sin(freq * le_arr[i]);
-            probs[i][1] = 1.0f - (sinsq2thmumu * sinterm * sinterm);
+            probs(i, 1) = 1.0f - (sinsq2thmumu * sinterm * sinterm);
         }
 
         return probs;
@@ -1119,7 +1119,7 @@ public:
     }
 
     
-    std::vector<std::vector<float>> get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
+    Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
         //log<LOG_ERROR>(L"%1% || Using unified, optimized get_probs function for model") % __func__;
 
         // Precompute physics parameters once
@@ -1132,25 +1132,25 @@ public:
 
         float freq = 1.266932679f * dmsq;
 
-        std::vector<std::vector<float>> probs(le_arr.size(), std::vector<float>(model_functions.size()));
+        Eigen::MatrixXf probs(le_arr.size(), model_functions.size());
 
         for(size_t i = 0; i < le_arr.size(); ++i) {
             
             // no oscillation
-            probs[i][0] = 1.0f;
+            probs(i, 0) = 1.0f;
 
             float delta = freq*le_arr[i];
             float costerm = std::cos(2.0f*delta);
             float expterm = std::exp(-g2*delta/(8.0f*3.14159f));
 
             // P_mumu
-            probs[i][1] = 1.0f - 2.0f*Um4sq*(1.0f-expterm*costerm) + Um4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+            probs(i, 1) = 1.0f - 2.0f*Um4sq*(1.0f-expterm*costerm) + Um4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
 
             // P_mue
-            probs[i][2] = Ue4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+            probs(i, 2) = Ue4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
 
             // P_ee
-            probs[i][3] = 1.0f - 2.0f*Ue4sq*(1.0f-expterm*costerm) + Ue4sq*Ue4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+            probs(i, 3) = 1.0f - 2.0f*Ue4sq*(1.0f-expterm*costerm) + Ue4sq*Ue4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
 
         }
 

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -105,6 +105,7 @@ public:
         // these get combined into one get_probs function in the constructor, but we can override this for faster computation
         model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0;});
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),le);});
+        prob_types = {0, 1};
 
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'.Make sure its in your model section of XML. ") % __func__ % __LINE__;
@@ -202,6 +203,7 @@ public:
     PROnueapp(const PROpeller &prop,const std::map<std::string,int> &parameter_map) {
         model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0;});
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmue(v(0),v(1),le);});
+        prob_types = {0, 1};
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'. Make sure its in your model section of XML.") % __func__ % __LINE__;
             throw std::runtime_error("Missing parameter: L/E");
@@ -277,7 +279,7 @@ public:
     PROnuedis(const PROpeller &prop,const std::map<std::string,int> &parameter_map) {
         model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0;});
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pee(v(0),v(1),le);});
-        
+        prob_types = {0, 1};
 
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'.Make sure its in your model section of XML. ") % __func__ % __LINE__;
@@ -353,6 +355,7 @@ public:
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),v(2),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmue(v(0),v(1),v(2),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pee(v(0),v(1),v(2),le); });
+        prob_types = {0, 1, 2, 3};
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'. Make sure its in your model section of XML.") % __func__ % __LINE__;
             throw std::runtime_error("Missing parameter: L/E");
@@ -503,6 +506,7 @@ public:
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),v(2),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmue(v(0),v(1),v(2),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pee(v(0),v(1),v(2),le); });
+        prob_types = {0, 1, 2, 3};
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'. Make sure its in your model section of XML.") % __func__ % __LINE__;
             throw std::runtime_error("Missing parameter: L/E");
@@ -814,6 +818,7 @@ public:
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),v(2),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmue(v(0),v(1),v(2),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pee(v(0),v(1),v(2),le); });
+        prob_types = {0, 1, 2, 3};
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'. Make sure its in your model section of XML.") % __func__ % __LINE__;
             throw std::runtime_error("Missing parameter: L/E");
@@ -941,6 +946,7 @@ public:
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),v(2),v(3),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmue(v(0),v(1),v(2),v(3),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pee(v(0),v(1),v(2),v(3),le); });
+        prob_types = {0, 1, 2, 3};
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'. Make sure its in your model section of XML.") % __func__ % __LINE__;
             throw std::runtime_error("Missing parameter: L/E");
@@ -1118,7 +1124,6 @@ public:
         return prob;
     }
 
-    
     Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
         //log<LOG_ERROR>(L"%1% || Using unified, optimized get_probs function for model") % __func__;
 

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -30,7 +30,25 @@ public:
     std::vector<std::vector<Eigen::MatrixXf>> hists; //2D hists for binned oscilattion, one for each model function, and the N-variables 
                                         //Todo: make this a vector of length n_variables, and fill them all. For now 1 is "special". 
 
+    std::vector<size_t> prob_types; // Indices of probability types (matches model_functions indices)
+
     std::vector<bool> is_log10; // Track whether each physics parameter is stored in log10 space.
+
+    // Compute oscillation probabilities for all L/E values and all probability types
+    // Returns probs[le_index][prob_type_index]
+    // Can be overridden for faster computation, computing multiple types of probabilities at multiple L/E values together
+    virtual std::vector<std::vector<float>> get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const {
+        //log<LOG_ERROR>(L"%1% || Using non-unified get_probs function for model") % __func__;
+        std::vector<std::vector<float>> probs(le_arr.size(), std::vector<float>(prob_types.size()));
+        for(size_t i = 0; i < le_arr.size(); ++i) {
+            for(size_t j = 0; j < prob_types.size(); ++j) {
+                probs[i][j] = model_functions[j](phys, le_arr[i]);
+            }
+        }
+
+        return probs;
+    }
+
     // Fast lookup from parameter name to index
     std::unordered_map<std::string, size_t> param_name_to_index;
     inline void build_param_index() {
@@ -59,6 +77,7 @@ public:
         nparams = 0;
         ivar = 1;
         model_functions.push_back([](const Eigen::VectorXf &, float){ return 1.0f; });
+        prob_types = {0};
        
         size_t nvar = prop.variable_mc_stat_err.size();
         hists.resize(nvar);
@@ -80,9 +99,12 @@ public:
 class PROnumudis : public PROmodel {
 public:
     PROnumudis(const PROpeller &prop,const std::map<std::string,int> &parameter_map) {
+        prob_types = {0, 1};
+
+        // model_functions is the non-unified version, these are optional
+        // these get combined into one get_probs function in the constructor, but we can override this for faster computation
         model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0;});
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),le);});
-        
 
         if(parameter_map.find("L/E") == parameter_map.end()) {
             log<LOG_ERROR>(L"%1%, %2% || Missing expected parameter: 'L/E'.Make sure its in your model section of XML. ") % __func__ % __LINE__;
@@ -146,6 +168,32 @@ public:
         }
 
         return prob;
+    }
+
+    std::vector<std::vector<float>> get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
+        //log<LOG_ERROR>(L"%1% || Using unified, optimized get_probs function for model") % __func__;
+        // Precompute physics parameters once
+        float dmsq = maybe_convert_log("dmsq", phys(0));
+        float sinsq2thmumu = maybe_convert_log("sinsq2thmm", phys(1));
+
+        float freq = 1.266932679f * dmsq;
+
+        if(sinsq2thmumu > 1) sinsq2thmumu = 1;
+        if(sinsq2thmumu < 0) sinsq2thmumu = 0;
+
+        std::vector<std::vector<float>> probs(le_arr.size(), std::vector<float>(model_functions.size()));
+
+        for(size_t i = 0; i < le_arr.size(); ++i) {
+
+            // no oscillation
+            probs[i][0] = 1.0f;
+
+            // P_mumu
+            float sinterm = std::sin(freq * le_arr[i]);
+            probs[i][1] = 1.0f - (sinsq2thmumu * sinterm * sinterm);
+        }
+
+        return probs;
     }
 };
 
@@ -886,6 +934,9 @@ public:
         // 3+1+decay to invisible particles, example from IceCube: https://arxiv.org/pdf/2204.00612
         // (invisible means no active or sterile-oscillating-to-active neutrinos after the decay)
 
+        prob_types = {0, 1, 2, 3};
+        // model_functions is the non-unified version, these are optional
+        // these get combined into one get_probs function in the constructor, but we can override this for faster computation
         model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0; });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmumu(v(0),v(1),v(2),v(3),le); });
         model_functions.push_back([this](const Eigen::VectorXf &v, float le) {return this->Pmue(v(0),v(1),v(2),v(3),le); });
@@ -1066,6 +1117,46 @@ public:
 
         return prob;
     }
+
+    /*
+    std::vector<std::vector<float>> get_probs(const Eigen::VectorXf &phys, const std::vector<float> &le_arr) const override {
+        //log<LOG_ERROR>(L"%1% || Using unified, optimized get_probs function for model") % __func__;
+
+        // Precompute physics parameters once
+        float dmsq = maybe_convert_log("dmsq", phys(0));
+        float Ue4sq = maybe_convert_log("Ue4^2", phys(1));
+        float Um4sq = maybe_convert_log("Um4^2", phys(2));
+        float g2 = maybe_convert_log("g2", phys(3));
+
+        //log<LOG_ERROR>(L"%1% || dmsq = %2%, Ue4sq = %3%, Um4sq = %4%, g2 = %5%") % __func__ % dmsq % Ue4sq % Um4sq % g2;
+
+        float freq = 1.266932679f * dmsq;
+
+        std::vector<std::vector<float>> probs(le_arr.size(), std::vector<float>(model_functions.size()));
+
+        for(size_t i = 0; i < le_arr.size(); ++i) {
+            
+            // no oscillation
+            probs[i][0] = 1.0f;
+
+            float delta = freq*le_arr[i];
+            float costerm = std::cos(2.0f*delta);
+            float expterm = std::exp(-g2*delta/(8.0f*3.14159f));
+
+            // P_mumu
+            probs[i][1] = 1.0f - 2.0f*Um4sq*(1.0f-expterm*costerm) + Um4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+
+            // P_mue
+            probs[i][2] = Ue4sq*Um4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+
+            // P_ee
+            probs[i][3] = 1.0f - 2.0f*Ue4sq*(1.0f-expterm*costerm) + Ue4sq*Ue4sq*(1.0f-2.0f*expterm*costerm + expterm*expterm);
+
+        }
+
+        return probs;
+    }
+    */
 };
 
 class PRO3p2 : public PROmodel {

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -77,35 +77,10 @@ namespace PROfit {
 
             auto probs = inmodel.get_probs(phys, le_arr);
 
-            // print Ue4sq and Um4sq
-            if (std::pow(10.0f, phys(1)) > 0.05) {
-                log<LOG_ERROR>(L"%1% || Temporary printout with phys(1) = %2%, binned spectrum for variable %3%") % __func__ % phys(1) % var_index;
-                for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
-                    float max_prob = 0.0f;
-                    float min_prob = 1.0f;
-                    for(size_t i = 0; i < le_arr.size(); ++i) {
-                        max_prob = std::max(max_prob, probs[i][j]);
-                        min_prob = std::min(min_prob, probs[i][j]);
-                    }
-                    log<LOG_ERROR>(L"%1% || For probability type %2%, probability is from %3% - %4%") % __func__ % j % max_prob % min_prob;
-                }
-            }
-
-            // Validate dimensions before accessing hists
             for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
                 if (inmodel.hists[var_index][j].data() == nullptr) {
                     log<LOG_ERROR>(L"Null matrix at var_index=%1%, j=%2%") % var_index % j;
                     continue;
-                }
-                if ((size_t)inmodel.hists[var_index][j].rows() != le_arr.size()) {
-                    log<LOG_ERROR>(L"FillSpectra binned: hists[%1%][%2%] has %3% rows but le_arr has %4% elements (ivar=%5%). Stopping.")
-                        % var_index % j % inmodel.hists[var_index][j].rows() % le_arr.size() % inmodel.ivar;
-                    exit(EXIT_FAILURE);
-                }
-                if ((size_t)inmodel.hists[var_index][j].cols() != myspectrum.GetNbins()) {
-                    log<LOG_ERROR>(L"FillSpectra binned: hists[%1%][%2%] has %3% cols but output spectrum has %4% bins. Stopping.")
-                        % var_index % j % inmodel.hists[var_index][j].cols() % myspectrum.GetNbins();
-                    exit(EXIT_FAILURE);
                 }
             }
 
@@ -116,8 +91,9 @@ namespace PROfit {
                     }
                 }
             }
+
         } else {
-            log<LOG_ERROR>(L"%1% || Filling unbinned spectrum for variable %2%") % __func__ % var_index;
+
             std::vector<float> le_arr;
             for(size_t i = 0; i < inprop.NEvent(); ++i) {
                 le_arr.push_back(inprop.VariableValue(inmodel.ivar, i));

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -48,6 +48,9 @@ namespace PROfit {
         Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
 
         if(binned) {
+            log<LOG_INFO>(L"%1% || Starting systw calculation %2%") % __func__ % var_index;
+            auto start_systw = std::chrono::high_resolution_clock::now();
+
             Eigen::VectorXf systw = Eigen::VectorXf::Constant(inconfig.m_num_variable_bins_total[var_index], 1);
             for(int i = 0; i < shifts.size(); ++i) {
                 size_t binning = insyst.spline_binnings[i];
@@ -69,11 +72,22 @@ namespace PROfit {
                     }
                 }
             }
+
+            auto end_systw = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> duration_systw = end_systw - start_systw;
+            log<LOG_INFO>(L"%1% || systw calculation took %2% seconds") % __func__ % duration_systw.count();
+
+            log<LOG_INFO>(L"%1% || Starting le_arr building %2%") % __func__ % var_index;
+            auto start_le = std::chrono::high_resolution_clock::now();
             
             std::vector<float> le_arr;
             for(long int i = 0; i < inconfig.m_num_variable_bins_total[inmodel.ivar]; ++i) {
                 le_arr.push_back(inprop.variable_midbin[inmodel.ivar][i]);
             }
+
+            auto end_le = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> duration_le = end_le - start_le;
+            log<LOG_INFO>(L"%1% || le_arr building took %2% seconds") % __func__ % duration_le.count();
 
             log<LOG_INFO>(L"%1% || Starting prob calculation %2%") % __func__ % var_index;
             auto start = std::chrono::high_resolution_clock::now();
@@ -101,27 +115,22 @@ namespace PROfit {
             log<LOG_INFO>(L"%1% || Starting filling %2%") % __func__ % var_index;
             auto start3 = std::chrono::high_resolution_clock::now();
 
-            // Cache pointers to avoid repeated vector/matrix indirection
-            const float* probs_data = probs.data();
-            const size_t probs_rows = probs.rows();
-            const float* systw_data = systw.data();
-            const size_t nbins = myspectrum.GetNbins();
-            
-            // Cache hist matrix pointers for each probability type
-            const std::vector<Eigen::MatrixXf>& hists_for_var = inmodel.hists[var_index];
+            // Use matrix-vector multiplication instead of triple nested loop
+            // Original: spec[k] = Σᵢⱼ systw[k] * probs(i,j) * hists[j](i,k)
+            // Rewritten: spec = systw ⊙ Σⱼ (hists[j]ᵀ × probs.col(j))
+            Eigen::VectorXf result = Eigen::VectorXf::Zero(myspectrum.GetNbins());
             
             for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
-                const float* hist_data = hists_for_var[j].data();
-                const size_t hist_rows = hists_for_var[j].rows();
-                
-                for(size_t i = 0; i < le_arr.size(); ++i) {
-                    const float prob_ij = probs_data[i + j * probs_rows];
-                    for(size_t k = 0; k < nbins; ++k) {
-                        // Column-major: element (i,k) is at index i + k * rows
-                        myspectrum.Fill(k, systw_data[k] * prob_ij * hist_data[i + k * hist_rows]);
-                    }
-                }
+                // hists[var_index][j] has shape (le_arr.size(), nbins)
+                // probs.col(j) has shape (le_arr.size(),)
+                // Result: (nbins, le_arr.size()) × (le_arr.size(),) = (nbins,)
+                result.noalias() += inmodel.hists[var_index][j].transpose() * probs.col(j);
             }
+            
+            // Apply systematic weights and create spectrum
+            Eigen::VectorXf final_spec = systw.cwiseProduct(result);
+            Eigen::VectorXf final_error = final_spec.array().abs().sqrt();
+            myspectrum = PROspec(final_spec, final_error);
 
             auto end3 = std::chrono::high_resolution_clock::now();
             std::chrono::duration<double> duration3 = end3 - start3;
@@ -196,25 +205,20 @@ namespace PROfit {
 
             auto probs = inmodel.get_probs(phys, le_arr);
 
-            // Cache pointers to avoid repeated vector/matrix indirection
-            const float* probs_data = probs.data();
-            const size_t probs_rows = probs.rows();
-            const size_t nbins = myspectrum.GetNbins();
+            // Use matrix-vector multiplication instead of triple nested loop
+            // Convert hist_w_arr to Eigen vector for element-wise operations
+            Eigen::Map<const Eigen::VectorXf> hist_w_vec(hist_w_arr.data(), hist_w_arr.size());
             
-            // Cache hist matrix pointers for each probability type
-            const std::vector<Eigen::MatrixXf>& hists_for_var = inmodel.hists[inconfig.i_prime];
+            Eigen::VectorXf result = Eigen::VectorXf::Zero(myspectrum.GetNbins());
             
             for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
-                const float* hist_data = hists_for_var[j].data();
-                const size_t hist_rows = hists_for_var[j].rows();
-                
-                for(size_t i = 0; i < le_arr.size(); ++i) {
-                    const float weighted_prob_ij = hist_w_arr[i] * probs_data[i + j * probs_rows];
-                    for(size_t k = 0; k < nbins; ++k) {
-                        myspectrum.Fill(k, weighted_prob_ij * hist_data[i + k * hist_rows]);
-                    }
-                }
+                // Weight probs by hist_w, then do matrix-vector multiply
+                Eigen::VectorXf weighted_probs = hist_w_vec.cwiseProduct(probs.col(j));
+                result.noalias() += inmodel.hists[inconfig.i_prime][j].transpose() * weighted_probs;
             }
+            
+            Eigen::VectorXf final_error = result.array().abs().sqrt();
+            myspectrum = PROspec(result, final_error);
 
         } else {
             std::vector<float> le_arr;

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -75,7 +75,17 @@ namespace PROfit {
                 le_arr.push_back(inprop.variable_midbin[inmodel.ivar][i]);
             }
 
+            log<LOG_INFO>(L"%1% || Starting prob calculation %2%") % __func__ % var_index;
+            auto start = std::chrono::high_resolution_clock::now();
+
             auto probs = inmodel.get_probs(phys, le_arr);
+
+            auto end = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> duration = end - start;
+            log<LOG_INFO>(L"%1% || L/E loop took %2% seconds") % __func__ % duration.count();
+
+            log<LOG_INFO>(L"%1% || Starting null matrix check  %2%") % __func__ % var_index;
+            auto start2 = std::chrono::high_resolution_clock::now();
 
             for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
                 if (inmodel.hists[var_index][j].data() == nullptr) {
@@ -84,13 +94,38 @@ namespace PROfit {
                 }
             }
 
-            for(size_t i = 0; i < le_arr.size(); ++i) {
-                for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
-                    for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, systw(k) * probs[i][j] * inmodel.hists[var_index][j](i, k));
+            auto end2 = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> duration2 = end2 - start2;
+            log<LOG_INFO>(L"%1% || null matrix check took %2% seconds") % __func__ % duration2.count();
+
+            log<LOG_INFO>(L"%1% || Starting filling %2%") % __func__ % var_index;
+            auto start3 = std::chrono::high_resolution_clock::now();
+
+            // Cache pointers to avoid repeated vector/matrix indirection
+            const float* probs_data = probs.data();
+            const size_t probs_rows = probs.rows();
+            const float* systw_data = systw.data();
+            const size_t nbins = myspectrum.GetNbins();
+            
+            // Cache hist matrix pointers for each probability type
+            const std::vector<Eigen::MatrixXf>& hists_for_var = inmodel.hists[var_index];
+            
+            for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
+                const float* hist_data = hists_for_var[j].data();
+                const size_t hist_rows = hists_for_var[j].rows();
+                
+                for(size_t i = 0; i < le_arr.size(); ++i) {
+                    const float prob_ij = probs_data[i + j * probs_rows];
+                    for(size_t k = 0; k < nbins; ++k) {
+                        // Column-major: element (i,k) is at index i + k * rows
+                        myspectrum.Fill(k, systw_data[k] * prob_ij * hist_data[i + k * hist_rows]);
                     }
                 }
             }
+
+            auto end3 = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> duration3 = end3 - start3;
+            log<LOG_INFO>(L"%1% || filling took %2% seconds") % __func__ % duration3.count();
 
         } else {
 
@@ -102,7 +137,7 @@ namespace PROfit {
             auto probs = inmodel.get_probs(phys, le_arr);
 
             for(size_t i = 0; i < inprop.NEvent(); ++i) {
-                float oscw = probs[i][inprop.model_rule[i]];
+                float oscw = probs(i, inprop.model_rule[i]);
                 float add_w = inprop.added_weights[i]; 
                 const int reco_bin = inprop.VariableBinIndex(var_index, i);
 
@@ -161,10 +196,22 @@ namespace PROfit {
 
             auto probs = inmodel.get_probs(phys, le_arr);
 
-            for(size_t i = 0; i < le_arr.size(); ++i) {
-                for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
-                    for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, hist_w_arr[i] * probs[i][j] * inmodel.hists[inconfig.i_prime][j](i, k));
+            // Cache pointers to avoid repeated vector/matrix indirection
+            const float* probs_data = probs.data();
+            const size_t probs_rows = probs.rows();
+            const size_t nbins = myspectrum.GetNbins();
+            
+            // Cache hist matrix pointers for each probability type
+            const std::vector<Eigen::MatrixXf>& hists_for_var = inmodel.hists[inconfig.i_prime];
+            
+            for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
+                const float* hist_data = hists_for_var[j].data();
+                const size_t hist_rows = hists_for_var[j].rows();
+                
+                for(size_t i = 0; i < le_arr.size(); ++i) {
+                    const float weighted_prob_ij = hist_w_arr[i] * probs_data[i + j * probs_rows];
+                    for(size_t k = 0; k < nbins; ++k) {
+                        myspectrum.Fill(k, weighted_prob_ij * hist_data[i + k * hist_rows]);
                     }
                 }
             }
@@ -201,7 +248,7 @@ namespace PROfit {
             auto probs = inmodel.get_probs(phys, le_arr);
 
             for(size_t i = 0; i < inprop.NEvent(); ++i) {
-                float oscw = phys.size() != 0 ? probs[i][inprop.model_rule[i]] : 1.0f;
+                float oscw = phys.size() != 0 ? probs(i, inprop.model_rule[i]) : 1.0f;
 
                 float finalw = oscw * add_w_arr[i] * hist_w_arr[i];
                 myspectrum.Fill(inprop.VariableBinIndex(inconfig.i_prime, i), finalw);

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -48,8 +48,8 @@ namespace PROfit {
         Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
 
         if(binned) {
-            log<LOG_INFO>(L"%1% || Starting systw calculation %2%") % __func__ % var_index;
-            auto start_systw = std::chrono::high_resolution_clock::now();
+            //log<LOG_INFO>(L"%1% || Starting systw calculation %2%") % __func__ % var_index;
+            //auto start_systw = std::chrono::high_resolution_clock::now();
 
             Eigen::VectorXf systw = Eigen::VectorXf::Constant(inconfig.m_num_variable_bins_total[var_index], 1);
             for(int i = 0; i < shifts.size(); ++i) {
@@ -73,33 +73,33 @@ namespace PROfit {
                 }
             }
 
-            auto end_systw = std::chrono::high_resolution_clock::now();
-            std::chrono::duration<double> duration_systw = end_systw - start_systw;
-            log<LOG_INFO>(L"%1% || systw calculation took %2% seconds") % __func__ % duration_systw.count();
+            //auto end_systw = std::chrono::high_resolution_clock::now();
+            //std::chrono::duration<double> duration_systw = end_systw - start_systw;
+            //log<LOG_INFO>(L"%1% || systw calculation took %2% seconds") % __func__ % duration_systw.count();
 
-            log<LOG_INFO>(L"%1% || Starting le_arr building %2%") % __func__ % var_index;
-            auto start_le = std::chrono::high_resolution_clock::now();
+            //log<LOG_INFO>(L"%1% || Starting le_arr building %2%") % __func__ % var_index;
+            //auto start_le = std::chrono::high_resolution_clock::now();
             
             std::vector<float> le_arr;
             for(long int i = 0; i < inconfig.m_num_variable_bins_total[inmodel.ivar]; ++i) {
                 le_arr.push_back(inprop.variable_midbin[inmodel.ivar][i]);
             }
 
-            auto end_le = std::chrono::high_resolution_clock::now();
-            std::chrono::duration<double> duration_le = end_le - start_le;
-            log<LOG_INFO>(L"%1% || le_arr building took %2% seconds") % __func__ % duration_le.count();
+            //auto end_le = std::chrono::high_resolution_clock::now();
+            //std::chrono::duration<double> duration_le = end_le - start_le;
+            //log<LOG_INFO>(L"%1% || le_arr building took %2% seconds") % __func__ % duration_le.count();
 
-            log<LOG_INFO>(L"%1% || Starting prob calculation %2%") % __func__ % var_index;
-            auto start = std::chrono::high_resolution_clock::now();
+            //log<LOG_INFO>(L"%1% || Starting prob calculation %2%") % __func__ % var_index;
+            //auto start = std::chrono::high_resolution_clock::now();
 
             auto probs = inmodel.get_probs(phys, le_arr);
 
-            auto end = std::chrono::high_resolution_clock::now();
-            std::chrono::duration<double> duration = end - start;
-            log<LOG_INFO>(L"%1% || L/E loop took %2% seconds") % __func__ % duration.count();
+            //auto end = std::chrono::high_resolution_clock::now();
+            //std::chrono::duration<double> duration = end - start;
+            //log<LOG_INFO>(L"%1% || L/E loop took %2% seconds") % __func__ % duration.count();
 
-            log<LOG_INFO>(L"%1% || Starting null matrix check  %2%") % __func__ % var_index;
-            auto start2 = std::chrono::high_resolution_clock::now();
+            //log<LOG_INFO>(L"%1% || Starting null matrix check  %2%") % __func__ % var_index;
+            //auto start2 = std::chrono::high_resolution_clock::now();
 
             for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
                 if (inmodel.hists[var_index][j].data() == nullptr) {
@@ -108,12 +108,12 @@ namespace PROfit {
                 }
             }
 
-            auto end2 = std::chrono::high_resolution_clock::now();
-            std::chrono::duration<double> duration2 = end2 - start2;
-            log<LOG_INFO>(L"%1% || null matrix check took %2% seconds") % __func__ % duration2.count();
+            //auto end2 = std::chrono::high_resolution_clock::now();
+            //std::chrono::duration<double> duration2 = end2 - start2;
+            //log<LOG_INFO>(L"%1% || null matrix check took %2% seconds") % __func__ % duration2.count();
 
-            log<LOG_INFO>(L"%1% || Starting filling %2%") % __func__ % var_index;
-            auto start3 = std::chrono::high_resolution_clock::now();
+            //log<LOG_INFO>(L"%1% || Starting filling %2%") % __func__ % var_index;
+            //auto start3 = std::chrono::high_resolution_clock::now();
 
             // Use matrix-vector multiplication instead of triple nested loop
             // Original: spec[k] = Σᵢⱼ systw[k] * probs(i,j) * hists[j](i,k)
@@ -132,9 +132,9 @@ namespace PROfit {
             Eigen::VectorXf final_error = final_spec.array().abs().sqrt();
             myspectrum = PROspec(final_spec, final_error);
 
-            auto end3 = std::chrono::high_resolution_clock::now();
-            std::chrono::duration<double> duration3 = end3 - start3;
-            log<LOG_INFO>(L"%1% || filling took %2% seconds") % __func__ % duration3.count();
+            //auto end3 = std::chrono::high_resolution_clock::now();
+            //std::chrono::duration<double> duration3 = end3 - start3;
+            //log<LOG_INFO>(L"%1% || filling took %2% seconds") % __func__ % duration3.count();
 
         } else {
 

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -52,7 +52,6 @@ namespace PROfit {
             for(int i = 0; i < shifts.size(); ++i) {
                 size_t binning = insyst.spline_binnings[i];
 
-
                 //const Eigen::MatrixXf &hist = inprop.variable_hist_storage(binning,var_index);
                 //direct access with inprop.variable_hist_storage(binning,var_index,j,k)
                 for(size_t k = 0; k < inconfig.m_num_variable_bins_total[var_index]; ++k) {
@@ -70,25 +69,64 @@ namespace PROfit {
                     }
                 }
             }
-
+            
+            std::vector<float> le_arr;
             for(long int i = 0; i < inconfig.m_num_variable_bins_total[inmodel.ivar]; ++i) {
-                float le = inprop.variable_midbin[inmodel.ivar][i];
+                le_arr.push_back(inprop.variable_midbin[inmodel.ivar][i]);
+            }
 
-                for(size_t j = 0; j < inmodel.model_functions.size(); ++j) {
-                    float oscw = inmodel.model_functions[j](phys, le);
-                    if (inmodel.hists[var_index][j].data() == nullptr) {
-                        log<LOG_ERROR>(L"Null matrix at var_index=%1%, j=%2%") % var_index % j;
-                        continue;
+            auto probs = inmodel.get_probs(phys, le_arr);
+
+            // print Ue4sq and Um4sq
+            if (std::pow(10.0f, phys(1)) > 0.05) {
+                log<LOG_ERROR>(L"%1% || Temporary printout with phys(1) = %2%, binned spectrum for variable %3%") % __func__ % phys(1) % var_index;
+                for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
+                    float max_prob = 0.0f;
+                    float min_prob = 1.0f;
+                    for(size_t i = 0; i < le_arr.size(); ++i) {
+                        max_prob = std::max(max_prob, probs[i][j]);
+                        min_prob = std::min(min_prob, probs[i][j]);
                     }
+                    log<LOG_ERROR>(L"%1% || For probability type %2%, probability is from %3% - %4%") % __func__ % j % max_prob % min_prob;
+                }
+            }
 
+            // Validate dimensions before accessing hists
+            for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
+                if (inmodel.hists[var_index][j].data() == nullptr) {
+                    log<LOG_ERROR>(L"Null matrix at var_index=%1%, j=%2%") % var_index % j;
+                    continue;
+                }
+                if ((size_t)inmodel.hists[var_index][j].rows() != le_arr.size()) {
+                    log<LOG_ERROR>(L"FillSpectra binned: hists[%1%][%2%] has %3% rows but le_arr has %4% elements (ivar=%5%). Stopping.")
+                        % var_index % j % inmodel.hists[var_index][j].rows() % le_arr.size() % inmodel.ivar;
+                    exit(EXIT_FAILURE);
+                }
+                if ((size_t)inmodel.hists[var_index][j].cols() != myspectrum.GetNbins()) {
+                    log<LOG_ERROR>(L"FillSpectra binned: hists[%1%][%2%] has %3% cols but output spectrum has %4% bins. Stopping.")
+                        % var_index % j % inmodel.hists[var_index][j].cols() % myspectrum.GetNbins();
+                    exit(EXIT_FAILURE);
+                }
+            }
+
+            for(size_t i = 0; i < le_arr.size(); ++i) {
+                for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
                     for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, systw(k) * oscw * inmodel.hists[var_index][j](i, k));
+                        myspectrum.Fill(k, systw(k) * probs[i][j] * inmodel.hists[var_index][j](i, k));
                     }
                 }
             }
         } else {
-            for(size_t i = 0; i<inprop.NEvent(); ++i){
-                float oscw  =  inmodel.model_functions[inprop.model_rule[i]](phys, inprop.VariableValue(inmodel.ivar, i));
+            log<LOG_ERROR>(L"%1% || Filling unbinned spectrum for variable %2%") % __func__ % var_index;
+            std::vector<float> le_arr;
+            for(size_t i = 0; i < inprop.NEvent(); ++i) {
+                le_arr.push_back(inprop.VariableValue(inmodel.ivar, i));
+            }
+
+            auto probs = inmodel.get_probs(phys, le_arr);
+
+            for(size_t i = 0; i < inprop.NEvent(); ++i) {
+                float oscw = probs[i][inprop.model_rule[i]];
                 float add_w = inprop.added_weights[i]; 
                 const int reco_bin = inprop.VariableBinIndex(var_index, i);
 
@@ -100,7 +138,6 @@ namespace PROfit {
                 }
                 float finalw = oscw * systw * add_w;
                 myspectrum.Fill(reco_bin, finalw);
-
             }
         }
         return myspectrum;
@@ -118,6 +155,8 @@ namespace PROfit {
 
         int i_osc_tmp =1;
         if (binned) {
+            std::vector<float> hist_w_arr;
+            std::vector<float> le_arr;
             for(long int i = 0; i < inprop.variable_hist_storage(i_osc_tmp,inconfig.i_prime).rows(); ++i) {
                 float le = inprop.variable_midbin[i_osc_tmp][i];
                 float hist_w = 1.0 ;
@@ -140,21 +179,29 @@ namespace PROfit {
                     }
                 }
 
-                for(size_t j = 0; j < inmodel.model_functions.size(); ++j) {
-                    float oscw = inmodel.model_functions[j](phys, le);
+                hist_w_arr.push_back(hist_w);
+                le_arr.push_back(le);
+            }
+
+            auto probs = inmodel.get_probs(phys, le_arr);
+
+            for(size_t i = 0; i < le_arr.size(); ++i) {
+                for(size_t j = 0; j < inmodel.prob_types.size(); ++j) {
                     for(size_t k = 0; k < myspectrum.GetNbins(); ++k) {
-                        myspectrum.Fill(k, hist_w * oscw * inmodel.hists[inconfig.i_prime][j](i, k));
+                        myspectrum.Fill(k, hist_w_arr[i] * probs[i][j] * inmodel.hists[inconfig.i_prime][j](i, k));
                     }
                 }
             }
-        } else {
-            for(size_t i = 0; i<inprop.NEvent(); ++i){
 
-                float oscw  = phys.size() != 0 ? 
-                    inmodel.model_functions[inprop.model_rule[i]](phys, inprop.VariableValue(inmodel.ivar, i)) :
-                    1;	
-                float add_w = inprop.added_weights[i];
-                float hist_w = 1.0 ;
+        } else {
+            std::vector<float> le_arr;
+            std::vector<float> hist_w_arr;
+            std::vector<float> add_w_arr;
+            for(size_t i = 0; i < inprop.NEvent(); ++i) {
+                le_arr.push_back(inprop.VariableValue(inmodel.ivar, i));
+                add_w_arr.push_back(inprop.added_weights[i]);
+
+                float hist_w = 1.0;
 
                 //Figure out what subchannel the event is in
                 size_t subchan = inconfig.GetSubchannelIndexFromVariableGlobalBin(inprop.VariableBinIndex(i_osc_tmp, i), i_osc_tmp);
@@ -172,7 +219,15 @@ namespace PROfit {
                     }
                 }
 
-                float finalw = oscw * add_w * hist_w;
+                hist_w_arr.push_back(hist_w);
+            }
+
+            auto probs = inmodel.get_probs(phys, le_arr);
+
+            for(size_t i = 0; i < inprop.NEvent(); ++i) {
+                float oscw = phys.size() != 0 ? probs[i][inprop.model_rule[i]] : 1.0f;
+
+                float finalw = oscw * add_w_arr[i] * hist_w_arr[i];
                 myspectrum.Fill(inprop.VariableBinIndex(inconfig.i_prime, i), finalw);
             }
         }


### PR DESCRIPTION
This PR modifies the `FillSpectra` with several improvements, leading to a >2x speedup.

We now calculate the oscillation probability for multiple probability types and multiple L/E values at once, to make it more computationally efficient/faster. By default, each model will still use the vector of `model_functions`, which are now called within `get_probs`. To make it more efficient for a certain model, you can write a new `get_probs` function to calculate these probabilities together; for example, we can calculate 1.27*dm^2 just once, and then use this value for P_mue, P_ee, and P_mumu at all L/E points. Currently, I've included more efficient versions for PROnumudis and PRO3p1_decay_invis.

This also modifies `FillSpectra` inside PROcess.cxx to use matrix operations, significantly improving the speed even without the (optional) unified probability calculation.

For future improvements, the dominant source of slowness in `FillSpectra` now seems to be the `systw` calculation step.

# Timing tests

This runs the following command 1000 times and records the time taken: `FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), fakeDataParams , true,config.i_prime);`

```
# Old commit of the code (d1a268d): 
3 main || PROtest took 4.46926 seconds total, or 0.00446926 per call of FillSpectra;

# New code, non-unified probability calculation:
3 main || PROtest took 2.24297 seconds total, or 0.00224297 per call of FillSpectra;

# New code, unified probability calculation:
3 main || PROtest took 1.7955 seconds total, or 0.0017955 per call of FillSpectra;
```


Using a surface with a 20x20 grid and an injected 3+1+Decay Invisible point, running on the Nevis houston computer:

```
# injected point, Ue4 vs m^2
time PROfit -x three_plus_one_plus_decay_invis_FullSBN.xml -t test1 --inject dmsq 1 Ue4^2 0.1 Um4^2 0.1 g2 3.14 \
-o Surf1 --seed 404 --log log.surf1 -v 2 -w 3 -n 50 surface \
--xvar Ue4^2 --yvar dmsq -g 20 --xlims 0.01 1 --ylims 0.1 100
```

Old commit of the code (d1a268d): 
```
real    11m19.311s
user    291m9.075s
sys     0m0.791s
```

New code:
```
real    6m20.376s
user    136m38.296s
sys     0m0.652s
```

