### PR TITLE
Add capability to work with MicroBooNE SURPRISE files including splines

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -382,6 +382,9 @@ int main(int argc, char* argv[])
     //Spline fake data injection studies
     Eigen::VectorXf fakedataparams = Eigen::VectorXf::Constant(model->nparams + variable_systs[config.i_prime].GetNSplines(), 0);
     for(size_t i = 0; i < model->nparams; ++i) fakedataparams(i) = fake_data_osc_param_vector(i);
+    log<LOG_INFO>(L"%1% || model->default_val: %2%") % __func__ % model->default_val;
+    log<LOG_INFO>(L"%1% || fake_data_osc_param_vector: %2%") % __func__ % fake_data_osc_param_vector;
+    log<LOG_INFO>(L"%1% || fakedataparams (physics portion): %2% %3%") % __func__ % fakedataparams(0) % fakedataparams(1);
     for(const auto& [name, shift]: injected_systs) {
         log<LOG_INFO>(L"%1% || Injected syst: %2% shifted by %3%") % __func__ % name.c_str() % shift;
 
@@ -926,6 +929,7 @@ int main(int argc, char* argv[])
         PROfile profile(config, metric->GetSysts(), metric->GetModel(), *metric, myseed, scanFitConfig, 
                 final_output_tag+"_PROfile", best_chi2, !systs_only, nthread, seeds,
                 fakedataparams);
+        log<LOG_INFO>(L"%1% || fakedataparams for Plot (true_params/red stars): %2%") % __func__ % fakedataparams;
         profile.Plot(config, metric->GetSysts(), metric->GetModel(), *metric, myseed,
                 final_output_tag+"_PROfile", !systs_only, best_fit,
                 fakedataparams);

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -244,8 +244,6 @@ int main(int argc, char* argv[])
     //Initilize configuration from the XML;
     PROconfig config(xmlname, rateonly);
 
-    log<LOG_INFO>(L"%1% || TEMP DEBUG: PROconfig constructor completed successfully") % __func__;
-
     //Inititilize PROpeller to keep MC
     PROpeller prop;
 
@@ -416,14 +414,10 @@ int main(int argc, char* argv[])
     //We will load all other variables too, but many are truth level so data won't be as common.
     std::vector<PROdata> variable_data;
     if(!data_xml.empty()){
-        log<LOG_INFO>(L"%1% || TEMP DEBUG: starting dataconfig constructor") % __func__;
         PROconfig dataconfig(data_xml);
-        log<LOG_INFO>(L"%1% || TEMP DEBUG: dataconfig constructor completed successfully") % __func__;
-        log<LOG_INFO>(L"%1% || dataconfig.m_num_channels: %2%") % __func__ % dataconfig.m_num_channels;
         std::string dataBinName = analysis_tag+"_data.bin";
         for(size_t i = 0; i < dataconfig.m_num_channels; ++i) {
             size_t nsubch = dataconfig.m_num_subchannels[i];
-            log<LOG_INFO>(L"%1% || TEMP DEBUG: nsubch: %2%") % __func__ % nsubch;
             if(nsubch != 1) {
                 log<LOG_ERROR>(L"%1% || Data xml required to have exactly 1 subchannel per channel. Found %2% for channel %3%")
                     % __func__ % nsubch % i;
@@ -431,7 +425,6 @@ int main(int argc, char* argv[])
                 exit(EXIT_FAILURE);
             }
             std::string &subchname = dataconfig.m_subchannel_names[i][0];
-            log<LOG_INFO>(L"%1% || TEMP DEBUG: subchname: %2%") % __func__ % subchname.c_str();
             if(subchname != "data") {
                 log<LOG_ERROR>(L"%1% || Data subchannel required to be called \"data.\" Found name %2% for channel %3%")
                     % __func__ % subchname.c_str() % i;
@@ -1449,6 +1442,7 @@ int main(int argc, char* argv[])
 
 
         if(with_splines) {
+
             c.Print((final_output_tag+"_PROplot_Spline.pdf" + "[").c_str(), "pdf");
 
             std::map<std::string, std::vector<std::pair<std::unique_ptr<TGraph>,std::unique_ptr<TGraph>>>> spline_graphs = getSplineGraphs(variable_systs[config.i_prime], config);
@@ -1461,12 +1455,15 @@ int main(int argc, char* argv[])
                 chan++;
                 int col = chan%2==0 ? kRed: kBlue;
                 int lastsbindex = 0;
+
                 for(const auto &[fixed_pts, curve]: syst_bins) {
+
                     unprinted = true;
                     c.cd(bin%16+1);
                     size_t sbi = config.GetSubchannelIndexFromVariableGlobalBin(bin,config.i_prime);
                     std::string nsubchannel = config.GetSubchannelName(sbi);
-                    std::string chan_units =   config.m_channel_variable_units[config.i_prime][config.GetLocalChannelIndexFromGlobalSubchannelIndex(sbi)];
+                    size_t local_channel_index = config.GetLocalChannelIndexFromGlobalSubchannelIndex(sbi);
+                    std::string chan_units = config.m_channel_variable_units[local_channel_index][config.i_prime];
                     int edges_vec_sz = (int)config.m_variable_bin_to_edges[config.i_prime].size();
                     size_t safe_bin = (edges_vec_sz>0) ? std::min((size_t)bin, (size_t)edges_vec_sz-1) : 0;
                     std::pair<float,float> edg = config.m_variable_bin_to_edges[config.i_prime][safe_bin];
@@ -1497,6 +1494,8 @@ int main(int argc, char* argv[])
             }
 
             c.Print((final_output_tag+"_PROplot_Spline.pdf" + "]").c_str(), "pdf");
+            c.Clear();
+
         }
 
         //now onto root files

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -244,6 +244,7 @@ int main(int argc, char* argv[])
     //Initilize configuration from the XML;
     PROconfig config(xmlname, rateonly);
 
+    log<LOG_INFO>(L"%1% || TEMP DEBUG: PROconfig constructor completed successfully") % __func__;
 
     //Inititilize PROpeller to keep MC
     PROpeller prop;
@@ -415,10 +416,14 @@ int main(int argc, char* argv[])
     //We will load all other variables too, but many are truth level so data won't be as common.
     std::vector<PROdata> variable_data;
     if(!data_xml.empty()){
+        log<LOG_INFO>(L"%1% || TEMP DEBUG: starting dataconfig constructor") % __func__;
         PROconfig dataconfig(data_xml);
+        log<LOG_INFO>(L"%1% || TEMP DEBUG: dataconfig constructor completed successfully") % __func__;
+        log<LOG_INFO>(L"%1% || dataconfig.m_num_channels: %2%") % __func__ % dataconfig.m_num_channels;
         std::string dataBinName = analysis_tag+"_data.bin";
         for(size_t i = 0; i < dataconfig.m_num_channels; ++i) {
             size_t nsubch = dataconfig.m_num_subchannels[i];
+            log<LOG_INFO>(L"%1% || TEMP DEBUG: nsubch: %2%") % __func__ % nsubch;
             if(nsubch != 1) {
                 log<LOG_ERROR>(L"%1% || Data xml required to have exactly 1 subchannel per channel. Found %2% for channel %3%")
                     % __func__ % nsubch % i;
@@ -426,6 +431,7 @@ int main(int argc, char* argv[])
                 exit(EXIT_FAILURE);
             }
             std::string &subchname = dataconfig.m_subchannel_names[i][0];
+            log<LOG_INFO>(L"%1% || TEMP DEBUG: subchname: %2%") % __func__ % subchname.c_str();
             if(subchname != "data") {
                 log<LOG_ERROR>(L"%1% || Data subchannel required to be called \"data.\" Found name %2% for channel %3%")
                     % __func__ % subchname.c_str() % i;

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -298,7 +298,7 @@ int main(int argc, char* argv[])
     // For process-only command, exit early after MC processing is complete
     // This avoids unnecessary setup and potential cleanup issues with ROOT
     if(*process_command && !*profile_command && !*surface_command && !*protest_command && !*proglobal_command && !*proplot_command && !*profc_command) {
-        log<LOG_INFO>(L"%1% || Process command complete. Binary files saved successfully.") % __func__;
+        log<LOG_WARNING>(L"%1% || Process command complete. Binary files saved successfully.") % __func__;
         return 0;
     }
 

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -297,10 +297,10 @@ int main(int argc, char* argv[])
 
     // For process-only command, exit early after MC processing is complete
     // This avoids unnecessary setup and potential cleanup issues with ROOT
-    if(*process_command && !*profile_command && !*surface_command && !*protest_command && !*proglobal_command && !*proplot_command && !*profc_command) {
-        log<LOG_WARNING>(L"%1% || Process command complete. Binary files saved successfully.") % __func__;
-        return 0;
-    }
+    //if(*process_command && !*profile_command && !*surface_command && !*protest_command && !*proglobal_command && !*proplot_command && !*profc_command) {
+    //    log<LOG_WARNING>(L"%1% || Process command complete. Binary files saved successfully.") % __func__;
+    //    return 0;
+    //}
 
     //Scale events by some percentage of total detector POT
     if(scale_arg.size()) {
@@ -443,10 +443,11 @@ int main(int argc, char* argv[])
             //Process the CAF files to grab and fill spectrum directly
             std::vector<PROdata> alldata = CreatePROdata(dataconfig);
             PROdata::saveVector(dataconfig, alldata, dataBinName);
-            data = alldata[0];
+            data = alldata[config.i_prime];
             //data.save(dataconfig,dataBinName);
+            
             for(size_t io = 0; io < dataconfig.m_num_variables; ++io)
-                variable_data.push_back(alldata[io+1]);
+                variable_data.push_back(alldata[io]);
 
             log<LOG_INFO>(L"%1% || Done processing Data from XML defined root files, and saving to binary output also: %2%") % __func__ % dataBinName.c_str();
         }else{
@@ -454,10 +455,11 @@ int main(int argc, char* argv[])
             //data.load(dataBinName);
             std::vector<PROdata> alldata;
             PROdata::loadVector(alldata, dataBinName);
-            data = alldata[0];
+            data = alldata[config.i_prime];
             //data.save(dataconfig,dataBinName);
+
             for(size_t io = 0; io < dataconfig.m_num_variables; ++io)
-                variable_data.push_back(alldata[io+1]);
+                variable_data.push_back(alldata[io]);
 
             log<LOG_INFO>(L"%1% || Done loading. Config hash (%2%) and binary loaded Data (%3%) hash are here. ") % __func__ %  dataconfig.hash % data.hash;
             if(dataconfig.hash!=data.hash){
@@ -471,10 +473,10 @@ int main(int argc, char* argv[])
             }
         }
 
-        if(*profile_command || *surface_command || *protest_command){
+        /*if(*profile_command || *surface_command || *protest_command){
             log<LOG_ERROR>(L"%1% || ERROR --data can only be used with plot subcommand! ") % __func__  ;
             return 1;
-        }
+        }*/
 
 
     }//if no data, use injected or fake data;

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -295,6 +295,13 @@ int main(int argc, char* argv[])
 
     }
 
+    // For process-only command, exit early after MC processing is complete
+    // This avoids unnecessary setup and potential cleanup issues with ROOT
+    if(*process_command && !*profile_command && !*surface_command && !*protest_command && !*proglobal_command && !*proplot_command && !*profc_command) {
+        log<LOG_INFO>(L"%1% || Process command complete. Binary files saved successfully.") % __func__;
+        return 0;
+    }
+
     //Scale events by some percentage of total detector POT
     if(scale_arg.size()) {
         if (scale_arg.size() % 2 != 0) {

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -347,6 +347,7 @@ namespace PROfit{
             std::vector<std::tuple<std::string, std::string, float>> m_mcgen_correlations;
             std::map<std::string, float> m_mcgen_variation_prior;
             std::map<std::string, float> m_mcgen_variation_prior_centers;
+            std::map<std::string, bool> m_mcgen_variation_force_0_cv; //map of systematics with force_0_cv=true (normalize shifts by shift at knob=0)
       
             //FIX skepic
             std::vector<std::string> systematic_name;

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -348,6 +348,7 @@ namespace PROfit{
             std::map<std::string, float> m_mcgen_variation_prior;
             std::map<std::string, float> m_mcgen_variation_prior_centers;
             std::map<std::string, bool> m_mcgen_variation_force_0_cv; //map of systematics with force_0_cv=true (normalize shifts by shift at knob=0)
+            std::map<std::string, bool> m_mcgen_variation_no_xs_weight_spline; //map of systematics with no_xs_weight_spline=true (don't multiply universe weights by mc_weight)
             std::map<std::string, float> m_mcgen_variation_scale; //map of systematics with scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
       
             //FIX skepic

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -348,6 +348,7 @@ namespace PROfit{
             std::map<std::string, float> m_mcgen_variation_prior;
             std::map<std::string, float> m_mcgen_variation_prior_centers;
             std::map<std::string, bool> m_mcgen_variation_force_0_cv; //map of systematics with force_0_cv=true (normalize shifts by shift at knob=0)
+            std::map<std::string, float> m_mcgen_variation_scale; //map of systematics with scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
       
             //FIX skepic
             std::vector<std::string> systematic_name;

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -83,6 +83,7 @@ namespace PROfit{
       };
 
       std::shared_ptr<Formula> branch_monte_carlo_weight_formula = nullptr;
+      std::shared_ptr<Formula> branch_xs_weight_formula = nullptr;
       std::vector<std::shared_ptr<Formula>> branch_variable_formulas;
 
       int model_rule;
@@ -115,13 +116,23 @@ namespace PROfit{
       };
 
 
-      // Function: evaluate additional weight setup in the branch and return in floating precision 
+      // Function: evaluate additional weight setup in the branch and return in floating precision
       // Note: if no additional weight is set, value of 1.0 will be returned.
       inline
       float GetMonteCarloWeight() const{
-	if(branch_monte_carlo_weight_formula){ 
+	if(branch_monte_carlo_weight_formula){
 
 	  return branch_monte_carlo_weight_formula->EvalInstance().first();
+	}
+	return 1.0;
+      }
+
+      // Function: evaluate cross-section weight and return in floating precision
+      // Note: if no xs_weight is set, value of 1.0 will be returned.
+      inline
+      float GetXSWeight() const{
+	if(branch_xs_weight_formula){
+	  return branch_xs_weight_formula->EvalInstance().first();
 	}
 	return 1.0;
       }
@@ -325,6 +336,8 @@ namespace PROfit{
             std::map<std::string,std::vector<std::string>> m_mcgen_file_friend_treename_map;
             std::vector<std::vector<std::string>> m_mcgen_additional_weight_name;
             std::vector<std::vector<bool>> m_mcgen_additional_weight_bool;
+            std::vector<std::vector<std::string>> m_mcgen_xs_weight_name;
+            std::vector<std::vector<bool>> m_mcgen_xs_weight_bool;
             std::vector<std::vector<std::shared_ptr<BranchVariable>>> m_branch_variables;
             std::vector<std::vector<std::string>> m_mcgen_eventweight_branch_names;
             std::vector<std::vector<int>> m_mcgen_eventweight_branch_syst;

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -82,8 +82,7 @@ namespace PROfit{
           virtual ~Formula() {}
       };
 
-      std::shared_ptr<Formula> branch_monte_carlo_weight_formula = nullptr;
-      std::shared_ptr<Formula> branch_xs_weight_formula = nullptr;
+      std::vector<std::shared_ptr<Formula>> branch_weight_formulas;
       std::vector<std::shared_ptr<Formula>> branch_variable_formulas;
 
       int model_rule;
@@ -116,25 +115,42 @@ namespace PROfit{
       };
 
 
-      // Function: evaluate additional weight setup in the branch and return in floating precision
-      // Note: if no additional weight is set, value of 1.0 will be returned.
+      // Function: get individual weight by 0-based index. Returns 1.0 if index out of range.
       inline
-      float GetMonteCarloWeight() const{
-	if(branch_monte_carlo_weight_formula){
-
-	  return branch_monte_carlo_weight_formula->EvalInstance().first();
-	}
-	return 1.0;
+      float GetWeight(int i) const{
+        if(i >= 0 && i < (int)branch_weight_formulas.size() && branch_weight_formulas[i]){
+          return branch_weight_formulas[i]->EvalInstance().first();
+        }
+        return 1.0;
       }
 
-      // Function: evaluate cross-section weight and return in floating precision
-      // Note: if no xs_weight is set, value of 1.0 will be returned.
+      // Function: get total weight (product of all defined weights). Returns 1.0 if no weights defined.
       inline
-      float GetXSWeight() const{
-	if(branch_xs_weight_formula){
-	  return branch_xs_weight_formula->EvalInstance().first();
-	}
-	return 1.0;
+      float GetTotalWeight() const{
+        float product = 1.0;
+        for(const auto& f : branch_weight_formulas){
+          if(f) product *= f->EvalInstance().first();
+        }
+        return product;
+      }
+
+      // Function: get product of weights at specified 1-based indices. Returns 1.0 if indices empty.
+      inline
+      float GetWeightProduct(const std::vector<int>& indices) const{
+        float product = 1.0;
+        for(int idx : indices){
+          int i = idx - 1; // convert 1-based to 0-based
+          if(i >= 0 && i < (int)branch_weight_formulas.size() && branch_weight_formulas[i]){
+            product *= branch_weight_formulas[i]->EvalInstance().first();
+          }
+        }
+        return product;
+      }
+
+      // Function: get number of defined weights
+      inline
+      int NumWeights() const{
+        return (int)branch_weight_formulas.size();
       }
 
       std::vector<BranchVariable::Value> GetVariables() const {
@@ -334,10 +350,8 @@ namespace PROfit{
             std::vector<bool> m_mcgen_fake;
             std::map<std::string,std::vector<std::string>> m_mcgen_file_friend_map;
             std::map<std::string,std::vector<std::string>> m_mcgen_file_friend_treename_map;
-            std::vector<std::vector<std::string>> m_mcgen_additional_weight_name;
-            std::vector<std::vector<bool>> m_mcgen_additional_weight_bool;
-            std::vector<std::vector<std::string>> m_mcgen_xs_weight_name;
-            std::vector<std::vector<bool>> m_mcgen_xs_weight_bool;
+            std::vector<std::vector<std::vector<std::string>>> m_mcgen_weight_names; // file × branch × weight_index
+            std::vector<std::vector<int>> m_mcgen_num_weights; // file × branch → count of weights
             std::vector<std::vector<std::shared_ptr<BranchVariable>>> m_branch_variables;
             std::vector<std::vector<std::string>> m_mcgen_eventweight_branch_names;
             std::vector<std::vector<int>> m_mcgen_eventweight_branch_syst;
@@ -361,7 +375,7 @@ namespace PROfit{
             std::map<std::string, float> m_mcgen_variation_prior;
             std::map<std::string, float> m_mcgen_variation_prior_centers;
             std::map<std::string, bool> m_mcgen_variation_force_0_cv; //map of systematics with force_0_cv=true (normalize shifts by shift at knob=0)
-            std::map<std::string, bool> m_mcgen_variation_no_xs_weight_spline; //map of systematics with no_xs_weight_spline=true (don't multiply universe weights by mc_weight)
+            std::map<std::string, std::vector<int>> m_mcgen_variation_include_only_weights; //map of systematics with include_only_weights (1-based indices of which weights to include in spline universes)
             std::map<std::string, float> m_mcgen_variation_scale; //map of systematics with scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
       
             //FIX skepic

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -66,6 +66,7 @@ namespace PROfit{
         std::vector<int> norm_bins;
         float norm_value;
         bool force_0_cv = false; // if true, normalize spline shifts by shift at knob=0
+        bool no_xs_weight_spline = false; // if true, don't multiply universe weights by mc_weight
         float scale = 1.0f; // scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
 
         //boost serialization
@@ -86,6 +87,7 @@ namespace PROfit{
             ar & norm_bins;
             ar & norm_value;
             ar & force_0_cv;
+            ar & no_xs_weight_spline;
             ar & scale;
         }
 

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -65,6 +65,7 @@ namespace PROfit{
 
         std::vector<int> norm_bins;
         float norm_value;
+        bool force_0_cv = false; // if true, normalize spline shifts by shift at knob=0
 
         //boost serialization
         template<class Archive>
@@ -83,6 +84,7 @@ namespace PROfit{
             ar & hash;
             ar & norm_bins;
             ar & norm_value;
+            ar & force_0_cv;
         }
 
 

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -66,6 +66,7 @@ namespace PROfit{
         std::vector<int> norm_bins;
         float norm_value;
         bool force_0_cv = false; // if true, normalize spline shifts by shift at knob=0
+        float scale = 1.0f; // scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
 
         //boost serialization
         template<class Archive>
@@ -85,6 +86,7 @@ namespace PROfit{
             ar & norm_bins;
             ar & norm_value;
             ar & force_0_cv;
+            ar & scale;
         }
 
 

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -66,7 +66,7 @@ namespace PROfit{
         std::vector<int> norm_bins;
         float norm_value;
         bool force_0_cv = false; // if true, normalize spline shifts by shift at knob=0
-        bool no_xs_weight_spline = false; // if true, don't multiply universe weights by mc_weight
+        std::vector<int> include_only_weights; // 1-based indices of which weights to include in spline universes; empty = all
         float scale = 1.0f; // scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
 
         //boost serialization
@@ -87,7 +87,7 @@ namespace PROfit{
             ar & norm_bins;
             ar & norm_value;
             ar & force_0_cv;
-            ar & no_xs_weight_spline;
+            ar & include_only_weights;
             ar & scale;
         }
 

--- a/inc/PROlog.h
+++ b/inc/PROlog.h
@@ -7,7 +7,8 @@
 #include <iomanip>
 #include <exception>
 #include <vector>
-#include <fstream> 
+#include <fstream>
+#include <unordered_map>
 
 #include <Eigen/Eigen>
 
@@ -71,16 +72,30 @@ namespace log_impl {
         public:
             formatted_log_t( log_level_t level, const wchar_t* msg ) : level(level), fmt(msg) {}
             ~formatted_log_t() {
+                static const int SUPPRESS_AFTER = 10;
+                static std::unordered_map<std::wstring, int> msg_counts;
+                std::wstring formatted_msg = boost::str(fmt);
+                int& count = msg_counts[formatted_msg];
+                count++;
+
                 // Check against console verbosity
                 if ( level <= GLOBAL_LEVEL ) {
-                    // Output to primary stream (usually wcout)
-                    *OSTREAM << level << L" " << fmt << endl;
+                    if (count <= SUPPRESS_AFTER) {
+                        *OSTREAM << level << L" " << fmt << endl;
+                    } else if (count == SUPPRESS_AFTER + 1) {
+                        *OSTREAM << level << L" " << fmt << L" (suppressing further cases)" << endl;
+                    }
                 }
 
                 // Check against file verbosity (can be different from console)
                 if(LOGGING_TO_FILE && LOG_FILE_STREAM.is_open() && level <= FILE_LEVEL) {
-                    LOG_FILE_STREAM << level << L" " << fmt << endl;
-                    LOG_FILE_STREAM.flush(); 
+                    if (count <= SUPPRESS_AFTER) {
+                        LOG_FILE_STREAM << level << L" " << fmt << endl;
+                        LOG_FILE_STREAM.flush();
+                    } else if (count == SUPPRESS_AFTER + 1) {
+                        LOG_FILE_STREAM << level << L" " << fmt << L" (suppressing further cases)" << endl;
+                        LOG_FILE_STREAM.flush();
+                    }
                 }
             }        
             

--- a/inc/PROlog.h
+++ b/inc/PROlog.h
@@ -72,7 +72,7 @@ namespace log_impl {
         public:
             formatted_log_t( log_level_t level, const wchar_t* msg ) : level(level), fmt(msg) {}
             ~formatted_log_t() {
-                static const int SUPPRESS_AFTER = 10;
+                static const int SUPPRESS_AFTER = 1000;
                 static std::unordered_map<std::wstring, int> msg_counts;
                 std::wstring formatted_msg = boost::str(fmt);
                 int& count = msg_counts[formatted_msg];

--- a/profit/lib.py
+++ b/profit/lib.py
@@ -28,6 +28,7 @@ class BranchVariable(profit._profit.BranchVariable):
         self._branch_true_value_formula = None
         self._branch_true_pdg_formula = None
         self._branch_monte_carlo_weight_formula = None
+        self._branch_xs_weight_formula = None
     
     @property
     def branch_formula(self):
@@ -107,6 +108,16 @@ class BranchVariable(profit._profit.BranchVariable):
 
         return self.branch_true_pdg_formula.EvalInstance()
 
+    @property
+    def branch_xs_weight_formula(self):
+        return self._branch_xs_weight_formula
+
+    @branch_xs_weight_formula.setter
+    def branch_xs_weight_formula(self, v):
+        if not isinstance(v, profit.pylib.DataFrameFormula):
+            raise ValueError("BranchVarible.branch_xs_weight_formula must be set to profit.DataFrameFormula")
+        self._branch_xs_weight_formula = v
+
     # Override BranchVariable::GetMonteCarloWeight to use local DataFrameFormula
     # Default to 1 instead of 0 if empty
     def GetMonteCarloWeight(self):
@@ -114,4 +125,12 @@ class BranchVariable(profit._profit.BranchVariable):
             return 1
 
         return self.branch_monte_carlo_weight_formula.EvalInstance()
+
+    # Override BranchVariable::GetXSWeight to use local DataFrameFormula
+    # Default to 1 instead of 0 if empty
+    def GetXSWeight(self):
+        if self.branch_xs_weight_formula is None:
+            return 1
+
+        return self.branch_xs_weight_formula.EvalInstance()
 

--- a/profit/lib.py
+++ b/profit/lib.py
@@ -27,8 +27,7 @@ class BranchVariable(profit._profit.BranchVariable):
         self._branch_true_L_formula = None
         self._branch_true_value_formula = None
         self._branch_true_pdg_formula = None
-        self._branch_monte_carlo_weight_formula = None
-        self._branch_xs_weight_formula = None
+        self._branch_weight_formulas = []
     
     @property
     def branch_formula(self):
@@ -71,14 +70,19 @@ class BranchVariable(profit._profit.BranchVariable):
         self._branch_true_pdg_formula = v
 
     @property
-    def branch_monte_carlo_weight_formula(self):
-        return self._branch_monte_carlo_weight_formula
-        
-    @branch_monte_carlo_weight_formula.setter
-    def branch_monte_carlo_weight_formula(self, v):
-        if not isinstance(v, profit.pylib.DataFrameFormula): 
-            raise ValueError("BranchVarible.branch_monte_carlo_weight_formula must be set to profit.DataFrameFormula")
-        self._branch_monte_carlo_weight_formula = v
+    def branch_weight_formulas(self):
+        return self._branch_weight_formulas
+
+    @branch_weight_formulas.setter
+    def branch_weight_formulas(self, v):
+        if not isinstance(v, list):
+            raise ValueError("BranchVariable.branch_weight_formulas must be set to a list of profit.DataFrameFormula")
+        self._branch_weight_formulas = v
+
+    def add_weight_formula(self, v):
+        if not isinstance(v, profit.pylib.DataFrameFormula):
+            raise ValueError("Weight formula must be a profit.DataFrameFormula")
+        self._branch_weight_formulas.append(v)
 
     # Override BranchVariable::GetValue to use local DataFrameFormula
     def GetValue(self):
@@ -108,29 +112,23 @@ class BranchVariable(profit._profit.BranchVariable):
 
         return self.branch_true_pdg_formula.EvalInstance()
 
-    @property
-    def branch_xs_weight_formula(self):
-        return self._branch_xs_weight_formula
+    # Override BranchVariable::GetWeight to use local DataFrameFormula
+    # Returns the weight at 0-based index i. Default to 1 if out of range.
+    def GetWeight(self, i):
+        if i >= 0 and i < len(self._branch_weight_formulas) and self._branch_weight_formulas[i] is not None:
+            return self._branch_weight_formulas[i].EvalInstance()
+        return 1
 
-    @branch_xs_weight_formula.setter
-    def branch_xs_weight_formula(self, v):
-        if not isinstance(v, profit.pylib.DataFrameFormula):
-            raise ValueError("BranchVarible.branch_xs_weight_formula must be set to profit.DataFrameFormula")
-        self._branch_xs_weight_formula = v
+    # Override BranchVariable::GetTotalWeight to use local DataFrameFormula
+    # Returns the product of all defined weights. Default to 1 if no weights.
+    def GetTotalWeight(self):
+        product = 1
+        for f in self._branch_weight_formulas:
+            if f is not None:
+                product = product * f.EvalInstance()
+        return product
 
-    # Override BranchVariable::GetMonteCarloWeight to use local DataFrameFormula
-    # Default to 1 instead of 0 if empty
-    def GetMonteCarloWeight(self):
-        if self.branch_monte_carlo_weight_formula is None:
-            return 1
-
-        return self.branch_monte_carlo_weight_formula.EvalInstance()
-
-    # Override BranchVariable::GetXSWeight to use local DataFrameFormula
-    # Default to 1 instead of 0 if empty
-    def GetXSWeight(self):
-        if self.branch_xs_weight_formula is None:
-            return 1
-
-        return self.branch_xs_weight_formula.EvalInstance()
+    # Get number of defined weights
+    def NumWeights(self):
+        return len(self._branch_weight_formulas)
 

--- a/profit/process.py
+++ b/profit/process.py
@@ -183,8 +183,9 @@ def process_branch(c, branch, evws, mcpot, subchannel_index, syst_vector, syst_a
     # Compute individual weight values for include_only_weights support
     num_weights = branch.NumWeights()
     weight_vals = [branch.GetWeight(wi) for wi in range(num_weights)]
+    pot_scale = c.m_plot_pot / mcpot
     mc_weight = branch.GetTotalWeight()
-    mc_weight *= c.m_plot_pot / mcpot
+    mc_weight *= pot_scale
 
     if not isinstance(mc_weight, pd.Series):
         mc_weight = pd.Series(mc_weight, true_param.index)
@@ -233,22 +234,27 @@ def process_branch(c, branch, evws, mcpot, subchannel_index, syst_vector, syst_a
 
             s.FillCV(spline_bin[valid], mc_weight[valid])
             
-            # Compute correction factor for include_only_weights
-            correction = 1
+            # Compute base weight for spline universes
             if len(s.include_only_weights) > 0:
-                for wi in range(num_weights):
-                    if (wi + 1) not in s.include_only_weights:
-                        correction = correction / weight_vals[wi]
+                # Multiply only the included weights (avoids divide-by-zero)
+                included_weight = pot_scale
+                for idx in s.include_only_weights:
+                    wi = idx - 1  # convert 1-based to 0-based
+                    if 0 <= wi < num_weights:
+                        included_weight = included_weight * weight_vals[wi]
+                spline_base = included_weight
+            else:
+                spline_base = mc_weight
 
             # If force_0_cv is set, normalize shifts by the shift at knob=0
             # Note: This is also implemented in PROsyst::FillSpline for the C++ code path
             if s.force_0_cv:
                 cv_shift = evw.shift(0)
                 for i_univ, shift in enumerate(s.knobval):
-                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*correction*additional_weight*evw.shift(shift)/cv_shift)[valid])
+                    s.FillUniverse(i_univ, spline_bin[valid], (spline_base*additional_weight*evw.shift(shift)/cv_shift)[valid])
             else:
                 for i_univ, shift in enumerate(s.knobval):
-                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*correction*additional_weight*evw.shift(shift))[valid])
+                    s.FillUniverse(i_univ, spline_bin[valid], (spline_base*additional_weight*evw.shift(shift))[valid])
         else:
             s.FillCV(global_bin[valid], mc_weight[valid])
             for i_univ in range(s.GetNUniverse()):

--- a/profit/process.py
+++ b/profit/process.py
@@ -149,6 +149,9 @@ def compute_branches(fname, fid, ttree_df, c):
         if c.m_mcgen_additional_weight_bool[fid][ib]:
             c.m_branch_variables[fid][ib].branch_monte_carlo_weight_formula = profit.DataFrameFormula("branch_add_weight_%i_%i" % (fid, ib), c.m_mcgen_additional_weight_name[fid][ib], ttree_df)
 
+        if c.m_mcgen_xs_weight_bool[fid][ib]:
+            c.m_branch_variables[fid][ib].branch_xs_weight_formula = profit.DataFrameFormula("branch_xs_weight_%i_%i" % (fid, ib), c.m_mcgen_xs_weight_name[fid][ib], ttree_df)
+
 def loadsysts(fname, ttree_df, c):
     friends = []
     friend_names = []
@@ -176,7 +179,8 @@ def process_branch(c, branch, evws, mcpot, subchannel_index, syst_vector, syst_a
     true_value = baseline / true_param
     pdg_id = branch.GetTruePDG()
     run_syst = branch.GetIncludeSystematics()
-    mc_weight = branch.GetMonteCarloWeight()
+    xs_weight = branch.GetXSWeight()
+    mc_weight = branch.GetMonteCarloWeight() * xs_weight
     mc_weight *= c.m_plot_pot / mcpot
 
     if not isinstance(mc_weight, pd.Series):
@@ -231,10 +235,16 @@ def process_branch(c, branch, evws, mcpot, subchannel_index, syst_vector, syst_a
             if s.force_0_cv:
                 cv_shift = evw.shift(0)
                 for i_univ, shift in enumerate(s.knobval):
-                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/cv_shift)[valid])
+                    if s.no_xs_weight_spline:
+                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/cv_shift/xs_weight)[valid])
+                    else:
+                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/cv_shift)[valid])
             else:
                 for i_univ, shift in enumerate(s.knobval):
-                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift))[valid])
+                    if s.no_xs_weight_spline:
+                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/xs_weight)[valid])
+                    else:
+                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift))[valid])
         else:
             s.FillCV(global_bin[valid], mc_weight[valid])
             for i_univ in range(s.GetNUniverse()):

--- a/profit/process.py
+++ b/profit/process.py
@@ -146,11 +146,11 @@ def compute_branches(fname, fid, ttree_df, c):
         c.m_branch_variables[fid][ib].branch_true_value_formula = profit.DataFrameFormula("branch_true_form_%i_%i" % (fid, ib), branch.true_param_name, ttree_df)
         c.m_branch_variables[fid][ib].branch_true_pdg_formula = profit.DataFrameFormula("branch_pdg_form_%i_%i" % (fid, ib), branch.pdg_name, ttree_df)
 
-        if c.m_mcgen_additional_weight_bool[fid][ib]:
-            c.m_branch_variables[fid][ib].branch_monte_carlo_weight_formula = profit.DataFrameFormula("branch_add_weight_%i_%i" % (fid, ib), c.m_mcgen_additional_weight_name[fid][ib], ttree_df)
-
-        if c.m_mcgen_xs_weight_bool[fid][ib]:
-            c.m_branch_variables[fid][ib].branch_xs_weight_formula = profit.DataFrameFormula("branch_xs_weight_%i_%i" % (fid, ib), c.m_mcgen_xs_weight_name[fid][ib], ttree_df)
+        weight_formulas = []
+        for wi in range(c.m_mcgen_num_weights[fid][ib]):
+            wname = c.m_mcgen_weight_names[fid][ib][wi]
+            weight_formulas.append(profit.DataFrameFormula("branch_weight_%i_%i_%i" % (wi+1, fid, ib), wname, ttree_df))
+        c.m_branch_variables[fid][ib].branch_weight_formulas = weight_formulas
 
 def loadsysts(fname, ttree_df, c):
     friends = []
@@ -179,8 +179,11 @@ def process_branch(c, branch, evws, mcpot, subchannel_index, syst_vector, syst_a
     true_value = baseline / true_param
     pdg_id = branch.GetTruePDG()
     run_syst = branch.GetIncludeSystematics()
-    xs_weight = branch.GetXSWeight()
-    mc_weight = branch.GetMonteCarloWeight() * xs_weight
+
+    # Compute individual weight values for include_only_weights support
+    num_weights = branch.NumWeights()
+    weight_vals = [branch.GetWeight(wi) for wi in range(num_weights)]
+    mc_weight = branch.GetTotalWeight()
     mc_weight *= c.m_plot_pot / mcpot
 
     if not isinstance(mc_weight, pd.Series):
@@ -230,21 +233,22 @@ def process_branch(c, branch, evws, mcpot, subchannel_index, syst_vector, syst_a
 
             s.FillCV(spline_bin[valid], mc_weight[valid])
             
+            # Compute correction factor for include_only_weights
+            correction = 1
+            if len(s.include_only_weights) > 0:
+                for wi in range(num_weights):
+                    if (wi + 1) not in s.include_only_weights:
+                        correction = correction / weight_vals[wi]
+
             # If force_0_cv is set, normalize shifts by the shift at knob=0
             # Note: This is also implemented in PROsyst::FillSpline for the C++ code path
             if s.force_0_cv:
                 cv_shift = evw.shift(0)
                 for i_univ, shift in enumerate(s.knobval):
-                    if s.no_xs_weight_spline:
-                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/cv_shift/xs_weight)[valid])
-                    else:
-                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/cv_shift)[valid])
+                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*correction*additional_weight*evw.shift(shift)/cv_shift)[valid])
             else:
                 for i_univ, shift in enumerate(s.knobval):
-                    if s.no_xs_weight_spline:
-                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/xs_weight)[valid])
-                    else:
-                        s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift))[valid])
+                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*correction*additional_weight*evw.shift(shift))[valid])
         else:
             s.FillCV(global_bin[valid], mc_weight[valid])
             for i_univ in range(s.GetNUniverse()):

--- a/profit/process.py
+++ b/profit/process.py
@@ -225,8 +225,16 @@ def process_branch(c, branch, evws, mcpot, subchannel_index, syst_vector, syst_a
                 pass # TODO -- implement other binning
 
             s.FillCV(spline_bin[valid], mc_weight[valid])
-            for i_univ, shift in enumerate(s.knobval):
-                s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift))[valid])
+            
+            # If force_0_cv is set, normalize shifts by the shift at knob=0
+            # Note: This is also implemented in PROsyst::FillSpline for the C++ code path
+            if s.force_0_cv:
+                cv_shift = evw.shift(0)
+                for i_univ, shift in enumerate(s.knobval):
+                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift)/cv_shift)[valid])
+            else:
+                for i_univ, shift in enumerate(s.knobval):
+                    s.FillUniverse(i_univ, spline_bin[valid], (mc_weight*additional_weight*evw.shift(shift))[valid])
         else:
             s.FillCV(global_bin[valid], mc_weight[valid])
             for i_univ in range(s.GetNUniverse()):

--- a/pybind/profit.cxx
+++ b/pybind/profit.cxx
@@ -242,8 +242,10 @@ PYBIND11_MODULE(_profit, m) {
         .def_readonly("central_value", &PROfit::BranchVariable::central_value)
         .def_property_readonly("branch_formula", 
             [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_formula.get());})
-        .def_property_readonly("branch_monte_carlo_weight_formula", 
+        .def_property_readonly("branch_monte_carlo_weight_formula",
             [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_monte_carlo_weight_formula.get());})
+        .def_property_readonly("branch_xs_weight_formula",
+            [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_xs_weight_formula.get());})
         .def_property_readonly("branch_true_value_formula", 
             [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_true_value_formula.get());})
         .def_property_readonly("branch_true_L_formula", 
@@ -315,6 +317,8 @@ PYBIND11_MODULE(_profit, m) {
         .def_readonly("m_mcgen_file_friend_treename_map",  &PROfit::PROconfig::m_mcgen_file_friend_treename_map)
         .def_readonly("m_mcgen_additional_weight_name",  &PROfit::PROconfig::m_mcgen_additional_weight_name)
         .def_readonly("m_mcgen_additional_weight_bool",  &PROfit::PROconfig::m_mcgen_additional_weight_bool)
+        .def_readonly("m_mcgen_xs_weight_name",  &PROfit::PROconfig::m_mcgen_xs_weight_name)
+        .def_readonly("m_mcgen_xs_weight_bool",  &PROfit::PROconfig::m_mcgen_xs_weight_bool)
         .def_readonly("m_branch_variables",  &PROfit::PROconfig::m_branch_variables)
         .def_readonly("m_mcgen_eventweight_branch_names",  &PROfit::PROconfig::m_mcgen_eventweight_branch_names)
         .def_readonly("m_mcgen_eventweight_branch_syst",  &PROfit::PROconfig::m_mcgen_eventweight_branch_syst)
@@ -410,7 +414,8 @@ PYBIND11_MODULE(_profit, m) {
         .def_readwrite("p_cv", &PROfit::SystStruct::p_cv)
         .def_readwrite("p_multi_spec", &PROfit::SystStruct::p_multi_spec)
         .def_readonly("index",  &PROfit::SystStruct::index)
-        .def_readwrite("force_0_cv", &PROfit::SystStruct::force_0_cv);
+        .def_readwrite("force_0_cv", &PROfit::SystStruct::force_0_cv)
+        .def_readwrite("no_xs_weight_spline", &PROfit::SystStruct::no_xs_weight_spline);
 
     // PROsyst
     py::class_<PROfit::PROsyst>(m, "PROsyst")

--- a/pybind/profit.cxx
+++ b/pybind/profit.cxx
@@ -242,11 +242,18 @@ PYBIND11_MODULE(_profit, m) {
         .def_readonly("central_value", &PROfit::BranchVariable::central_value)
         .def_property_readonly("branch_formula", 
             [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_formula.get());})
-        .def_property_readonly("branch_monte_carlo_weight_formula",
-            [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_monte_carlo_weight_formula.get());})
-        .def_property_readonly("branch_xs_weight_formula",
-            [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_xs_weight_formula.get());})
-        .def_property_readonly("branch_true_value_formula", 
+        .def_property_readonly("branch_weight_formulas",
+            [](const PROfit::BranchVariable &b) {
+                py::list result;
+                for(const auto& f : b.branch_weight_formulas) {
+                    result.append(ttreeformula_getter(f.get()));
+                }
+                return result;
+            })
+        .def("GetWeight", &PROfit::BranchVariable::GetWeight)
+        .def("GetTotalWeight", &PROfit::BranchVariable::GetTotalWeight)
+        .def("NumWeights", &PROfit::BranchVariable::NumWeights)
+        .def_property_readonly("branch_true_value_formula",
             [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_true_value_formula.get());})
         .def_property_readonly("branch_true_L_formula", 
             [](const PROfit::BranchVariable &b) {return ttreeformula_getter(b.branch_true_L_formula.get());})
@@ -315,10 +322,8 @@ PYBIND11_MODULE(_profit, m) {
         .def_readonly("m_mcgen_fake",  &PROfit::PROconfig::m_mcgen_fake)
         .def_readonly("m_mcgen_file_friend_map",  &PROfit::PROconfig::m_mcgen_file_friend_map)
         .def_readonly("m_mcgen_file_friend_treename_map",  &PROfit::PROconfig::m_mcgen_file_friend_treename_map)
-        .def_readonly("m_mcgen_additional_weight_name",  &PROfit::PROconfig::m_mcgen_additional_weight_name)
-        .def_readonly("m_mcgen_additional_weight_bool",  &PROfit::PROconfig::m_mcgen_additional_weight_bool)
-        .def_readonly("m_mcgen_xs_weight_name",  &PROfit::PROconfig::m_mcgen_xs_weight_name)
-        .def_readonly("m_mcgen_xs_weight_bool",  &PROfit::PROconfig::m_mcgen_xs_weight_bool)
+        .def_readonly("m_mcgen_weight_names",  &PROfit::PROconfig::m_mcgen_weight_names)
+        .def_readonly("m_mcgen_num_weights",  &PROfit::PROconfig::m_mcgen_num_weights)
         .def_readonly("m_branch_variables",  &PROfit::PROconfig::m_branch_variables)
         .def_readonly("m_mcgen_eventweight_branch_names",  &PROfit::PROconfig::m_mcgen_eventweight_branch_names)
         .def_readonly("m_mcgen_eventweight_branch_syst",  &PROfit::PROconfig::m_mcgen_eventweight_branch_syst)
@@ -415,7 +420,7 @@ PYBIND11_MODULE(_profit, m) {
         .def_readwrite("p_multi_spec", &PROfit::SystStruct::p_multi_spec)
         .def_readonly("index",  &PROfit::SystStruct::index)
         .def_readwrite("force_0_cv", &PROfit::SystStruct::force_0_cv)
-        .def_readwrite("no_xs_weight_spline", &PROfit::SystStruct::no_xs_weight_spline);
+        .def_readwrite("include_only_weights", &PROfit::SystStruct::include_only_weights);
 
     // PROsyst
     py::class_<PROfit::PROsyst>(m, "PROsyst")

--- a/pybind/profit.cxx
+++ b/pybind/profit.cxx
@@ -409,7 +409,8 @@ PYBIND11_MODULE(_profit, m) {
         .def_readwrite("binning", &PROfit::SystStruct::binning)
         .def_readwrite("p_cv", &PROfit::SystStruct::p_cv)
         .def_readwrite("p_multi_spec", &PROfit::SystStruct::p_multi_spec)
-        .def_readonly("index",  &PROfit::SystStruct::index);
+        .def_readonly("index",  &PROfit::SystStruct::index)
+        .def_readwrite("force_0_cv", &PROfit::SystStruct::force_0_cv);
 
     // PROsyst
     py::class_<PROfit::PROsyst>(m, "PROsyst")

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -95,20 +95,55 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         : data.Spec();
 
     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
-    collapsed_stat_covariance = ( normdata).matrix().asDiagonal();
-    inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
+    collapsed_stat_covariance = (normdata).matrix().asDiagonal();
 
-    Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - (shape_only ? data.Normalize(config,result) : data.Spec());
+    // remove rows and columns corresponding to empty data bin indices here, avoiding any nan chi2 calculations for bins with no data events
+    std::vector<Eigen::Index> non_empty_indices;
+    for (Eigen::Index i = 0; i < normdata.size(); ++i) {
+        if (normdata(i) > 0) {
+            non_empty_indices.push_back(i);
+        }
+    }
+    
+    size_t reduced_size = non_empty_indices.size();
+    if (reduced_size == 0) {
+        log<LOG_ERROR>(L"%1% || ERROR: All data bins are empty!") % __func__;
+        throw std::runtime_error("All data bins are empty in PROchi.");
+    }
+    
+    // Create reduced covariance matrices by removing empty bin rows/columns
+    Eigen::MatrixXf reduced_collapsed_full_covariance(reduced_size, reduced_size);
+    Eigen::MatrixXf reduced_collapsed_stat_covariance(reduced_size, reduced_size);
+    for (size_t i = 0; i < reduced_size; ++i) {
+        for (size_t j = 0; j < reduced_size; ++j) {
+            reduced_collapsed_full_covariance(i, j) = collapsed_full_covariance(non_empty_indices[i], non_empty_indices[j]);
+            reduced_collapsed_stat_covariance(i, j) = collapsed_stat_covariance(non_empty_indices[i], non_empty_indices[j]);
+        }
+    }
+
+    inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + reduced_collapsed_full_covariance).inverse();
+
+    // Create reduced delta vector
+    Eigen::VectorXf collapsed_mc_spec = CollapseMatrix(config, result.Spec());
+    Eigen::VectorXf delta(reduced_size);
+    for (size_t i = 0; i < reduced_size; ++i) {
+        delta(i) = collapsed_mc_spec(non_empty_indices[i]) - normdata(non_empty_indices[i]);
+    }
+    
     float pull = Pull(subvector2);
     float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
     float value = covar_portion + pull;
 
     if(std::isnan(value) || value!=value) {
-        log<LOG_ERROR>(L"%1% || ERROR: CNP chi2 is NaN (%2%). This is very bad.\n"
+        log<LOG_ERROR>(L"%1% || ERROR: PROchi chi2 is NaN (%2%). This is very bad.\n"
                 L"covar_portion: %3%\npull: %4%\ndelta: %5%\n"
                 L"mc spec: %6%\ndata spec: %7%")
             % __func__ % value % covar_portion % pull % delta % CollapseMatrix(config, result.Spec())
             % data.Spec();
+        // collapsed_stat_covariance, print diagonal
+        for (size_t i = 0; i < collapsed_stat_covariance.cols(); ++i) {
+            log<LOG_ERROR>(L"%1% || ERROR: collapsed_stat_covariance(%2%) = %3%") % __func__ % i % collapsed_stat_covariance(i,i);
+        }
         throw std::runtime_error("NANs in Chi().");
 
     }
@@ -161,9 +196,21 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
                 Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                Eigen::MatrixXf inverted_collapsed_full_covariance = (collapsed_stat_covariance + collapsed_full_covariance).inverse();
+                
+                // Reduce matrices using non_empty_indices
+                Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
+                for (size_t ii = 0; ii < reduced_size; ++ii) {
+                    for (size_t jj = 0; jj < reduced_size; ++jj) {
+                        grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
+                    }
+                }
+                Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
-                Eigen::VectorXf delta = CollapseMatrix(config,result.Spec()) - normdata;
+                Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
+                Eigen::VectorXf delta(reduced_size);
+                for (size_t ii = 0; ii < reduced_size; ++ii) {
+                    delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
+                }
                 Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                 float pull = Pull(subvector2);
                 chi2_oneside = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
@@ -195,9 +242,21 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
                     Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    Eigen::MatrixXf inverted_collapsed_full_covariance = (collapsed_stat_covariance + collapsed_full_covariance).inverse();
+                    
+                    // Reduce matrices using non_empty_indices
+                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
+                    for (size_t ii = 0; ii < reduced_size; ++ii) {
+                        for (size_t jj = 0; jj < reduced_size; ++jj) {
+                            grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
+                        }
+                    }
+                    Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
-                    Eigen::VectorXf delta = CollapseMatrix(config,result.Spec()) - normdata;
+                    Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
+                    Eigen::VectorXf delta(reduced_size);
+                    for (size_t ii = 0; ii < reduced_size; ++ii) {
+                        delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
+                    }
                     Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
                     chi2_plus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
@@ -213,9 +272,21 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
                     Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    Eigen::MatrixXf inverted_collapsed_full_covariance = (collapsed_stat_covariance + collapsed_full_covariance).inverse();
+                    
+                    // Reduce matrices using non_empty_indices
+                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
+                    for (size_t ii = 0; ii < reduced_size; ++ii) {
+                        for (size_t jj = 0; jj < reduced_size; ++jj) {
+                            grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
+                        }
+                    }
+                    Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
-                    Eigen::VectorXf delta = CollapseMatrix(config,result.Spec()) - normdata;
+                    Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
+                    Eigen::VectorXf delta(reduced_size);
+                    for (size_t ii = 0; ii < reduced_size; ++ii) {
+                        delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
+                    }
                     Eigen::VectorXf subvector2 = param_minus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
                     chi2_minus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1270,7 +1270,7 @@ void PROconfig::CalcTotalBins(){
         m_num_variable_bins_total_collapsed[io] = m_num_variable_bins_mode_block_collapsed[io] * m_num_modes;
     }
 
-    log<LOG_INFO>(L"%1% || Generating Index maps for convienance") % __func__;
+    log<LOG_INFO>(L"%1% || Generating Index maps for convenience") % __func__;
     this->generate_index_map();
 
     //some internal cals

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -838,7 +838,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(text) wt = std::string(text);
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv"};
+                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "scale"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -856,6 +856,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *prior = pAllowList->Attribute("prior");
                 const char *center = pAllowList->Attribute("center");
                 const char *force_0_cv = pAllowList->Attribute("force_0_cv");
+                const char *scale = pAllowList->Attribute("scale");
 
 
 
@@ -919,6 +920,10 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(force_0_cv && strcmp(force_0_cv, "true") == 0) {
                     m_mcgen_variation_force_0_cv[wt] = true;
                     log<LOG_INFO>(L"%1% || Parsed force_0_cv=true for systematic %2%") % __func__ % wt.c_str();
+                }
+                if(scale) {
+                    m_mcgen_variation_scale[wt] = std::strtof(scale, NULL);
+                    log<LOG_INFO>(L"%1% || Parsed scale=%2% for systematic %3%") % __func__ % m_mcgen_variation_scale[wt] % wt.c_str();
                 }
                 log<LOG_DEBUG>(L"%1% || Allowlisting variations: %2%") % __func__ % wt.c_str() ;
                 pAllowList = pAllowList->NextSiblingElement("allowlist");

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -692,10 +692,10 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 }
 
                 if(bincsyst== NULL || strcmp(bincsyst, "true") == 0){
-                    log<LOG_DEBUG>(L"%1% ||Apply systemtics to this file (default) ' @ line %2% in %3% ") % __func__ % __LINE__  % __FILE__;
+                    log<LOG_DEBUG>(L"%1% ||Apply systematics to this file (default) ' @ line %2% in %3% ") % __func__ % __LINE__  % __FILE__;
                     TEMP_eventweight_branch_syst.push_back(1);
                 }else{
-                    log<LOG_DEBUG>(L"%1% || DO NOT apply systemtics to this file (e.g for cosmics) ' @ line %2% in %3% ") % __func__ % __LINE__  % __FILE__;
+                    log<LOG_DEBUG>(L"%1% || DO NOT apply systematics to this file (e.g for cosmics) ' @ line %2% in %3% ") % __func__ % __LINE__  % __FILE__;
                     TEMP_eventweight_branch_syst.push_back(0);
                 }
 

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -838,7 +838,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(text) wt = std::string(text);
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "scale"};
+                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "no_xs_weight_spline", "scale"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -856,6 +856,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *prior = pAllowList->Attribute("prior");
                 const char *center = pAllowList->Attribute("center");
                 const char *force_0_cv = pAllowList->Attribute("force_0_cv");
+                const char *no_xs_weight_spline = pAllowList->Attribute("no_xs_weight_spline");
                 const char *scale = pAllowList->Attribute("scale");
 
 
@@ -920,6 +921,10 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(force_0_cv && strcmp(force_0_cv, "true") == 0) {
                     m_mcgen_variation_force_0_cv[wt] = true;
                     log<LOG_INFO>(L"%1% || Parsed force_0_cv=true for systematic %2%") % __func__ % wt.c_str();
+                }
+                if(no_xs_weight_spline && strcmp(no_xs_weight_spline, "true") == 0) {
+                    m_mcgen_variation_no_xs_weight_spline[wt] = true;
+                    log<LOG_INFO>(L"%1% || Parsed no_xs_weight_spline=true for systematic %2%") % __func__ % wt.c_str();
                 }
                 if(scale) {
                     m_mcgen_variation_scale[wt] = std::strtof(scale, NULL);

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -838,7 +838,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(text) wt = std::string(text);
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center"};
+                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -855,6 +855,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *tags = pAllowList->Attribute("tag");
                 const char *prior = pAllowList->Attribute("prior");
                 const char *center = pAllowList->Attribute("center");
+                const char *force_0_cv = pAllowList->Attribute("force_0_cv");
 
 
 
@@ -914,6 +915,10 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     }
                     if(begin) tags_vec.push_back(std::string(begin, c));
                     m_mcgen_variation_tags[wt] = tags_vec;
+                }
+                if(force_0_cv && strcmp(force_0_cv, "true") == 0) {
+                    m_mcgen_variation_force_0_cv[wt] = true;
+                    log<LOG_INFO>(L"%1% || Parsed force_0_cv=true for systematic %2%") % __func__ % wt.c_str();
                 }
                 log<LOG_DEBUG>(L"%1% || Allowlisting variations: %2%") % __func__ % wt.c_str() ;
                 pAllowList = pAllowList->NextSiblingElement("allowlist");

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1814,7 +1814,13 @@ ROOTFormula::ROOTFormula(const std::string &name, const std::string &formula, TT
     // split the formula at a ";" into multiple values. used to be "," but that breaks arguments
     std::string this_formula;
     while(std::getline(formula_reader, this_formula, ';')) {
-        fs.push_back(std::make_unique<TTreeFormula>(name.c_str(), this_formula.c_str(), t));
+        auto f = std::make_unique<TTreeFormula>(name.c_str(), this_formula.c_str(), t);
+        // Check if formula compiled successfully
+        if (f->GetNdim() == 0 && f->GetNcodes() == 0) {
+            log<LOG_ERROR>(L"%1% || ERROR: TTreeFormula not compiled correctly for formula: %2%") % __func__ % this_formula.c_str();
+            exit(EXIT_FAILURE);
+        }
+        fs.push_back(std::move(f));
     }
     treeNumber = -1;
 }

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -657,6 +657,8 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
             std::vector<bool> TEMP_additional_weight_bool;
             std::vector<std::string> TEMP_additional_weight_name;
+            std::vector<bool> TEMP_xs_weight_bool;
+            std::vector<std::string> TEMP_xs_weight_name;
             std::vector<std::string> TEMP_eventweight_branch_names;
             std::vector<bool> TEMP_hist_weight_bool;
             std::vector<std::string> TEMP_hist_weight_name;
@@ -665,7 +667,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
             std::vector<std::shared_ptr<BranchVariable>> TEMP_branch_variables;
             while(pBranch){
 
-                expected_attrs = {"incl_systematics","associated_subchannel","associated_systematic","central_value","eventweight_branch_name","additional_weight","model_rule"};
+                expected_attrs = {"incl_systematics","associated_subchannel","associated_systematic","central_value","eventweight_branch_name","additional_weight", "xs_weight", "model_rule"};
                 for (const tinyxml2::XMLAttribute* attr = pBranch->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -682,6 +684,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char* bcentral = pBranch->Attribute("central_value");
                 const char* bwname = pBranch->Attribute("eventweight_branch_name");
                 const char* badditional_weight = pBranch->Attribute("additional_weight");
+                const char* bxs_weight = pBranch->Attribute("xs_weight");
 
                 if(bwname== NULL){
                     //log<LOG_WARNING>(L"%1% || WARNING: No eventweight branch name passed, defaulting to 'weights' @ line %2% in %3% ") % __func__ % __LINE__  % __FILE__;
@@ -722,7 +725,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 }
 
                 //std::string chk_wei = badditional_weight;
-                if(badditional_weight == NULL || strcmp(badditional_weight, "") == 0){ 
+                if(badditional_weight == NULL || strcmp(badditional_weight, "") == 0){
                     TEMP_additional_weight_bool.push_back(0);
                     TEMP_additional_weight_name.push_back("1");
                     log<LOG_DEBUG>(L"%1% || Setting NO additional weight for branch ") % __func__  ;
@@ -731,6 +734,16 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     TEMP_additional_weight_bool.push_back(1);
                     log<LOG_DEBUG>(L"%1% || Setting an additional weight for branch using the branch %2% as a reweighting.") % __func__ % badditional_weight;
 
+                }
+
+                if(bxs_weight == NULL || strcmp(bxs_weight, "") == 0){
+                    TEMP_xs_weight_bool.push_back(0);
+                    TEMP_xs_weight_name.push_back("1");
+                    log<LOG_DEBUG>(L"%1% || Setting NO xs_weight for branch ") % __func__  ;
+                }else{
+                    TEMP_xs_weight_name.push_back(bxs_weight);
+                    TEMP_xs_weight_bool.push_back(1);
+                    log<LOG_DEBUG>(L"%1% || Setting an xs_weight for branch using the branch %2% as a reweighting.") % __func__ % bxs_weight;
                 }
 
 
@@ -818,6 +831,8 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
             m_mcgen_additional_weight_name.push_back(TEMP_additional_weight_name);
             m_mcgen_additional_weight_bool.push_back(TEMP_additional_weight_bool);
+            m_mcgen_xs_weight_name.push_back(TEMP_xs_weight_name);
+            m_mcgen_xs_weight_bool.push_back(TEMP_xs_weight_bool);
             m_branch_variables.push_back(TEMP_branch_variables);
             m_mcgen_eventweight_branch_names.push_back(TEMP_eventweight_branch_names);
             m_mcgen_eventweight_branch_syst.push_back(TEMP_eventweight_branch_syst);

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -656,10 +656,8 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
 
 
-            std::vector<bool> TEMP_additional_weight_bool;
-            std::vector<std::string> TEMP_additional_weight_name;
-            std::vector<bool> TEMP_xs_weight_bool;
-            std::vector<std::string> TEMP_xs_weight_name;
+            std::vector<std::vector<std::string>> TEMP_weight_names; // per-branch list of weight formulas
+            std::vector<int> TEMP_num_weights; // per-branch count of weights
             std::vector<std::string> TEMP_eventweight_branch_names;
             std::vector<bool> TEMP_hist_weight_bool;
             std::vector<std::string> TEMP_hist_weight_name;
@@ -668,12 +666,21 @@ int PROconfig::LoadFromXML(const std::string &filename){
             std::vector<std::shared_ptr<BranchVariable>> TEMP_branch_variables;
             while(pBranch){
 
-                expected_attrs = {"incl_systematics","associated_subchannel","associated_systematic","central_value","eventweight_branch_name","additional_weight", "xs_weight", "model_rule"};
+                expected_attrs = {"incl_systematics","associated_subchannel","associated_systematic","central_value","eventweight_branch_name","additional_weight", "model_rule"};
                 for (const tinyxml2::XMLAttribute* attr = pBranch->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
-                    if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
+                    // Allow weight_1, weight_2, ... weight_N dynamically
+                    bool is_weight_attr = (name.substr(0, 7) == "weight_" && name.size() > 7);
+                    if(is_weight_attr) {
+                        bool all_digits = true;
+                        for(size_t ci = 7; ci < name.size(); ++ci) {
+                            if(!isdigit(name[ci])) { all_digits = false; break; }
+                        }
+                        is_weight_attr = all_digits;
+                    }
+                    if (!is_weight_attr && std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
                         log<LOG_ERROR>(L"%1% || ERROR! Attribute [%2%] in the <MCFile/branch> element is not expected.") % __func__ % name.c_str()  ;
-                        log<LOG_ERROR>(L"%1% || -- Check spelling: allowed attributes are %2%") % __func__ % expected_attrs ;
+                        log<LOG_ERROR>(L"%1% || -- Check spelling: allowed attributes are %2% and weight_1, weight_2, ...") % __func__ % expected_attrs ;
                         throw std::invalid_argument(std::string("<MCfile/branch> attribute not allowed : ") + name);
                     }
                 }
@@ -685,7 +692,6 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char* bcentral = pBranch->Attribute("central_value");
                 const char* bwname = pBranch->Attribute("eventweight_branch_name");
                 const char* badditional_weight = pBranch->Attribute("additional_weight");
-                const char* bxs_weight = pBranch->Attribute("xs_weight");
 
                 if(bwname== NULL){
                     //log<LOG_WARNING>(L"%1% || WARNING: No eventweight branch name passed, defaulting to 'weights' @ line %2% in %3% ") % __func__ % __LINE__  % __FILE__;
@@ -725,26 +731,36 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
                 }
 
-                //std::string chk_wei = badditional_weight;
-                if(badditional_weight == NULL || strcmp(badditional_weight, "") == 0){
-                    TEMP_additional_weight_bool.push_back(0);
-                    TEMP_additional_weight_name.push_back("1");
-                    log<LOG_DEBUG>(L"%1% || Setting NO additional weight for branch ") % __func__  ;
-                }else{
-                    TEMP_additional_weight_name.push_back(badditional_weight);
-                    TEMP_additional_weight_bool.push_back(1);
-                    log<LOG_DEBUG>(L"%1% || Setting an additional weight for branch using the branch %2% as a reweighting.") % __func__ % badditional_weight;
-
+                // Parse generic weight attributes: weight_1, weight_2, ..., weight_N
+                // Also accept additional_weight as backwards-compatible alias for weight_1
+                std::vector<std::string> branch_weights;
+                const char* bweight_1 = pBranch->Attribute("weight_1");
+                if(bweight_1 != NULL && strcmp(bweight_1, "") != 0) {
+                    branch_weights.push_back(bweight_1);
+                } else if(badditional_weight != NULL && strcmp(badditional_weight, "") != 0) {
+                    // additional_weight is backwards-compatible alias for weight_1
+                    branch_weights.push_back(badditional_weight);
+                    log<LOG_DEBUG>(L"%1% || Using additional_weight as alias for weight_1") % __func__;
                 }
-
-                if(bxs_weight == NULL || strcmp(bxs_weight, "") == 0){
-                    TEMP_xs_weight_bool.push_back(0);
-                    TEMP_xs_weight_name.push_back("1");
-                    log<LOG_DEBUG>(L"%1% || Setting NO xs_weight for branch ") % __func__  ;
-                }else{
-                    TEMP_xs_weight_name.push_back(bxs_weight);
-                    TEMP_xs_weight_bool.push_back(1);
-                    log<LOG_DEBUG>(L"%1% || Setting an xs_weight for branch using the branch %2% as a reweighting.") % __func__ % bxs_weight;
+                // Parse weight_2, weight_3, ... (weight_1 already handled above)
+                for(int wi = 2; ; ++wi) {
+                    std::string attr_name = "weight_" + std::to_string(wi);
+                    const char* wval = pBranch->Attribute(attr_name.c_str());
+                    if(wval == NULL || strcmp(wval, "") == 0) break;
+                    // If weight_1 was not set but weight_2+ exists, pad with "1" for weight_1
+                    while((int)branch_weights.size() < wi - 1) {
+                        branch_weights.push_back("1");
+                    }
+                    branch_weights.push_back(wval);
+                }
+                TEMP_weight_names.push_back(branch_weights);
+                TEMP_num_weights.push_back((int)branch_weights.size());
+                if(branch_weights.empty()) {
+                    log<LOG_DEBUG>(L"%1% || Setting NO weights for branch ") % __func__;
+                } else {
+                    for(size_t wi = 0; wi < branch_weights.size(); ++wi) {
+                        log<LOG_DEBUG>(L"%1% || Setting weight_%2% for branch: %3%") % __func__ % (wi+1) % branch_weights[wi].c_str();
+                    }
                 }
 
 
@@ -830,10 +846,8 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 pBranch = pBranch->NextSiblingElement("branch");
             }
 
-            m_mcgen_additional_weight_name.push_back(TEMP_additional_weight_name);
-            m_mcgen_additional_weight_bool.push_back(TEMP_additional_weight_bool);
-            m_mcgen_xs_weight_name.push_back(TEMP_xs_weight_name);
-            m_mcgen_xs_weight_bool.push_back(TEMP_xs_weight_bool);
+            m_mcgen_weight_names.push_back(TEMP_weight_names);
+            m_mcgen_num_weights.push_back(TEMP_num_weights);
             m_branch_variables.push_back(TEMP_branch_variables);
             m_mcgen_eventweight_branch_names.push_back(TEMP_eventweight_branch_names);
             m_mcgen_eventweight_branch_syst.push_back(TEMP_eventweight_branch_syst);
@@ -854,7 +868,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(text) wt = std::string(text);
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "no_xs_weight_spline", "scale"};
+                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -872,7 +886,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *prior = pAllowList->Attribute("prior");
                 const char *center = pAllowList->Attribute("center");
                 const char *force_0_cv = pAllowList->Attribute("force_0_cv");
-                const char *no_xs_weight_spline = pAllowList->Attribute("no_xs_weight_spline");
+                const char *include_only_weights_str = pAllowList->Attribute("include_only_weights");
                 const char *scale = pAllowList->Attribute("scale");
 
 
@@ -938,9 +952,19 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     m_mcgen_variation_force_0_cv[wt] = true;
                     log<LOG_INFO>(L"%1% || Parsed force_0_cv=true for systematic %2%") % __func__ % wt.c_str();
                 }
-                if(no_xs_weight_spline && strcmp(no_xs_weight_spline, "true") == 0) {
-                    m_mcgen_variation_no_xs_weight_spline[wt] = true;
-                    log<LOG_INFO>(L"%1% || Parsed no_xs_weight_spline=true for systematic %2%") % __func__ % wt.c_str();
+                if(include_only_weights_str) {
+                    std::vector<int> iow_vec;
+                    const char *c = include_only_weights_str, *begin = NULL;
+                    while(*c) {
+                        if(begin && (isspace(*c) || *c == ',')) {
+                            iow_vec.push_back(atoi(begin));
+                            begin = NULL;
+                        } else if(!begin && !isspace(*c) && *c != ',') begin = c;
+                        ++c;
+                    }
+                    if(begin) iow_vec.push_back(atoi(begin));
+                    m_mcgen_variation_include_only_weights[wt] = iow_vec;
+                    log<LOG_INFO>(L"%1% || Parsed include_only_weights for systematic %2%: %3% entries") % __func__ % wt.c_str() % iow_vec.size();
                 }
                 if(scale) {
                     m_mcgen_variation_scale[wt] = std::strtof(scale, NULL);
@@ -1540,8 +1564,8 @@ void PROconfig::remove_unused_files(){
         std::vector<bool> temp_fake;
         std::map<std::string,std::vector<std::string>> temp_file_friend_map;
         std::map<std::string,std::vector<std::string>> temp_file_friend_treename_map;
-        std::vector<std::vector<std::string>> temp_additional_weight_name;
-        std::vector<std::vector<bool>> temp_additional_weight_bool;
+        std::vector<std::vector<std::vector<std::string>>> temp_weight_names;
+        std::vector<std::vector<int>> temp_num_weights;
         std::vector<std::vector<std::shared_ptr<BranchVariable>>> temp_branch_variables;
         std::vector<std::vector<std::string>> temp_eventweight_branch_names;
         std::vector<std::vector<int>> temp_eventweight_branch_syst;
@@ -1550,8 +1574,8 @@ void PROconfig::remove_unused_files(){
             log<LOG_DEBUG>(L"%1% || Check on @%2% th file: %3%...") % __func__ % i % m_mcgen_file_name[i].c_str();
             bool this_file_needed = false;
 
-            std::vector<std::string> this_file_additional_weight_name;
-            std::vector<bool> this_file_additional_weight_bool;
+            std::vector<std::vector<std::string>> this_file_weight_names;
+            std::vector<int> this_file_num_weights;
             std::vector<std::shared_ptr<BranchVariable>> this_file_branch_variables;
             std::vector<std::string> this_file_eventweight_branch_names;
             std::vector<int> this_file_eventweight_branch_syst;
@@ -1563,8 +1587,8 @@ void PROconfig::remove_unused_files(){
                     set_all_names.erase(m_branch_variables[i][j]->associated_hist);
                     this_file_needed = true;
 
-                    this_file_additional_weight_name.push_back(m_mcgen_additional_weight_name[i][j]);
-                    this_file_additional_weight_bool.push_back(m_mcgen_additional_weight_bool[i][j]);
+                    this_file_weight_names.push_back(m_mcgen_weight_names[i][j]);
+                    this_file_num_weights.push_back(m_mcgen_num_weights[i][j]);
                     this_file_branch_variables.push_back(m_branch_variables[i][j]);
                     this_file_eventweight_branch_names.push_back(m_mcgen_eventweight_branch_names[i][j]);
                     this_file_eventweight_branch_syst.push_back(m_mcgen_eventweight_branch_syst[i][j]);
@@ -1583,8 +1607,8 @@ void PROconfig::remove_unused_files(){
                 temp_file_friend_map[m_mcgen_file_name[i]] = m_mcgen_file_friend_map[m_mcgen_file_name[i]];		
                 temp_file_friend_treename_map[m_mcgen_file_name[i]] = m_mcgen_file_friend_treename_map[m_mcgen_file_name[i]];
 
-                temp_additional_weight_name.push_back(this_file_additional_weight_name);
-                temp_additional_weight_bool.push_back(this_file_additional_weight_bool);
+                temp_weight_names.push_back(this_file_weight_names);
+                temp_num_weights.push_back(this_file_num_weights);
                 temp_branch_variables.push_back(this_file_branch_variables);
                 temp_eventweight_branch_names.push_back(this_file_eventweight_branch_names);
             }
@@ -1599,8 +1623,8 @@ void PROconfig::remove_unused_files(){
         m_mcgen_fake = temp_fake;
         m_mcgen_file_friend_map =temp_file_friend_map;
         m_mcgen_file_friend_treename_map = temp_file_friend_treename_map;
-        m_mcgen_additional_weight_name = temp_additional_weight_name;
-        m_mcgen_additional_weight_bool = temp_additional_weight_bool;
+        m_mcgen_weight_names = temp_weight_names;
+        m_mcgen_num_weights = temp_num_weights;
         m_branch_variables = temp_branch_variables;
         m_mcgen_eventweight_branch_names = temp_eventweight_branch_names;
         m_mcgen_eventweight_branch_syst = temp_eventweight_branch_syst;
@@ -1742,17 +1766,11 @@ void PROconfig::construct_variable_collapsing_matrices(){
         //construct the matrix by detector block
         Eigen::MatrixXf block_collapser = Eigen::MatrixXf::Zero(m_num_variable_bins_detector_block[io], m_num_variable_bins_detector_block_collapsed[io]);
 
-        log<LOG_INFO>(L"%1% || TEMP DEBUG: created block_collapser matrix with size %2% x %3%") % __func__ % m_num_variable_bins_detector_block[io] % m_num_variable_bins_detector_block_collapsed[io];
-
         size_t channel_row_start = 0, channel_col_start = 0;
         for(size_t ic =0; ic != m_num_channels; ++ic){
 
-            log<LOG_INFO>(L"%1% || TEMP DEBUG: creating channel_collapser matrix for channel %2% with size %3% x %4%") % __func__ % ic % m_num_subchannels[ic] % m_channel_variable_bins[ic][io].NBins();
-
             //first, build matrix for each channel block
             size_t total_num_bins_channel = m_num_subchannels[ic] * m_channel_variable_bins[ic][io].NBins();
-
-            log<LOG_INFO>(L"%1% || TEMP DEBUG: total_num_bins_channel: %2%") % __func__ % total_num_bins_channel;
 
             Eigen::MatrixXf channel_collapser = Eigen::MatrixXf::Zero(total_num_bins_channel, m_channel_variable_bins[ic][io].NBins());
             for(size_t col = 0; col != m_channel_variable_bins[ic][io].NBins(); ++col){
@@ -1762,17 +1780,11 @@ void PROconfig::construct_variable_collapsing_matrices(){
                 }
             }
 
-            log<LOG_INFO>(L"%1% || TEMP DEBUG: created channel_collapser matrix with size %2% x %3%") % __func__ % total_num_bins_channel % m_channel_variable_bins[ic][io].NBins();
-
             // now, copy this matrix to detector block
             block_collapser(Eigen::seqN(channel_row_start, total_num_bins_channel), Eigen::seqN(channel_col_start, m_channel_variable_bins[ic][io].NBins())) = channel_collapser;
             channel_row_start += total_num_bins_channel;
             channel_col_start += m_channel_variable_bins[ic][io].NBins();
-
-            log<LOG_INFO>(L"%1% || TEMP DEBUG: copied channel_collapser matrix to block_collapser matrix with size %2% x %3%") % __func__ % total_num_bins_channel % m_channel_variable_bins[ic][io].NBins();
         }
-
-        log<LOG_INFO>(L"%1% || TEMP DEBUG: copied all channel_collapser matrices to block_collapser matrix with size %2% x %3%") % __func__ % m_num_variable_bins_detector_block[io] % m_num_variable_bins_detector_block_collapsed[io];
 
         //okay! now stuff every detector block size_to the final collapse matrix
         for(size_t im = 0; im != m_num_modes; ++im){
@@ -1782,8 +1794,6 @@ void PROconfig::construct_variable_collapsing_matrices(){
                 variable_collapsing_matrices.back()(Eigen::seqN(row_block_start, m_num_variable_bins_detector_block[io]), Eigen::seqN(col_block_start, m_num_variable_bins_detector_block_collapsed[io])) = block_collapser;
             }
         }
-
-        log<LOG_INFO>(L"%1% || TEMP DEBUG: copied all block_collapser matrices to variable_collapsing_matrices with size %2% x %3%") % __func__ % m_num_variable_bins_total[io] % m_num_variable_bins_total_collapsed[io];
 
     }
     return;
@@ -1828,8 +1838,9 @@ uint32_t PROconfig::CalcHash() const{
             }
         }
     }
-    for (const auto& vec : m_mcgen_additional_weight_name) 
-        unique_string << vecToString(vec);
+    for (const auto& vec : m_mcgen_weight_names)
+        for (const auto& vec2 : vec)
+            unique_string << vecToString(vec2);
 
     for (const auto& vec : m_mcgen_eventweight_branch_names) 
         unique_string << vecToString(vec);

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -6,6 +6,7 @@
 #include <numeric>
 #include "TTree.h"
 #include "TTreeFormula.h"
+#include "TFriendElement.h"
 using namespace PROfit;
 
 
@@ -72,22 +73,22 @@ bool PROconfig::SameChannels(const PROconfig &one, const PROconfig &two) {
                 % __func__ % one.m_channel_names[i].c_str() % two.m_channel_names[i].c_str();
             return false;
         }
-        if(one.m_channel_variable_bins[one.i_prime][i].NBins() != two.m_channel_variable_bins[two.i_prime][i].NBins()) {
+        if(one.m_channel_variable_bins[i][one.i_prime].NBins() != two.m_channel_variable_bins[i][two.i_prime].NBins()) {
             log<LOG_WARNING>(L"%1% || Found different number of channel bins %2% vs %3%")
-                % __func__ % one.m_channel_variable_bins[one.i_prime][i].NBins() % two.m_channel_variable_bins[two.i_prime][i].NBins();
+                % __func__ % one.m_channel_variable_bins[i][one.i_prime].NBins() % two.m_channel_variable_bins[i][two.i_prime].NBins();
             return false;
         }
-        if (one.m_channel_variable_bins[one.i_prime][i].NDim() != two.m_channel_variable_bins[two.i_prime][i].NDim()) {
+        if (one.m_channel_variable_bins[i][one.i_prime].NDim() != two.m_channel_variable_bins[i][two.i_prime].NDim()) {
             log<LOG_WARNING>(L"%1% || Found different number of channel variable dimensions %2% vs %3%")
-                % __func__ % one.m_channel_variable_bins[one.i_prime][i].NDim() % two.m_channel_variable_bins[two.i_prime][i].NDim();
+                % __func__ % one.m_channel_variable_bins[i][one.i_prime].NDim() % two.m_channel_variable_bins[i][two.i_prime].NDim();
             return false;
         }
 
-        for (size_t jdim = 0; jdim < one.m_channel_variable_bins[one.i_prime][i].NDim(); jdim++) {
-            for (size_t k = 0; k < one.m_channel_variable_bins[one.i_prime][i].NBinEdgesAlong(jdim); k++) {
-                if(one.m_channel_variable_bins[one.i_prime][i].Edges(jdim)[k] != two.m_channel_variable_bins[two.i_prime][i].Edges(jdim)[k]) {
+        for (size_t jdim = 0; jdim < one.m_channel_variable_bins[i][one.i_prime].NDim(); jdim++) {
+            for (size_t k = 0; k < one.m_channel_variable_bins[i][one.i_prime].NBinEdgesAlong(jdim); k++) {
+                if(one.m_channel_variable_bins[i][one.i_prime].Edges(jdim)[k] != two.m_channel_variable_bins[i][two.i_prime].Edges(jdim)[k]) {
                     log<LOG_WARNING>(L"%1% || Found different bin edge for bin %2% in channel %3% dimension %4%. %5% vs %6%")
-                        % __func__ % k % i % jdim % one.m_channel_variable_bins[one.i_prime][i].Edges(jdim)[k] % two.m_channel_variable_bins[two.i_prime][i].Edges(jdim)[k];
+                        % __func__ % k % i % jdim % one.m_channel_variable_bins[i][one.i_prime].Edges(jdim)[k] % two.m_channel_variable_bins[i][two.i_prime].Edges(jdim)[k];
                     return false;
                 }
             }
@@ -1741,11 +1742,17 @@ void PROconfig::construct_variable_collapsing_matrices(){
         //construct the matrix by detector block
         Eigen::MatrixXf block_collapser = Eigen::MatrixXf::Zero(m_num_variable_bins_detector_block[io], m_num_variable_bins_detector_block_collapsed[io]);
 
+        log<LOG_INFO>(L"%1% || TEMP DEBUG: created block_collapser matrix with size %2% x %3%") % __func__ % m_num_variable_bins_detector_block[io] % m_num_variable_bins_detector_block_collapsed[io];
+
         size_t channel_row_start = 0, channel_col_start = 0;
         for(size_t ic =0; ic != m_num_channels; ++ic){
 
+            log<LOG_INFO>(L"%1% || TEMP DEBUG: creating channel_collapser matrix for channel %2% with size %3% x %4%") % __func__ % ic % m_num_subchannels[ic] % m_channel_variable_bins[ic][io].NBins();
+
             //first, build matrix for each channel block
             size_t total_num_bins_channel = m_num_subchannels[ic] * m_channel_variable_bins[ic][io].NBins();
+
+            log<LOG_INFO>(L"%1% || TEMP DEBUG: total_num_bins_channel: %2%") % __func__ % total_num_bins_channel;
 
             Eigen::MatrixXf channel_collapser = Eigen::MatrixXf::Zero(total_num_bins_channel, m_channel_variable_bins[ic][io].NBins());
             for(size_t col = 0; col != m_channel_variable_bins[ic][io].NBins(); ++col){
@@ -1755,11 +1762,17 @@ void PROconfig::construct_variable_collapsing_matrices(){
                 }
             }
 
+            log<LOG_INFO>(L"%1% || TEMP DEBUG: created channel_collapser matrix with size %2% x %3%") % __func__ % total_num_bins_channel % m_channel_variable_bins[ic][io].NBins();
+
             // now, copy this matrix to detector block
             block_collapser(Eigen::seqN(channel_row_start, total_num_bins_channel), Eigen::seqN(channel_col_start, m_channel_variable_bins[ic][io].NBins())) = channel_collapser;
             channel_row_start += total_num_bins_channel;
             channel_col_start += m_channel_variable_bins[ic][io].NBins();
+
+            log<LOG_INFO>(L"%1% || TEMP DEBUG: copied channel_collapser matrix to block_collapser matrix with size %2% x %3%") % __func__ % total_num_bins_channel % m_channel_variable_bins[ic][io].NBins();
         }
+
+        log<LOG_INFO>(L"%1% || TEMP DEBUG: copied all channel_collapser matrices to block_collapser matrix with size %2% x %3%") % __func__ % m_num_variable_bins_detector_block[io] % m_num_variable_bins_detector_block_collapsed[io];
 
         //okay! now stuff every detector block size_to the final collapse matrix
         for(size_t im = 0; im != m_num_modes; ++im){
@@ -1769,6 +1782,8 @@ void PROconfig::construct_variable_collapsing_matrices(){
                 variable_collapsing_matrices.back()(Eigen::seqN(row_block_start, m_num_variable_bins_detector_block[io]), Eigen::seqN(col_block_start, m_num_variable_bins_detector_block_collapsed[io])) = block_collapser;
             }
         }
+
+        log<LOG_INFO>(L"%1% || TEMP DEBUG: copied all block_collapser matrices to variable_collapsing_matrices with size %2% x %3%") % __func__ % m_num_variable_bins_total[io] % m_num_variable_bins_total_collapsed[io];
 
     }
     return;
@@ -1844,14 +1859,40 @@ ROOTFormula::ROOTFormula(const std::string &name, const std::string &formula, TT
     // split the formula at a ";" into multiple values. used to be "," but that breaks arguments
     std::string this_formula;
     while(std::getline(formula_reader, this_formula, ';')) {
+        log<LOG_DEBUG>(L"%1% || Compiling TTreeFormula '%2%' with name '%3%' on tree '%4%'") % __func__ % this_formula.c_str() % name.c_str() % t->GetName();
         auto f = std::make_unique<TTreeFormula>(name.c_str(), this_formula.c_str(), t);
+        log<LOG_DEBUG>(L"%1% || TTreeFormula compiled: GetNdim()=%2%, GetNcodes()=%3%, GetNdata()=%4%") % __func__ % f->GetNdim() % f->GetNcodes() % f->GetNdata();
         // Check if formula compiled successfully
         if (f->GetNdim() == 0 && f->GetNcodes() == 0) {
             log<LOG_ERROR>(L"%1% || ERROR: TTreeFormula not compiled correctly for formula: %2%") % __func__ % this_formula.c_str();
+            log<LOG_ERROR>(L"%1% || -- Tree name: %2%, Tree entries: %3%") % __func__ % t->GetName() % t->GetEntries();
+            // List available branches for debugging
+            log<LOG_ERROR>(L"%1% || -- Available branches in tree:") % __func__;
+            if(t->GetListOfBranches()){
+                for(int ib = 0; ib < std::min(t->GetListOfBranches()->GetEntries(), (int)50); ++ib){
+                    log<LOG_ERROR>(L"%1% ||    branch: %2%") % __func__ % t->GetListOfBranches()->At(ib)->GetName();
+                }
+                if(t->GetListOfBranches()->GetEntries() > 50){
+                    log<LOG_ERROR>(L"%1% ||    ... and %2% more branches") % __func__ % (t->GetListOfBranches()->GetEntries() - 50);
+                }
+            }
+            // List friend tree branches too
+            if(t->GetListOfFriends()){
+                for(const TObject* fr : *t->GetListOfFriends()){
+                    TTree* ftree = ((TFriendElement*)fr)->GetTree();
+                    if(ftree && ftree->GetListOfBranches()){
+                        log<LOG_ERROR>(L"%1% || -- Friend tree '%2%' branches:") % __func__ % ftree->GetName();
+                        for(int ib = 0; ib < std::min(ftree->GetListOfBranches()->GetEntries(), (int)20); ++ib){
+                            log<LOG_ERROR>(L"%1% ||    branch: %2%") % __func__ % ftree->GetListOfBranches()->At(ib)->GetName();
+                        }
+                    }
+                }
+            }
             exit(EXIT_FAILURE);
         }
         fs.push_back(std::move(f));
     }
+    log<LOG_DEBUG>(L"%1% || Successfully compiled %2% formula(s) for '%3%'") % __func__ % fs.size() % name.c_str();
     treeNumber = -1;
 }
 
@@ -1969,8 +2010,14 @@ int PROconfig::Binning::Bin(const std::vector<float> &v) const {
         size_t local_bin = pos_iter - thisbin.begin() - 1;
 
         if(pos_iter == thisbin.end() || pos_iter == thisbin.begin()){
-            log<LOG_DEBUG>(L"%1% || Value: %2% in Dim: %3% is in underflow or overflow bins, return bin of -1") % __func__ % v[i_vec] % i_vec;
-            log<LOG_DEBUG>(L"%1% || Binning has bin lower edge: %2% and bin upper edge: %3%") % __func__ % thisbin.front() % thisbin.back();
+            static int underflow_overflow_count = 0;
+            underflow_overflow_count++;
+            if(underflow_overflow_count <= 10) {
+                log<LOG_DEBUG>(L"%1% || Value: %2% in Dim: %3% is in underflow or overflow bins, return bin of -1") % __func__ % v[i_vec] % i_vec;
+                log<LOG_DEBUG>(L"%1% || Binning has bin lower edge: %2% and bin upper edge: %3%") % __func__ % thisbin.front() % thisbin.back();
+                if(underflow_overflow_count == 10)
+                    log<LOG_DEBUG>(L"%1% || (suppressing further underflow/overflow messages)") % __func__;
+            }
             return -1;
         }
 

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -413,6 +413,11 @@ namespace PROfit {
                     sv.back().SetWeightFormula(sys_weight_formula);
                     sv.back().SetMode(sys_mode);
                 }
+                // Check if scale is set for this systematic
+                if(inconfig.m_mcgen_variation_scale.find(sys_name) != inconfig.m_mcgen_variation_scale.end()) {
+                    sv.back().scale = inconfig.m_mcgen_variation_scale.at(sys_name);
+                    log<LOG_INFO>(L"%1% || Setting scale=%2% for systematic %3%") % __func__ % sv.back().scale % sys_name.c_str();
+                }
                 if(sys_mode == "spline") {
                     bool override_knobs = inconfig.m_mcgen_variation_knobval_override.find(sys_name) != inconfig.m_mcgen_variation_knobval_override.end();
                     if(!override_knobs && map_systematic_knob_vals.find(sys_name) == map_systematic_knob_vals.end()) {
@@ -938,7 +943,9 @@ namespace PROfit {
                     }
                 }
                 for(int iuni = 0; iuni < var_syst_objs.front()->GetNUniverse(); ++iuni){
-                    float sys_wei = run_syst ? additional_weight * static_cast<float>(map_iter->second->at(iuni) ) :  1.0;
+                    float raw_weight = static_cast<float>(map_iter->second->at(iuni));
+                    float scaled_weight = raw_weight * var_syst_objs.front()->scale; // apply scale factor (default 1.0)
+                    float sys_wei = run_syst ? additional_weight * scaled_weight :  1.0;
                     for(size_t io = 0; io < inconfig.m_num_variables; ++io) {
                         if(var_bin_indices[io] >= 0){
                             var_syst_objs[io]->FillUniverse(iuni, var_bin_indices[io], mc_weight * sys_wei);

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -959,9 +959,8 @@ namespace PROfit {
         int channel_group = subchannel_index / std::accumulate(inconfig.m_num_subchannels.begin(), inconfig.m_num_subchannels.end(), 0);
         int det = channel_group % inconfig.m_num_detectors;
 
-        float mc_weight = branch->GetTotalWeight() * inconfig.m_det_pot[det] / mcpot;
-
-        //log<LOG_ERROR>(L"%1% || Final mc_weight after det_pot scaling: %2%") % __func__ % mc_weight;
+        float pot_scale = inconfig.m_det_pot[det] / mcpot;
+        float mc_weight = branch->GetTotalWeight() * pot_scale;
 
         int model_rule = branch->GetModelRule();
 
@@ -1020,14 +1019,15 @@ namespace PROfit {
                     if(std::isnan(w) || std::isinf(w)) w = 1;
                     for(auto so: var_syst_objs){
                         if (!so->include_only_weights.empty()) {
-                            // Compute correction: divide out weights NOT in include_only_weights
-                            float correction = 1.0;
-                            for(int wi = 0; wi < num_weights; ++wi) {
-                                if(std::find(so->include_only_weights.begin(), so->include_only_weights.end(), wi+1) == so->include_only_weights.end()) {
-                                    correction /= weight_vals[wi];
+                            // Compute weight using only the included weights (avoids divide-by-zero)
+                            float included_weight = 1.0;
+                            for(int idx : so->include_only_weights) {
+                                int wi = idx - 1; // convert 1-based to 0-based
+                                if(wi >= 0 && wi < num_weights) {
+                                    included_weight *= weight_vals[wi];
                                 }
                             }
-                            so->FillUniverse(u, spline_bin, mc_weight * correction * additional_weight * w);
+                            so->FillUniverse(u, spline_bin, included_weight * pot_scale * additional_weight * w);
                         } else {
                             so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w);
                         }

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -75,6 +75,7 @@ namespace PROfit {
     }
 
     void SystStruct::FillUniverse(int universe, int global_bin, float event_weight){
+        
         /*
         if (event_weight < 0) {
             log<LOG_ERROR>(L"%1% || Event weight is negative with value %2% for systematic %3%") % __func__ % event_weight % systname.c_str();
@@ -82,6 +83,7 @@ namespace PROfit {
             exit(EXIT_FAILURE);
         }
         */
+        
         p_multi_spec.at(universe)->QuickFill(global_bin, event_weight);
         return;
     }
@@ -439,6 +441,11 @@ namespace PROfit {
                     if(inconfig.m_mcgen_variation_force_0_cv.find(sys_name) != inconfig.m_mcgen_variation_force_0_cv.end()) {
                         sv.back().force_0_cv = inconfig.m_mcgen_variation_force_0_cv.at(sys_name);
                         log<LOG_INFO>(L"%1% || Setting force_0_cv=true for systematic %2%") % __func__ % sys_name.c_str();
+                    }
+                    // Check if no_xs_weight_spline is set for this systematic
+                    if(inconfig.m_mcgen_variation_no_xs_weight_spline.find(sys_name) != inconfig.m_mcgen_variation_no_xs_weight_spline.end()) {
+                        sv.back().no_xs_weight_spline = inconfig.m_mcgen_variation_no_xs_weight_spline.at(sys_name);
+                        log<LOG_INFO>(L"%1% || Setting no_xs_weight_spline=true for systematic %2%") % __func__ % sys_name.c_str();
                     }
                 }
                 if(sys_mode == "flat"){
@@ -873,12 +880,16 @@ namespace PROfit {
         std::vector<BranchVariable::Value> vars = branch->GetVariables();
 
         int run_syst = branch->GetIncludeSystematics();
-        float mc_weight = branch->GetMonteCarloWeight();
+        float mc_weight_no_pot_scaling = branch->GetMonteCarloWeight();
+
+        //log<LOG_ERROR>(L"%1% || Initial mc_weight from GetMonteCarloWeight: %2%") % __func__ % mc_weight;
 
         int channel_group = subchannel_index / std::accumulate(inconfig.m_num_subchannels.begin(), inconfig.m_num_subchannels.end(), 0);
         int det = channel_group % inconfig.m_num_detectors;
 
-        mc_weight *= inconfig.m_det_pot[det] / mcpot;
+        float mc_weight = mc_weight_no_pot_scaling * inconfig.m_det_pot[det] / mcpot;
+
+        //log<LOG_ERROR>(L"%1% || Final mc_weight after det_pot scaling: %2%") % __func__ % mc_weight;
 
         int model_rule = branch->GetModelRule();
 
@@ -919,7 +930,7 @@ namespace PROfit {
             for(size_t io = 0; io < inconfig.m_num_variables; ++io)
                 var_syst_objs.push_back(&syst_vector[io][i]);
 
-            float additional_weight = syst_additional_weight.at(i);
+            float additional_weight = syst_additional_weight.at(i); // extra per-systematic weights, unrelated to the per-event additional_weight set in the xml file
             auto map_iter = eventweight_map.find(var_syst_objs.front()->GetSysName());
             int spline_bin = (var_syst_objs.front()->mode == "covariance") ? -1: var_bin_indices[var_syst_objs.front()->binning];
 
@@ -935,8 +946,12 @@ namespace PROfit {
                     
                     float w = static_cast<float>(map_iter->second->at(is));
                     if(std::isnan(w) || std::isinf(w)) w = 1;
-                    for(auto so: var_syst_objs)
-                        so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w);
+                    for(auto so: var_syst_objs){
+                        if (so->no_xs_weight_spline)
+                            so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w / mc_weight_no_pot_scaling);
+                        else
+                            so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w);
+                    }
                 }
 
                 continue;

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -135,7 +135,7 @@ namespace PROfit {
             std::vector<std::string> filesForChain;
 
             if (fn.find(".root") != std::string::npos) {
-                log<LOG_INFO>(L"%1% || Starting a (single) TCHain, loading file %2%") % __func__  % fn.c_str();
+                log<LOG_INFO>(L"%1% || Starting a (single) TChain, loading file %2%") % __func__  % fn.c_str();
                 filesForChain.push_back(useXrootD ? convertToXRootD(fn) : fn);
             }else{
 
@@ -664,6 +664,25 @@ namespace PROfit {
         time_t time_took = time(nullptr) - start_time;
         log<LOG_INFO>(L"%1% || Finish reading files, it took %2% seconds..") % __func__ % time_took;
         log<LOG_INFO>(L"%1% || DONE") %__func__ ;
+
+        // Cleanup TChain objects to avoid ROOT/Cling JIT crash during global cleanup
+        log<LOG_DEBUG>(L"%1% || Cleaning up TChain objects...") % __func__;
+        for(int fid = 0; fid < num_files; ++fid) {
+            // Delete friend chains first (they were added to main chain)
+            for(auto* friendChain : friendChains[fid]) {
+                if(friendChain) {
+                    delete friendChain;
+                }
+            }
+            friendChains[fid].clear();
+            
+            // Delete main chain
+            if(chains[fid]) {
+                delete chains[fid];
+                chains[fid] = nullptr;
+            }
+        }
+        log<LOG_DEBUG>(L"%1% || TChain cleanup complete.") % __func__;
 
         return 0;
     }

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -75,6 +75,13 @@ namespace PROfit {
     }
 
     void SystStruct::FillUniverse(int universe, int global_bin, float event_weight){
+        /*
+        if (event_weight < 0) {
+            log<LOG_ERROR>(L"%1% || Event weight is negative with value %2% for systematic %3%") % __func__ % event_weight % systname.c_str();
+            log<LOG_ERROR>(L"Terminating.");
+            exit(EXIT_FAILURE);
+        }
+        */
         p_multi_spec.at(universe)->QuickFill(global_bin, event_weight);
         return;
     }

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -261,6 +261,7 @@ namespace PROfit {
                 //}
                 int other_count = 0;
                 for(const auto &name: branch_variable->variable_names) {
+                    log<LOG_INFO>(L"%1% || Setting up variable formula for file %2%, branch %3% (%4%): %5%") % __func__ % fid % ib % branch_variable->associated_hist.c_str() % name.c_str();
                     branch_variable->branch_variable_formulas.push_back(std::make_shared<ROOTFormula>(
                         "branch_variable_form_"+std::to_string(fid) +"_" + std::to_string(ib)+"_"+std::to_string(other_count),
                         name, chains[fid]));
@@ -270,18 +271,20 @@ namespace PROfit {
 
                 //grab monte carlo weight
                 if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
+                    log<LOG_INFO>(L"%1% || Setting up additional monte carlo weight for file %2%, branch %3% (%4%): %5%") % __func__ % fid % ib % branch_variable->associated_hist.c_str() % inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
                     branch_variable->branch_monte_carlo_weight_formula = std::make_shared<ROOTFormula>(
                         "branch_add_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
                         inconfig.m_mcgen_additional_weight_name[fid][ib], chains[fid]);
-                    log<LOG_INFO>(L"%1% || Setting up additional monte carlo weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
+                    log<LOG_INFO>(L"%1% || Successfully set up additional monte carlo weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
                 }
 
                 //grab cross-section weight
                 if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
+                    log<LOG_INFO>(L"%1% || Setting up cross-section weight for file %2%, branch %3% (%4%): %5%") % __func__ % fid % ib % branch_variable->associated_hist.c_str() % inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
                     branch_variable->branch_xs_weight_formula = std::make_shared<ROOTFormula>(
                         "branch_xs_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
                         inconfig.m_mcgen_xs_weight_name[fid][ib], chains[fid]);
-                    log<LOG_INFO>(L"%1% || Setting up cross-section weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
+                    log<LOG_INFO>(L"%1% || Successfully set up cross-section weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
                 }
 
 
@@ -898,6 +901,19 @@ namespace PROfit {
             for(long int i=0; i < nevents; ++i) {
                 if(i%1000==0)	log<LOG_INFO>(L"%1% || -- uni : %2% / %3%") % __func__ % i % nevents;
                 chains[fid]->GetEntry(i);
+
+                // update the formulas to the current event (handles TChain file transitions)
+                for(int ib = 0; ib != num_branch; ++ib) {
+                    if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
+                        branches[ib]->branch_monte_carlo_weight_formula->LoadEvent(i);
+                    }
+                    if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
+                        branches[ib]->branch_xs_weight_formula->LoadEvent(i);
+                    }
+                    for(auto &b: branches[ib]->branch_variable_formulas) {
+                        b->LoadEvent(i);
+                    }
+                }
 
                 //branch loop
                 for(int ib = 0; ib != num_branch; ++ib) {

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -720,41 +720,76 @@ namespace PROfit {
 
         std::vector<long int> nentries(num_files,0);
         std::vector<float> pot_scale(num_files, 1.0);
-        std::vector<std::unique_ptr<TFile>> files(num_files);
-        std::vector<TTree*> trees(num_files,nullptr);//keep as bare pointers because of ROOT :(
+        std::vector<TChain*> chains(num_files, nullptr);
+        std::vector<std::vector<TChain*>> friendChains(num_files);
 
         for(int fid=0; fid < num_files; ++fid) {
             const auto& fn = inconfig.m_mcgen_file_name.at(fid);
 
-            files[fid] = std::make_unique<TFile>(fn.c_str(),"read");
-            trees[fid] = (TTree*)(files[fid]->Get(inconfig.m_mcgen_tree_name.at(fid).c_str()));
-            nentries[fid]= (long int)trees.at(fid)->GetEntries();
+            std::vector<std::string> filesForChain;
 
-            if(files[fid]->IsOpen()){
-                log<LOG_INFO>(L"%1% || Root file succesfully opened: %2%") % __func__  % fn.c_str();
+            if (fn.find(".root") != std::string::npos) {
+                log<LOG_INFO>(L"%1% || Starting a (single) TChain, loading file %2%") % __func__  % fn.c_str();
+                filesForChain.push_back(fn);
             }else{
-                log<LOG_ERROR>(L"%1% || Fail to open root file: %2%") % __func__  % fn.c_str();
-                exit(EXIT_FAILURE);
-            }
-            log<LOG_INFO>(L"%1% || Total Entries: %2%") % __func__ %  nentries[fid];
+                log<LOG_INFO>(L"%1% || Starting a TChain, loading from filelist %2%") % __func__  % fn.c_str();
+                std::ifstream infile(fn.c_str());
+                if (!infile) {
+                    log<LOG_ERROR>(L"%1% || Failed to open input filelist %2%") % __func__  % fn.c_str();
+                    exit(EXIT_FAILURE);
+                }
 
-            //first, grab friend trees
-            if (inconfig.m_mcgen_numfriends[fid]>0){
-                auto mcgen_file_friend_treename_iter = inconfig.m_mcgen_file_friend_treename_map.find(fn);
-                if (mcgen_file_friend_treename_iter != inconfig.m_mcgen_file_friend_treename_map.end()) {
-                    auto mcgen_file_friend_iter = inconfig.m_mcgen_file_friend_map.find(fn);
-                    if (mcgen_file_friend_iter == inconfig.m_mcgen_file_friend_map.end()) {
-                        log<LOG_ERROR>(L"%1% || Friend TTree provided but no friend file??") % __func__;
-                        log<LOG_ERROR>(L"Terminating.");
-                        exit(EXIT_FAILURE);
-                    }
-                    for(size_t k=0; k < mcgen_file_friend_treename_iter->second.size(); k++){
-                        std::string treefriendname = mcgen_file_friend_treename_iter->second.at(k);
-                        std::string treefriendfile = mcgen_file_friend_iter->second.at(k);
-                        trees[fid]->AddFriend(treefriendname.c_str(),treefriendfile.c_str());
+                std::string line;
+                while (std::getline(infile, line)) {
+                    log<LOG_INFO>(L"%1% || Loading file %2% into TChain") %__func__ % line.c_str();
+                    filesForChain.push_back(line);
+                }
+
+                infile.close();
+            }
+
+            chains[fid] = new TChain(inconfig.m_mcgen_tree_name.at(fid).c_str());
+            if (inconfig.m_mcgen_numfriends[fid] > 0) {
+                friendChains[fid].resize(inconfig.m_mcgen_numfriends[fid], nullptr);
+            }
+
+            for(auto &file: filesForChain){
+                chains[fid]->Add(file.c_str());
+
+                if (inconfig.m_mcgen_numfriends[fid] > 0) {
+                    auto mcgen_file_friend_treename_iter = inconfig.m_mcgen_file_friend_treename_map.find(fn);
+                    if (mcgen_file_friend_treename_iter != inconfig.m_mcgen_file_friend_treename_map.end()) {
+                        auto mcgen_file_friend_iter = inconfig.m_mcgen_file_friend_map.find(fn);
+                        if (mcgen_file_friend_iter == inconfig.m_mcgen_file_friend_map.end()) {
+                            log<LOG_ERROR>(L"%1% || Friend TTree provided but no friend file??") % __func__;
+                            log<LOG_ERROR>(L"Terminating.");
+                            exit(EXIT_FAILURE);
+                        }
+
+                        for (size_t k = 0; k < mcgen_file_friend_treename_iter->second.size(); k++) {
+                            std::string treefriendname = mcgen_file_friend_treename_iter->second.at(k);
+
+                            if (!friendChains[fid][k]) {
+                                friendChains[fid][k] = new TChain(treefriendname.c_str());
+                            }
+
+                            log<LOG_DEBUG>(L"%1% || Adding friend tree %2% from file %3%") % __func__ % treefriendname.c_str() % file.c_str();
+                            friendChains[fid][k]->Add(file.c_str());
+                        }
                     }
                 }
             }
+
+            // Add friend chains to main chain
+            if (inconfig.m_mcgen_numfriends[fid] > 0) {
+                for (size_t k = 0; k < friendChains[fid].size(); k++) {
+                    log<LOG_DEBUG>(L"%1% || Adding friend chain %2% to main chain %3%") % __func__ % k % fid;
+                    chains[fid]->AddFriend(friendChains[fid][k]);
+                }
+            }
+
+            nentries[fid] = (long int)chains[fid]->GetEntries();
+            log<LOG_INFO>(L"%1% || Total Entries: %2%") % __func__ %  nentries[fid];
 
             // grab branches 
             int num_branch = inconfig.m_branch_variables[fid].size();
@@ -804,7 +839,7 @@ namespace PROfit {
                 for(const auto &name: branch_variable->variable_names) {
                     branch_variable->branch_variable_formulas.push_back(std::make_shared<ROOTFormula>(
                         "branch_variabler_form_"+std::to_string(fid) +"_" + std::to_string(ib)+"_"+std::to_string(other_count),
-                        name, trees[fid]));
+                        name, chains[fid]));
                     other_count++;
                 }
 
@@ -812,7 +847,7 @@ namespace PROfit {
                 if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
                     branch_variable->branch_monte_carlo_weight_formula  =  std::make_shared<ROOTFormula>(
                         "branch_add_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
-                        inconfig.m_mcgen_additional_weight_name[fid][ib], trees[fid]);
+                        inconfig.m_mcgen_additional_weight_name[fid][ib], chains[fid]);
                     log<LOG_INFO>(L"%1% || Setting up additional monte carlo weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
                 }
 
@@ -843,7 +878,7 @@ namespace PROfit {
             // loop over all entries
             for(long int i=0; i < nevents; ++i) {
                 if(i%1000==0)	log<LOG_INFO>(L"%1% || -- uni : %2% / %3%") % __func__ % i % nevents;
-                trees[fid]->GetEntry(i);
+                chains[fid]->GetEntry(i);
 
                 //branch loop
                 for(int ib = 0; ib != num_branch; ++ib) {
@@ -868,6 +903,18 @@ namespace PROfit {
         } //end of file loop
         time_t time_took = time(nullptr) - start_time;
         log<LOG_INFO>(L"%1% || Generating data spectrum took %2% seconds..") % __func__ % time_took;
+
+        // Cleanup TChain objects
+        for(int fid = 0; fid < num_files; ++fid) {
+            for(auto* friendChain : friendChains[fid]) {
+                delete friendChain;
+            }
+            if(chains[fid]) {
+                delete chains[fid];
+                chains[fid] = nullptr;
+            }
+        }
+
         return data;
     }
 

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -276,6 +276,14 @@ namespace PROfit {
                     log<LOG_INFO>(L"%1% || Setting up additional monte carlo weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
                 }
 
+                //grab cross-section weight
+                if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
+                    branch_variable->branch_xs_weight_formula = std::make_shared<ROOTFormula>(
+                        "branch_xs_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
+                        inconfig.m_mcgen_xs_weight_name[fid][ib], chains[fid]);
+                    log<LOG_INFO>(L"%1% || Setting up cross-section weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
+                }
+
 
                 // check to make sure if its in allowlist, it IS in files
                 std::vector<std::string> allowlist_check;
@@ -637,6 +645,9 @@ namespace PROfit {
                     if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
                         branches[ib]->branch_monte_carlo_weight_formula->LoadEvent(i);
                     }
+                    if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
+                        branches[ib]->branch_xs_weight_formula->LoadEvent(i);
+                    }
                     for(auto &b: branches[ib]->branch_variable_formulas) {
                         b->LoadEvent(i);
                     }
@@ -851,6 +862,14 @@ namespace PROfit {
                     log<LOG_INFO>(L"%1% || Setting up additional monte carlo weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
                 }
 
+                //grab cross-section weight
+                if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
+                    branch_variable->branch_xs_weight_formula = std::make_shared<ROOTFormula>(
+                        "branch_xs_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
+                        inconfig.m_mcgen_xs_weight_name[fid][ib], chains[fid]);
+                    log<LOG_INFO>(L"%1% || Setting up cross-section weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
+                }
+
             } //end of branch loop
         } // end fid
 
@@ -883,7 +902,7 @@ namespace PROfit {
                 //branch loop
                 for(int ib = 0; ib != num_branch; ++ib) {
                     std::vector<BranchVariable::Value> vars = branches[ib]->GetVariables();
-                    float additional_weight = branches[ib]->GetMonteCarloWeight();
+                    float additional_weight = branches[ib]->GetMonteCarloWeight() * branches[ib]->GetXSWeight();
                     additional_weight *= pot_scale[fid];
 
                     if(additional_weight == 0) //skip on event failing cuts
@@ -927,14 +946,14 @@ namespace PROfit {
         std::vector<BranchVariable::Value> vars = branch->GetVariables();
 
         int run_syst = branch->GetIncludeSystematics();
-        float mc_weight_no_pot_scaling = branch->GetMonteCarloWeight();
+        float xs_weight_val = branch->GetXSWeight();
 
         //log<LOG_ERROR>(L"%1% || Initial mc_weight from GetMonteCarloWeight: %2%") % __func__ % mc_weight;
 
         int channel_group = subchannel_index / std::accumulate(inconfig.m_num_subchannels.begin(), inconfig.m_num_subchannels.end(), 0);
         int det = channel_group % inconfig.m_num_detectors;
 
-        float mc_weight = mc_weight_no_pot_scaling * inconfig.m_det_pot[det] / mcpot;
+        float mc_weight = branch->GetMonteCarloWeight() * xs_weight_val * inconfig.m_det_pot[det] / mcpot;
 
         //log<LOG_ERROR>(L"%1% || Final mc_weight after det_pot scaling: %2%") % __func__ % mc_weight;
 
@@ -995,7 +1014,7 @@ namespace PROfit {
                     if(std::isnan(w) || std::isinf(w)) w = 1;
                     for(auto so: var_syst_objs){
                         if (so->no_xs_weight_spline)
-                            so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w / mc_weight_no_pot_scaling);
+                            so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w / xs_weight_val);
                         else
                             so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w);
                     }

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -269,22 +269,14 @@ namespace PROfit {
                 }
 
 
-                //grab monte carlo weight
-                if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
-                    log<LOG_INFO>(L"%1% || Setting up additional monte carlo weight for file %2%, branch %3% (%4%): %5%") % __func__ % fid % ib % branch_variable->associated_hist.c_str() % inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
-                    branch_variable->branch_monte_carlo_weight_formula = std::make_shared<ROOTFormula>(
-                        "branch_add_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
-                        inconfig.m_mcgen_additional_weight_name[fid][ib], chains[fid]);
-                    log<LOG_INFO>(L"%1% || Successfully set up additional monte carlo weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
-                }
-
-                //grab cross-section weight
-                if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
-                    log<LOG_INFO>(L"%1% || Setting up cross-section weight for file %2%, branch %3% (%4%): %5%") % __func__ % fid % ib % branch_variable->associated_hist.c_str() % inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
-                    branch_variable->branch_xs_weight_formula = std::make_shared<ROOTFormula>(
-                        "branch_xs_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
-                        inconfig.m_mcgen_xs_weight_name[fid][ib], chains[fid]);
-                    log<LOG_INFO>(L"%1% || Successfully set up cross-section weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
+                //grab weight formulas (weight_1, weight_2, ...)
+                for(int wi = 0; wi < inconfig.m_mcgen_num_weights[fid][ib]; ++wi){
+                    const std::string& wname = inconfig.m_mcgen_weight_names[fid][ib][wi];
+                    log<LOG_INFO>(L"%1% || Setting up weight_%2% for file %3%, branch %4% (%5%): %6%") % __func__ % (wi+1) % fid % ib % branch_variable->associated_hist.c_str() % wname.c_str();
+                    branch_variable->branch_weight_formulas.push_back(std::make_shared<ROOTFormula>(
+                        "branch_weight_"+std::to_string(wi+1)+"_"+std::to_string(fid)+"_" + std::to_string(ib),
+                        wname, chains[fid]));
+                    log<LOG_INFO>(L"%1% || Successfully set up weight_%2% for this branch: %3%") % __func__ % (wi+1) % wname.c_str();
                 }
 
 
@@ -453,10 +445,10 @@ namespace PROfit {
                         sv.back().force_0_cv = inconfig.m_mcgen_variation_force_0_cv.at(sys_name);
                         log<LOG_INFO>(L"%1% || Setting force_0_cv=true for systematic %2%") % __func__ % sys_name.c_str();
                     }
-                    // Check if no_xs_weight_spline is set for this systematic
-                    if(inconfig.m_mcgen_variation_no_xs_weight_spline.find(sys_name) != inconfig.m_mcgen_variation_no_xs_weight_spline.end()) {
-                        sv.back().no_xs_weight_spline = inconfig.m_mcgen_variation_no_xs_weight_spline.at(sys_name);
-                        log<LOG_INFO>(L"%1% || Setting no_xs_weight_spline=true for systematic %2%") % __func__ % sys_name.c_str();
+                    // Check if include_only_weights is set for this systematic
+                    if(inconfig.m_mcgen_variation_include_only_weights.find(sys_name) != inconfig.m_mcgen_variation_include_only_weights.end()) {
+                        sv.back().include_only_weights = inconfig.m_mcgen_variation_include_only_weights.at(sys_name);
+                        log<LOG_INFO>(L"%1% || Setting include_only_weights for systematic %2% (%3% entries)") % __func__ % sys_name.c_str() % sv.back().include_only_weights.size();
                     }
                 }
                 if(sys_mode == "flat"){
@@ -651,18 +643,14 @@ namespace PROfit {
 
                 // update the branches to the current event
                 for(int ib = 0; ib != num_branch; ++ib) {
-
-                    if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
-                        branches[ib]->branch_monte_carlo_weight_formula->LoadEvent(i);
-                    }
-                    if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
-                        branches[ib]->branch_xs_weight_formula->LoadEvent(i);
+                    for(auto &wf: branches[ib]->branch_weight_formulas) {
+                        wf->LoadEvent(i);
                     }
                     for(auto &b: branches[ib]->branch_variable_formulas) {
                         b->LoadEvent(i);
                     }
                 }
-                
+
                 // Refresh the systematics loaders
                 if (chains[fid]->GetTreeNumber() != currentTreeNumber) {
                     currentTreeNumber = chains[fid]->GetTreeNumber();
@@ -864,20 +852,13 @@ namespace PROfit {
                     other_count++;
                 }
 
-                //grab monte carlo weight
-                if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
-                    branch_variable->branch_monte_carlo_weight_formula  =  std::make_shared<ROOTFormula>(
-                        "branch_add_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
-                        inconfig.m_mcgen_additional_weight_name[fid][ib], chains[fid]);
-                    log<LOG_INFO>(L"%1% || Setting up additional monte carlo weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_additional_weight_name[fid][ib].c_str();
-                }
-
-                //grab cross-section weight
-                if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
-                    branch_variable->branch_xs_weight_formula = std::make_shared<ROOTFormula>(
-                        "branch_xs_weight_"+std::to_string(fid)+"_" + std::to_string(ib),
-                        inconfig.m_mcgen_xs_weight_name[fid][ib], chains[fid]);
-                    log<LOG_INFO>(L"%1% || Setting up cross-section weight for this branch: %2%") % __func__ %  inconfig.m_mcgen_xs_weight_name[fid][ib].c_str();
+                //grab weight formulas (weight_1, weight_2, ...)
+                for(int wi = 0; wi < inconfig.m_mcgen_num_weights[fid][ib]; ++wi){
+                    const std::string& wname = inconfig.m_mcgen_weight_names[fid][ib][wi];
+                    log<LOG_INFO>(L"%1% || Setting up weight_%2% for this branch: %3%") % __func__ % (wi+1) % wname.c_str();
+                    branch_variable->branch_weight_formulas.push_back(std::make_shared<ROOTFormula>(
+                        "branch_weight_"+std::to_string(wi+1)+"_"+std::to_string(fid)+"_" + std::to_string(ib),
+                        wname, chains[fid]));
                 }
 
             } //end of branch loop
@@ -911,11 +892,8 @@ namespace PROfit {
 
                 // update the formulas to the current event (handles TChain file transitions)
                 for(int ib = 0; ib != num_branch; ++ib) {
-                    if(inconfig.m_mcgen_additional_weight_bool[fid][ib]){
-                        branches[ib]->branch_monte_carlo_weight_formula->LoadEvent(i);
-                    }
-                    if(inconfig.m_mcgen_xs_weight_bool[fid][ib]){
-                        branches[ib]->branch_xs_weight_formula->LoadEvent(i);
+                    for(auto &wf: branches[ib]->branch_weight_formulas) {
+                        wf->LoadEvent(i);
                     }
                     for(auto &b: branches[ib]->branch_variable_formulas) {
                         b->LoadEvent(i);
@@ -925,7 +903,7 @@ namespace PROfit {
                 //branch loop
                 for(int ib = 0; ib != num_branch; ++ib) {
                     std::vector<BranchVariable::Value> vars = branches[ib]->GetVariables();
-                    float additional_weight = branches[ib]->GetMonteCarloWeight() * branches[ib]->GetXSWeight();
+                    float additional_weight = branches[ib]->GetTotalWeight();
                     additional_weight *= pot_scale[fid];
 
                     if(additional_weight == 0) //skip on event failing cuts
@@ -937,9 +915,10 @@ namespace PROfit {
                     }
 
 
-                        for(size_t io = 0; io < inconfig.m_num_variables; ++io)
-                            if(var_bin_indices[io] >= 0)
-                                data[io].Fill(var_bin_indices[io], additional_weight);//from io+1
+                    for(size_t io = 0; io < inconfig.m_num_variables; ++io)
+                        if(var_bin_indices[io] >= 0)
+                            data[io].Fill(var_bin_indices[io], additional_weight);//from io+1
+                    
                 }  //end of branch loop
             } //end of entry loop
         } //end of file loop
@@ -969,14 +948,18 @@ namespace PROfit {
         std::vector<BranchVariable::Value> vars = branch->GetVariables();
 
         int run_syst = branch->GetIncludeSystematics();
-        float xs_weight_val = branch->GetXSWeight();
 
-        //log<LOG_ERROR>(L"%1% || Initial mc_weight from GetMonteCarloWeight: %2%") % __func__ % mc_weight;
+        // Compute individual weight values for potential use with include_only_weights
+        int num_weights = branch->NumWeights();
+        std::vector<float> weight_vals(num_weights);
+        for(int wi = 0; wi < num_weights; ++wi) {
+            weight_vals[wi] = branch->GetWeight(wi);
+        }
 
         int channel_group = subchannel_index / std::accumulate(inconfig.m_num_subchannels.begin(), inconfig.m_num_subchannels.end(), 0);
         int det = channel_group % inconfig.m_num_detectors;
 
-        float mc_weight = branch->GetMonteCarloWeight() * xs_weight_val * inconfig.m_det_pot[det] / mcpot;
+        float mc_weight = branch->GetTotalWeight() * inconfig.m_det_pot[det] / mcpot;
 
         //log<LOG_ERROR>(L"%1% || Final mc_weight after det_pot scaling: %2%") % __func__ % mc_weight;
 
@@ -1036,10 +1019,18 @@ namespace PROfit {
                     float w = static_cast<float>(map_iter->second->at(is));
                     if(std::isnan(w) || std::isinf(w)) w = 1;
                     for(auto so: var_syst_objs){
-                        if (so->no_xs_weight_spline)
-                            so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w / xs_weight_val);
-                        else
+                        if (!so->include_only_weights.empty()) {
+                            // Compute correction: divide out weights NOT in include_only_weights
+                            float correction = 1.0;
+                            for(int wi = 0; wi < num_weights; ++wi) {
+                                if(std::find(so->include_only_weights.begin(), so->include_only_weights.end(), wi+1) == so->include_only_weights.end()) {
+                                    correction /= weight_vals[wi];
+                                }
+                            }
+                            so->FillUniverse(u, spline_bin, mc_weight * correction * additional_weight * w);
+                        } else {
                             so->FillUniverse(u, spline_bin, mc_weight * additional_weight * w);
+                        }
                     }
                 }
 

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -423,6 +423,11 @@ namespace PROfit {
                     sv.back().knobval = sv.back().knob_index;
                     std::sort(sv.back().knobval.begin(), sv.back().knobval.end());
                     sv.back().binning = binningindex;
+                    // Check if force_0_cv is set for this systematic
+                    if(inconfig.m_mcgen_variation_force_0_cv.find(sys_name) != inconfig.m_mcgen_variation_force_0_cv.end()) {
+                        sv.back().force_0_cv = inconfig.m_mcgen_variation_force_0_cv.at(sys_name);
+                        log<LOG_INFO>(L"%1% || Setting force_0_cv=true for systematic %2%") % __func__ % sys_name.c_str();
+                    }
                 }
                 if(sys_mode == "flat"){
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a flat covariance systematic. Processing a such. ") % __func__ % sys_name.c_str();

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -633,11 +633,18 @@ namespace PROfit {
             size_t to_print = nevents > 5 ? nevents / 5 : 1;
             if(to_print>50000)to_print=50000;
             int currentTreeNumber = -1;
+            bool file_name_logged = false;
 
             for(long int i=0; i < nevents; ++i) {
                 if(i%to_print==0){
                     time_t time_passed = time(nullptr) - time_stamp;
-                    log<LOG_INFO>(L"%1% || File %2% -- uni : %3% / %4%  took %5% seconds") % __func__ % fid % i % nevents % time_passed;
+                    if(!file_name_logged){
+                        log<LOG_INFO>(L"%1% || File %2% (%6%) -- uni : %3% / %4%  took %5% seconds") % __func__ % fid % i % nevents % time_passed % fn.c_str();
+                        file_name_logged = true;
+                    }
+                    else {
+                        log<LOG_INFO>(L"%1% || File %2% -- uni : %3% / %4%  took %5% seconds") % __func__ % fid % i % nevents % time_passed;
+                    }
                     time_stamp = time(nullptr);
                 }
                 chains[fid]->GetEntry(i);

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -162,7 +162,9 @@ namespace PROfit{
                         auto fn = [coeffs](float shift) {
                             return coeffs[0] + coeffs[1] * shift + coeffs[2] * shift * shift + coeffs[3] * shift * shift * shift;
                         };
-                        fixed_pts->SetPoint(fixed_pts->GetN(), lo, fn(0));
+                        // Only plot knot points within the original knobval range (skip mirrored points for the two-universe case)
+                        if (lo >= systs.spline_lo[i])
+                            fixed_pts->SetPoint(fixed_pts->GetN(), lo, fn(0));
                         if (k == nsegs - 1)
                             fixed_pts->SetPoint(fixed_pts->GetN(), hi, fn(hi - lo));
                         float width = (hi - lo) / 20.0f;

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -1,5 +1,7 @@
 #include "PROplot.h"
 #include "TStyle.h"
+#include <cmath>
+#include <Eigen/SVD>
 
 namespace PROfit{
 
@@ -1301,12 +1303,61 @@ namespace PROfit{
         int gridCols = std::ceil(std::sqrt(nTags));
         int gridRows = std::ceil(nTags / float(gridCols));
 
-        TCanvas c("c", "Systematics Comparison", gridCols*1600, gridRows*1200);  
+        TCanvas c("c", "Systematics Comparison", 1600, 1200);  
         c.Print((filename+"[").c_str());
         c.Divide(gridCols, gridRows);
 
-        Eigen::MatrixXf diag = spec.Spec().array().matrix().asDiagonal(); 
+        Eigen::MatrixXf diag = spec.Spec().array().matrix().asDiagonal();
         Eigen::MatrixXf collapsed_diag = CollapseMatrix(config, diag);
+
+        // Diagnostic: Check collapsed_diag for issues
+        bool has_nan = collapsed_diag.array().isNaN().any();
+        bool has_inf = collapsed_diag.array().isInf().any();
+        float min_diag = collapsed_diag.diagonal().minCoeff();
+        float max_diag = collapsed_diag.diagonal().maxCoeff();
+        log<LOG_INFO>(L"%1% || collapsed_diag diagnostics: size=%2%x%3%, has_nan=%4%, has_inf=%5%, diag_min=%6%, diag_max=%7%")
+            % __func__ % collapsed_diag.rows() % collapsed_diag.cols() % has_nan % has_inf % min_diag % max_diag;
+
+        // Check if matrix is actually diagonal (off-diagonal elements should be ~0)
+        Eigen::MatrixXf off_diag = collapsed_diag;
+        off_diag.diagonal().setZero();
+        float max_off_diag = off_diag.array().abs().maxCoeff();
+        log<LOG_INFO>(L"%1% || collapsed_diag max off-diagonal element: %2% (should be ~0 if truly diagonal)")
+            % __func__ % max_off_diag;
+
+        // Check determinant / condition for invertibility
+        Eigen::JacobiSVD<Eigen::MatrixXf> svd(collapsed_diag);
+        float cond_number = svd.singularValues()(0) / svd.singularValues()(svd.singularValues().size()-1);
+        float min_singular = svd.singularValues().minCoeff();
+        log<LOG_INFO>(L"%1% || collapsed_diag condition number: %2%, min singular value: %3%")
+            % __func__ % cond_number % min_singular;
+
+        if (min_singular < 1e-10) {
+            log<LOG_ERROR>(L"%1% || WARNING: collapsed_diag is nearly singular (min singular value = %2%). Matrix inverse will be unreliable!")
+                % __func__ % min_singular;
+        }
+
+        // adding 1e-6 to diagonal entries that are zero, to make the matrix invertible when there are zero-uncertainty bins
+        // logging a warning in each of these cases.
+        for (size_t i = 0; i < collapsed_diag.rows(); ++i) {
+            if (collapsed_diag(i,i) == 0) {
+                log<LOG_WARNING>(L"%1% || WARNING: collapsed_diag(i,i) is zero for bin %2%! Adding 1e-6 to make the matrix invertible.")
+                    % __func__ % i;
+                collapsed_diag(i,i) = 1e-6;
+            }
+        }
+
+        // Compute inverse and check it
+        Eigen::MatrixXf collapsed_diag_inv = collapsed_diag.inverse();
+        bool inv_has_nan = collapsed_diag_inv.array().isNaN().any();
+        bool inv_has_inf = collapsed_diag_inv.array().isInf().any();
+        float inv_max = collapsed_diag_inv.array().abs().maxCoeff();
+        log<LOG_INFO>(L"%1% || collapsed_diag inverse diagnostics: has_nan=%2%, has_inf=%3%, max_abs=%4%")
+            % __func__ % inv_has_nan % inv_has_inf % inv_max;
+
+        if (inv_has_nan || inv_has_inf) {
+            log<LOG_ERROR>(L"%1% || FATAL: collapsed_diag.inverse() contains NaN or Inf! This will cause empty plots.") % __func__;
+        }
 
         size_t global_channel_index = 0;
         for(size_t mode = 0; mode < config.m_num_modes; ++mode) {
@@ -1325,11 +1376,36 @@ namespace PROfit{
                     std::vector<int> channel_bins(nbins);
                     std::iota(channel_bins.begin(), channel_bins.end(), binstart);
 
+                    // Diagnostic: Check bin_edges validity
+                    log<LOG_INFO>(L"%1% || Channel %2%: bin_edges.size()=%3%, nbins=%4%, binstart=%5%")
+                        % __func__ % global_channel_index % bin_edges.size() % nbins % binstart;
+                    if (!bin_edges.empty()) {
+                        log<LOG_INFO>(L"%1% || Channel %2%: bin_edges range [%3%, %4%]")
+                            % __func__ % global_channel_index % bin_edges.front() % bin_edges.back();
+                    }
+                    if (bin_edges.empty()) {
+                        log<LOG_ERROR>(L"%1% || FATAL: bin_edges is empty for channel %2%! Histogram will be invalid.")
+                            % __func__ % global_channel_index;
+                    }
+                    if (bin_edges.size() != nbins + 1) {
+                        log<LOG_ERROR>(L"%1% || WARNING: bin_edges.size() (%2%) != nbins+1 (%3%) for channel %4%")
+                            % __func__ % bin_edges.size() % (nbins + 1) % global_channel_index;
+                    }
+                    log<LOG_INFO>(L"%1% || Channel %2%: gridCols=%3%, gridRows=%4%, nTags=%5%")
+                        % __func__ % global_channel_index % gridCols % gridRows % nTags;
+
                     std::vector<TH1F*> vsums;
                     std::vector<std::string> vnames;
                     for (const auto &[tag, vec] : used_tags) {
 
                         c.cd(padIndex++);
+                        if (!gPad) {
+                            log<LOG_ERROR>(L"%1% || FATAL: gPad is null after c.cd(%2%)! Canvas subdivision failed.")
+                                % __func__ % (padIndex-1);
+                        } else {
+                            log<LOG_INFO>(L"%1% || Pad %2%: gPad=%3%, name=%4%")
+                                % __func__ % (padIndex-1) % (void*)gPad % gPad->GetName();
+                        }
 
                         TLegend* leg = new TLegend(0.11, 0.6, 0.89, 0.89);
                         //TLegend* leg = new TLegend(0.11, 0.79, 0.89, 0.88);
@@ -1346,11 +1422,22 @@ namespace PROfit{
                             Eigen::MatrixXf frac_covariance = allsplinesyst.GrabMatrix(systname);
                             Eigen::MatrixXf full_covariance = diag*(frac_covariance)*diag;
                             Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                            Eigen::MatrixXf collapsed_frac_covariance = collapsed_diag.inverse()*collapsed_full_covariance*collapsed_diag.inverse();
+                            Eigen::MatrixXf collapsed_frac_covariance = collapsed_diag_inv*collapsed_full_covariance*collapsed_diag_inv;
 
 
                             //submatix ffractional
                             Eigen::MatrixXf channel_cov = collapsed_frac_covariance(channel_bins, channel_bins);
+
+                            // Diagnostic: Check channel_cov diagonal for bad values
+                            bool cov_has_nan = channel_cov.diagonal().array().isNaN().any();
+                            bool cov_has_inf = channel_cov.diagonal().array().isInf().any();
+                            bool cov_has_neg = (channel_cov.diagonal().array() < 0).any();
+                            float cov_diag_min = channel_cov.diagonal().minCoeff();
+                            float cov_diag_max = channel_cov.diagonal().maxCoeff();
+                            if (cov_has_nan || cov_has_inf || cov_has_neg) {
+                                log<LOG_ERROR>(L"%1% || BAD channel_cov for %2%: has_nan=%3%, has_inf=%4%, has_neg=%5%, min=%6%, max=%7%")
+                                    % __func__ % systname.c_str() % cov_has_nan % cov_has_inf % cov_has_neg % cov_diag_min % cov_diag_max;
+                            }
 
                             log<LOG_INFO>(L"%1% || Channel: %2%/%3% | Det: %4%/%5% | Mode: %6%/%7% | Tag: %8% | Syst: %9% | Bins: %10% [%11%:%12%]") 
                                 % __func__ 
@@ -1385,13 +1472,29 @@ namespace PROfit{
                         }
                         leg->AddEntry(hsum,"Sum","l");
 
+                        // Diagnostic: Check hsum for bad values before drawing
+                        bool hsum_has_bad = false;
+                        for (int bin = 1; bin <= hsum->GetNbinsX(); ++bin) {
+                            double val = hsum->GetBinContent(bin);
+                            if (std::isnan(val) || std::isinf(val)) {
+                                hsum_has_bad = true;
+                                break;
+                            }
+                        }
+                        if (hsum_has_bad) {
+                            log<LOG_ERROR>(L"%1% || FATAL: hsum histogram for tag '%2%' contains NaN or Inf values! Plot will be empty.")
+                                % __func__ % tag.c_str();
+                        }
+                        log<LOG_INFO>(L"%1% || hsum for tag '%2%': nbins=%3%, max=%4%, integral=%5%")
+                            % __func__ % tag.c_str() % hsum->GetNbinsX() % hsum->GetMaximum() % hsum->Integral();
+
                         hsum->SetXTitle(config.m_channel_plotnames[channel].c_str());
                         hsum->SetYTitle("Fractional Uncertainty");
                         hsum->SetLineColor(kBlack);
                         hsum->SetLineWidth(2);
                         hsum->SetLineStyle(1);
                         hsum->SetMinimum(0);
-                        hsum->SetStats(0);  
+                        hsum->SetStats(0);
                         hsum->Draw("HIST");
                         hsum->SetMaximum(hsum->GetMaximum()*1.7);
                         gPad->Modified();
@@ -1463,7 +1566,7 @@ namespace PROfit{
                     std::string pv = "PROfit v"+std::string(PROJECT_VERSION_STR);
                     t->DrawText(0.895, 0.945, pv.c_str()); 
 
-
+                    c.Update();
                     c.Print(filename.c_str());
                     global_channel_index++;
                 }

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -990,7 +990,7 @@ namespace PROfit{
                         xtitle = joined_title.substr(0, pos);
                         std::string ytitle2d = joined_title.erase(0, pos + del.length());
                         ratio_titles = ";"+xtitle2d+";"+rat_y_title;
-                        std::string hist_title = config.m_detector_plotnames[det]  + " "+ config.m_channel_plotnames[channel]+" CV;"+xtitle2d+";"+ytitle2d;
+                        std::string hist_title = config.m_detector_plotnames[det]  + " "+ config.m_channel_names[channel]+" CV;"+xtitle2d+";"+ytitle2d;
 
                         std::vector<float> edges_x = config.m_channel_variable_bins[channel][other_index].Edges(0);
                         std::vector<float> edges_y = config.m_channel_variable_bins[channel][other_index].Edges(1);
@@ -1102,7 +1102,7 @@ namespace PROfit{
 
                     std::vector<float> edges = config.m_channel_variable_bins[channel][other_index].Edges();
 
-                    std::string hist_titles = config.m_mode_plotnames[mode]+" "+config.m_detector_plotnames[det]  + " "+ config.m_channel_plotnames[channel]+";"+xtitle+";"+ytitle;
+                    std::string hist_titles = config.m_mode_plotnames[mode]+" "+config.m_detector_plotnames[det]  + " "+ config.m_channel_names[channel]+";"+xtitle+";"+ytitle;
                     TH1D cv_hist(("cv_hist"+std::to_string(global_channel_index)).c_str(), hist_titles.c_str(), channel_nbins_x, edges.data());
                     cv_hist.SetLineWidth(2);
 

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -796,22 +796,33 @@ namespace PROfit{
             if(data_hist){
                 for(int i = 0; i < data_hist->GetNbinsX(); ++i) {
                     float numerator = data_hist->GetBinContent(i+1);
-                    float denonminator = 
+                    float denominator = 
                         bool(opt&PlotOptions::DataMCRatio)
                         ? cv_hist->GetBinContent(i+1)
                         : bf_hist->GetBinContent(i+1);
 
-                    float rat = numerator/denonminator;
-                    if(isnan(rat)) rat = 1;
-                    ratio->SetBinError(i+1, data_hist->GetBinError(i+1)/denonminator);
+                    float rat = numerator/denominator;
+                    if(isnan(rat) || isinf(rat) || denominator == 0) rat = 1;
+                    float rat_err = (denominator != 0) ? data_hist->GetBinError(i+1)/denominator : 0;
+                    if(isnan(rat_err) || isinf(rat_err)) rat_err = 0;
+                    ratio->SetBinError(i+1, rat_err);
                     ratio->SetBinContent(i+1, rat);
                     one->SetBinContent(i+1, 1.0);
 
-                    ratio_err->SetPointEYhigh(i, ratio_err->GetErrorYhigh(i)/ratio_err->GetPointY(i));
-                    ratio_err->SetPointEYlow(i, ratio_err->GetErrorYlow(i)/ratio_err->GetPointY(i));
+                    // Avoid division by zero when normalizing error band
+                    float point_y = ratio_err->GetPointY(i);
+                    if(point_y != 0 && !isnan(point_y) && !isinf(point_y)) {
+                        ratio_err->SetPointEYhigh(i, ratio_err->GetErrorYhigh(i)/point_y);
+                        ratio_err->SetPointEYlow(i, ratio_err->GetErrorYlow(i)/point_y);
+                    } else {
+                        ratio_err->SetPointEYhigh(i, 0);
+                        ratio_err->SetPointEYlow(i, 0);
+                    }
                     ratio_err->SetPointY(i, 1.0);
-                    ymin = std::min(ymin, rat);
-                    ymax = std::max(ymax, rat);
+                    if(!isnan(rat) && !isinf(rat)) {
+                        ymin = std::min(ymin, rat);
+                        ymax = std::max(ymax, rat);
+                    }
                 }
 
                 for (int i = 0; i < ratio_err->GetN(); ++i) {
@@ -819,17 +830,31 @@ namespace PROfit{
                     y = ratio_err->GetPointY(i);
                     eyh = ratio_err->GetErrorYhigh(i);
                     eyl = ratio_err->GetErrorYlow(i);
-                    ymin = std::min(ymin, y - eyl);
-                    ymax = std::max(ymax, y + eyh);
-
+                    if(!isnan(y) && !isinf(y) && !isnan(eyh) && !isinf(eyh) && !isnan(eyl) && !isinf(eyl)) {
+                        ymin = std::min(ymin, y - eyl);
+                        ymax = std::max(ymax, y + eyh);
+                    }
                 }
             }
+            
+            // Ensure valid axis range - use defaults if no valid data
+            if(ymin >= ymax || ymin > 1e8 || ymax < -1e8) {
+                ymin = 0.5f;
+                ymax = 1.5f;
+            }
+            
             float yrange = ymax - ymin;
-            float ylow = ymin - 0.05 * yrange;  // 15% padding below
-            float yhigh = ymax + 0.05 * yrange; // 15% padding above
+            float ylow = ymin - 0.05 * yrange;  // 5% padding below
+            float yhigh = ymax + 0.05 * yrange; // 5% padding above
 
             float kmin = bounds.hasBound("ratmin") ? bounds.getBound("ratmin") : std::min(ylow,0.95f);
             float kmax = bounds.hasBound("ratmax") ? bounds.getBound("ratmax") : std::max(yhigh,1.05f);
+
+            // Final safety check to ensure kmin != kmax
+            if(kmin >= kmax) {
+                kmin = 0.5f;
+                kmax = 1.5f;
+            }
 
             one->SetMinimum(kmin);
             one->SetMaximum(kmax);

--- a/src/PROspec.cxx
+++ b/src/PROspec.cxx
@@ -17,8 +17,19 @@ PROspec PROspec::PoissonVariation(const PROspec &s, uint32_t seed) {
     PROspec newSpec(s.nbins);
 
     for(size_t i = 0; i < s.nbins; i++) {
-        std::poisson_distribution<> d(s.GetBinContent(i));
-        newSpec.Fill(i, d(gen));
+        float bin_content = s.GetBinContent(i);
+        if(bin_content < 0) {
+            log<LOG_ERROR>(L"%1% || Cannot perform Poisson variation: bin %2% has negative content %3%. ") 
+                % __func__ % i % bin_content;
+            log<LOG_ERROR>(L"Terminating.");
+            exit(EXIT_FAILURE);
+        }
+        else if(bin_content == 0) {
+            newSpec.Fill(i, 0);
+        } else {
+            std::poisson_distribution<> d(bin_content);
+            newSpec.Fill(i, d(gen));
+        }
     }
 
     return newSpec;

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -200,9 +200,9 @@ std::vector<profOut> PROfile::PROfilePointHelper(const PROsyst *systs, const PRO
         lb = Eigen::VectorXf::Constant(nparams, -3.0);
         ub = Eigen::VectorXf::Constant(nparams, 3.0);
         size_t nphys = local_metric->GetModel().nparams;
-        // Fix physics parameters at seed values
+        // Fix physics parameters at model default values
         for(size_t j=0; j<nphys; j++){
-            float fixed_val = (seed_points.size() > 0) ? seed_points.front()(j) : 0.0f;
+            float fixed_val = local_metric->GetModel().default_val(j);
             ub(j) = fixed_val;
             lb(j) = fixed_val;
         }
@@ -867,8 +867,10 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
         // Capture w by value for the lambda
         size_t idx = w;
         plotFunctions.push_back([&, idx]() {
-            std::string xval = idx < model.nparams ? "Log_{10}(" + model.pretty_param_names[idx]+")" : "#sigma Shift";
-            std::string tit = (idx < model.nparams ? names[idx] : config.m_mcgen_variation_plotname_map.at(names[idx])) + ";" + xval + "; #Delta#Chi^{2}";
+            // Check if this is a physics param (only possible when with_osc=true)
+            bool is_physics = with_osc && idx < model.nparams;
+            std::string xval = is_physics ? "Log_{10}(" + model.pretty_param_names[idx]+")" : "#sigma Shift";
+            std::string tit = (is_physics ? names[idx] : config.m_mcgen_variation_plotname_map.at(names[idx])) + ";" + xval + "; #Delta#Chi^{2}";
             graphs[idx]->SetTitle(tit.c_str());
             graphs[idx]->Draw("AL");
             graphs[idx]->SetLineWidth(1);
@@ -884,7 +886,7 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
             line->SetLineColor(kBlack);
             line->Draw();
 
-            if(idx < model.nparams) graphs[idx]->SetLineColor(kBlue-7);
+            if(is_physics) graphs[idx]->SetLineColor(kBlue-7);
 
             if(graphs[idx]->GetN() == 1) {
                 float x_val = graphs[idx]->GetPointX(0);
@@ -894,7 +896,7 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
                 linet->SetLineColor(kGreen+2);
                 linet->Draw();
             }
-            else if(idx >= model.nparams) {
+            else if(!is_physics) {
                 gprior->Draw("L same");
                 gprior->SetLineStyle(2);
                 gprior->SetLineWidth(1);
@@ -903,8 +905,8 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
             }
         });
 
-        // Add zoomed plots for physics parameters after the last physics parameter
-        if(w == model.nparams - 1) {
+        // Add zoomed plots for physics parameters after the last physics parameter (only when physics params are included)
+        if(with_osc && w == model.nparams - 1) {
             for(int zs = model.nparams - 1; zs >= 0; zs--) {
                 size_t zoomIdx = w - zs;
                 plotFunctions.push_back([&, zoomIdx]() {
@@ -1015,11 +1017,18 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
 
     float y_min = todraw.GetMinimum();
     for (size_t i = 0; i < barvalues.size(); ++i) {
-        std::string label = i < model.nparams ? "Log_{10}(" + model.pretty_param_names[i]+")" : config.m_mcgen_variation_plotname_map.at(names[i]);
+        // In syst-only mode (with_osc=false), all entries are splines
+        // In with_osc mode, first model.nparams entries are physics, rest are splines
+        std::string label;
+        if (with_osc && i < model.nparams) {
+            label = "Log_{10}(" + model.pretty_param_names[i] + ")";
+        } else {
+            label = config.m_mcgen_variation_plotname_map.at(names[i]);
+        }
         TLatex* text = new TLatex(barvalues[i], y_min - 0.05, label.c_str());  // Position text below axis
-        text->SetTextAlign(13);  
-        text->SetTextSize(0.03); 
-        text->SetTextAngle(-45); 
+        text->SetTextAlign(13);
+        text->SetTextSize(0.03);
+        text->SetTextAngle(-45);
         text->Draw();
     }
     TText *t = new TText();
@@ -1056,27 +1065,72 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
 
 
 
+    // Get y-axis range for out-of-bounds handling
+    float y_axis_min = minVal * 1.1;
+    float y_axis_max = maxVal * 1.1;
+    float y_range = y_axis_max - y_axis_min;
+    log<LOG_INFO>(L"%1% || _1sigma plot y-axis range: min=%2%, max=%3%") % __func__ % y_axis_min % y_axis_max;
+    float arrow_margin = y_range * 0.08;  // margin from edge for out-of-range markers
+    float arrow_length = y_range * 0.06;  // length of the arrow
+
+    // Horizontal offsets to prevent marker overlap
+    float offset_blue = -0.12;   // init_seed (blue) - left
+    float offset_red = 0.0;      // true_params (red) - center
+    float offset_black = 0.12;   // best fit (black) - right
+
+    // Helper lambda to draw a marker with out-of-range arrow handling
+    auto drawMarkerWithArrow = [&](float x, float y, int color, float marker_size) {
+        bool below_range = y < y_axis_min;
+        bool above_range = y > y_axis_max;
+
+        float draw_y = y;
+        if (below_range) {
+            draw_y = y_axis_min + arrow_margin;
+        } else if (above_range) {
+            draw_y = y_axis_max - arrow_margin;
+        }
+
+        TMarker* marker = new TMarker(x, draw_y, 29);
+        marker->SetMarkerSize(marker_size);
+        marker->SetMarkerColor(color);
+        marker->Draw();
+
+        // Draw arrow if out of range
+        if (below_range) {
+            TArrow* arr = new TArrow(x, draw_y - arrow_length * 0.3, x, y_axis_min + arrow_length * 0.2, 0.008, "|>");
+            arr->SetLineColor(color);
+            arr->SetFillColor(color);
+            arr->SetLineWidth(1);
+            arr->Draw();
+        } else if (above_range) {
+            TArrow* arr = new TArrow(x, draw_y + arrow_length * 0.3, x, y_axis_max - arrow_length * 0.2, 0.008, "|>");
+            arr->SetLineColor(color);
+            arr->SetFillColor(color);
+            arr->SetLineWidth(1);
+            arr->Draw();
+        }
+    };
+
     for (int i = 0; i < nBins; ++i) {
         if(mask_osc && i < model.nparams) continue;
         // In syst-only mode, init_seed/true_params are full-size but plot indices are spline-only
         int vec_idx = with_osc ? i : (i + model.nparams);
-        TMarker* initstar = new TMarker(i+0.5, init_seed[vec_idx], 29);
-        initstar->SetMarkerSize(0.6); 
-        initstar->SetMarkerColor(kBlue); 
-        initstar->Draw();
+        float x_center = i + 0.5;
 
+        // Blue star: init_seed (best fit seed)
+        drawMarkerWithArrow(x_center + offset_blue, init_seed[vec_idx], kBlue, 0.6);
+
+        // Red star: true_params (injected truth)
         if (vec_idx < true_params.size()) {
-
-            TMarker* truestar = new TMarker(i+0.5, true_params[vec_idx], 29);
-            truestar->SetMarkerSize(0.5); 
-            truestar->SetMarkerColor(kRed); 
-            truestar->Draw();
+            if (i < 3) {  // Log first few for debugging
+                log<LOG_INFO>(L"%1% || _1sigma marker i=%2%: true_params[%3%]=%4%, below_range=%5%")
+                    % __func__ % i % vec_idx % true_params[vec_idx] % (true_params[vec_idx] < y_axis_min);
+            }
+            drawMarkerWithArrow(x_center + offset_red, true_params[vec_idx], kRed, 0.5);
         }
 
-        TMarker* star = new TMarker(i+0.5, bfvalues[i], 29);
-        star->SetMarkerSize(0.5); 
-        star->SetMarkerColor(kBlack); 
-        star->Draw();
+        // Black star: best fit value
+        drawMarkerWithArrow(x_center + offset_black, bfvalues[i], kBlack, 0.5);
     }
 
 

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -195,19 +195,34 @@ std::vector<profOut> PROfile::PROfilePointHelper(const PROsyst *systs, const PRO
             ub(j) = systs->spline_hi[j-nphys];
         }
     } else {
-        ub = Eigen::VectorXf::Map(systs->spline_hi.data(), systs->spline_hi.size());
-        lb = Eigen::VectorXf::Map(systs->spline_lo.data(), systs->spline_lo.size());
-        nparams = systs->GetNSplines();
+        // Syst-only mode: create full-size bounds but fix physics params at seed values
+        lb = Eigen::VectorXf::Constant(nparams, -3.0);
+        ub = Eigen::VectorXf::Constant(nparams, 3.0);
+        size_t nphys = local_metric->GetModel().nparams;
+        // Fix physics parameters at seed values
+        for(size_t j=0; j<nphys; j++){
+            float fixed_val = (seed_points.size() > 0) ? seed_points.front()(j) : 0.0f;
+            ub(j) = fixed_val;
+            lb(j) = fixed_val;
+        }
+        // Spline bounds as normal
+        for(int j = nphys; j < nparams; ++j) {
+            lb(j) = systs->spline_lo[j-nphys];
+            ub(j) = systs->spline_hi[j-nphys];
+        }
     }
 
+    // In syst-only mode, start loop at first spline index (nphys), not 0
+    int loop_start = with_osc ? 0 : (int)local_metric->GetModel().nparams;
+
     //loop over this threads todo list
-    for(int i=offset; i<nparams;i+=stride) {
+    for(int i=loop_start+offset; i<nparams;i+=stride) {
         tlb = lb;
         tub = ub;
 
         local_metric->reset();
 
-        size_t which_spline= i;
+        size_t which_spline = i;
         bool isphys = which_spline < local_metric->GetModel().nparams;
         profOut output;
 
@@ -1015,14 +1030,16 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
 
     for (int i = 0; i < nBins; ++i) {
         if(mask_osc && i < model.nparams) continue;
-        TMarker* initstar = new TMarker(i+0.5, init_seed[i], 29);
+        // In syst-only mode, init_seed/true_params are full-size but plot indices are spline-only
+        int vec_idx = with_osc ? i : (i + model.nparams);
+        TMarker* initstar = new TMarker(i+0.5, init_seed[vec_idx], 29);
         initstar->SetMarkerSize(0.6); 
         initstar->SetMarkerColor(kBlue); 
         initstar->Draw();
 
-        if (i < true_params.size()) {
+        if (vec_idx < true_params.size()) {
 
-            TMarker* truestar = new TMarker(i+0.5, true_params[i], 29);
+            TMarker* truestar = new TMarker(i+0.5, true_params[vec_idx], 29);
             truestar->SetMarkerSize(0.5); 
             truestar->SetMarkerColor(kRed); 
             truestar->Draw();

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -4,9 +4,10 @@
 
 #include <Eigen/Eigen>
 
-#include <cmath> 
+#include <cmath>
 #include <future>
 #include <algorithm>
+#include <functional>
 
 #include "TGraph.h"
 #include "TLatex.h"
@@ -846,108 +847,135 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
     }
     std::unique_ptr<TGraph> gprior = std::make_unique<TGraph>(priorX.size(), priorX.data(), priorY.data());
 
-    //First plot
-    int depth = std::ceil((nparams+model.nparams)/4.0);
-    TCanvas *c =  new TCanvas(filename.c_str(), filename.c_str() , 350*4, 350*depth);
-    c->Divide(4,depth);
+    //First plot - use multi-page PDF with 4 columns x 3 rows per page
+    const int nCols = 4;
+    const int nRows = 3;
+    const int plotsPerPage = nCols * nRows;
 
+    TCanvas *c = new TCanvas(filename.c_str(), filename.c_str(), 350*nCols, 350*nRows);
+    c->Divide(nCols, nRows);
 
-    size_t zoom_shift = 0;
-    for(size_t w = 0; w< graphs.size(); w++ ){
+    // Open multi-page PDF
+    c->Print((filename+".pdf[").c_str());
+
+    // First, collect all plots to draw (main plots + zoomed physics plots)
+    std::vector<std::function<void()>> plotFunctions;
+
+    for(size_t w = 0; w < graphs.size(); w++) {
         if(mask_osc && w < model.nparams) continue;
 
-        c->cd(w+1+zoom_shift);
-        std::string xval = w < model.nparams ? "Log_{10}(" + model.pretty_param_names[w]+")" :"#sigma Shift"  ;
-        std::string tit = (w < model.nparams ? names[w] :config.m_mcgen_variation_plotname_map.at(names[w]))+ ";"+xval+"; #Delta#Chi^{2}";
-        graphs[w]->SetTitle(tit.c_str());
-        graphs[w]->Draw("AL");
-        graphs[w]->SetLineWidth(2);
-        graphs[w]->GetYaxis()->SetTitleSize(0.04);             
-        graphs[w]->GetYaxis()->SetLabelSize(0.04);            
-        graphs[w]->GetXaxis()->SetTitleSize(0.04);             
-        graphs[w]->GetXaxis()->SetLabelSize(0.04);            
-        graphs[w]->GetYaxis()->SetRangeUser(0, graphs[w]->GetHistogram()->GetMaximum());
+        // Capture w by value for the lambda
+        size_t idx = w;
+        plotFunctions.push_back([&, idx]() {
+            std::string xval = idx < model.nparams ? "Log_{10}(" + model.pretty_param_names[idx]+")" : "#sigma Shift";
+            std::string tit = (idx < model.nparams ? names[idx] : config.m_mcgen_variation_plotname_map.at(names[idx])) + ";" + xval + "; #Delta#Chi^{2}";
+            graphs[idx]->SetTitle(tit.c_str());
+            graphs[idx]->Draw("AL");
+            graphs[idx]->SetLineWidth(1);
+            graphs[idx]->GetYaxis()->SetTitleSize(0.05);
+            graphs[idx]->GetYaxis()->SetLabelSize(0.04);
+            graphs[idx]->GetXaxis()->SetTitleSize(0.05);
+            graphs[idx]->GetXaxis()->SetLabelSize(0.04);
+            graphs[idx]->GetYaxis()->SetRangeUser(0, graphs[idx]->GetHistogram()->GetMaximum());
 
-        TLine* line = new TLine(graphs[w]->GetXaxis()->GetXmin(), 1, graphs[w]->GetXaxis()->GetXmax(), 1);
-        line->SetLineStyle(3);  // Dotted line style (1 is solid, 2 is dashed, 3 is dotted)
-        line->SetLineWidth(1);  // Thin line
-        line->SetLineColor(kBlack);  // Set color (black for visibility)
-        line->Draw();
+            TLine* line = new TLine(graphs[idx]->GetXaxis()->GetXmin(), 1, graphs[idx]->GetXaxis()->GetXmax(), 1);
+            line->SetLineStyle(3);
+            line->SetLineWidth(1);
+            line->SetLineColor(kBlack);
+            line->Draw();
 
-        if(w<model.nparams) graphs[w]->SetLineColor(kBlue-7);
+            if(idx < model.nparams) graphs[idx]->SetLineColor(kBlue-7);
 
-        if(graphs[w]->GetN()==1){//1 point, its been fixed. Just draw a line
-            float x_val = graphs[w]->GetPointX(0);
-            TLine* linet = new TLine(x_val, 0, x_val, 1);
-            linet->SetLineStyle(1);  // Dotted line style (1 is solid, 2 is dashed, 3 is dotted)
-            linet->SetLineWidth(2);  // Thin line
-            linet->SetLineColor(kGreen+2);  // Set color (black for visibility)
-            linet->Draw();
-        }
-        else if(w>=model.nparams){
-            gprior->Draw("L same");
-            gprior->SetLineStyle(2);
-            gprior->SetLineWidth(2);
-            gprior->SetLineColor(kRed-7);
-            graphs[w]->GetYaxis()->SetRangeUser(0, std::min(graphs[w]->GetHistogram()->GetMaximum(),10.0));
-        }
-
-
-
-        if(w==model.nparams-1){
-            //on past physics param, lets do a quick zoom, stepping back though the physics param
-            for(int zs = model.nparams-1; zs>=0; zs--){
-                c->cd(w+1+zs+1);
-                TGraph * graphClone = new TGraph(*graphs[w-zs]);
-                graphClone->Draw("AL");
-                std::string newTitle = std::string(graphClone->GetTitle()) + " Zoomed 1#sigma";
-                graphClone->SetTitle(newTitle.c_str());
-                graphClone->SetLineColor(kViolet);
-                float vd = std::min(values1_down[w-zs],values1_up[w-zs]) ;
-                float vu = std::max(values1_down[w-zs],values1_up[w-zs]) ;
-                float pd = (vd>0 ? vd*0.9 : vd*1.1);
-                float pu = (vu >0 ? vu*1.1 : vu*0.9);
-                graphClone->GetXaxis()->SetLimits(pd,pu); 
-                graphClone->GetYaxis()->SetRangeUser(0, std::max(graphClone->Eval(pu),graphClone->Eval(pd))*1.1) ;
-                graphClone->GetYaxis()->SetTitleSize(0.04);             
-                graphClone->GetYaxis()->SetLabelSize(0.04);            
-                graphClone->GetXaxis()->SetTitleSize(0.04);             
-                graphClone->GetXaxis()->SetLabelSize(0.04);            
-
-                if(graphClone->GetN()==1){//1 point, its been fixed. Just draw a line
-                    float x_val = graphClone->GetPointX(0);
-                    TLine* linet = new TLine(x_val, 0, x_val, 1);
-                    linet->SetLineStyle(1);  // Dotted line style (1 is solid, 2 is dashed, 3 is dotted)
-                    linet->SetLineWidth(2);  // Thin line
-                    linet->SetLineColor(kGreen+2);  // Set color (black for visibility)
-                    linet->Draw();
-                }
-
-                log<LOG_INFO>(L"%1% || Zoom boundaries X %2% %3% Y %4% %5%  ") % __func__ % pd % pu % 0.0 % (std::max(graphClone->Eval(pu),graphClone->Eval(pd))*1.1)  ;
-
-                TLine *line1 = new TLine(pd, 1, pu, 1);
-                line1->SetLineStyle(3);  
-                line1->SetLineWidth(1);  
-                line1->SetLineColor(kBlack); 
-                line1->Draw();
-
-                TLine* line2 = new TLine(vd, graphClone->Eval(vd) ,vd, 0);
-                line2->SetLineStyle(3);  
-                line2->SetLineWidth(1);  
-                line2->SetLineColor(kBlack); 
-                line2->Draw();
-
-                TLine *line3 = new TLine(vu, graphClone->Eval(vu) ,vu, 0);
-                line3->SetLineStyle(3);  
-                line3->SetLineWidth(1);  
-                line3->SetLineColor(kBlack); 
-                line3->Draw();
+            if(graphs[idx]->GetN() == 1) {
+                float x_val = graphs[idx]->GetPointX(0);
+                TLine* linet = new TLine(x_val, 0, x_val, 1);
+                linet->SetLineStyle(1);
+                linet->SetLineWidth(1);
+                linet->SetLineColor(kGreen+2);
+                linet->Draw();
             }
-            zoom_shift=model.nparams;
+            else if(idx >= model.nparams) {
+                gprior->Draw("L same");
+                gprior->SetLineStyle(2);
+                gprior->SetLineWidth(1);
+                gprior->SetLineColor(kRed-7);
+                graphs[idx]->GetYaxis()->SetRangeUser(0, std::min(graphs[idx]->GetHistogram()->GetMaximum(), 10.0));
+            }
+        });
+
+        // Add zoomed plots for physics parameters after the last physics parameter
+        if(w == model.nparams - 1) {
+            for(int zs = model.nparams - 1; zs >= 0; zs--) {
+                size_t zoomIdx = w - zs;
+                plotFunctions.push_back([&, zoomIdx]() {
+                    TGraph* graphClone = new TGraph(*graphs[zoomIdx]);
+                    graphClone->Draw("AL");
+                    std::string newTitle = std::string(graphClone->GetTitle()) + " Zoomed 1#sigma";
+                    graphClone->SetTitle(newTitle.c_str());
+                    graphClone->SetLineColor(kViolet);
+                    graphClone->SetLineWidth(1);
+                    float vd = std::min(values1_down[zoomIdx], values1_up[zoomIdx]);
+                    float vu = std::max(values1_down[zoomIdx], values1_up[zoomIdx]);
+                    float pd = (vd > 0 ? vd * 0.9 : vd * 1.1);
+                    float pu = (vu > 0 ? vu * 1.1 : vu * 0.9);
+                    graphClone->GetXaxis()->SetLimits(pd, pu);
+                    graphClone->GetYaxis()->SetRangeUser(0, std::max(graphClone->Eval(pu), graphClone->Eval(pd)) * 1.1);
+                    graphClone->GetYaxis()->SetTitleSize(0.05);
+                    graphClone->GetYaxis()->SetLabelSize(0.04);
+                    graphClone->GetXaxis()->SetTitleSize(0.05);
+                    graphClone->GetXaxis()->SetLabelSize(0.04);
+
+                    if(graphClone->GetN() == 1) {
+                        float x_val = graphClone->GetPointX(0);
+                        TLine* linet = new TLine(x_val, 0, x_val, 1);
+                        linet->SetLineStyle(1);
+                        linet->SetLineWidth(1);
+                        linet->SetLineColor(kGreen+2);
+                        linet->Draw();
+                    }
+
+                    log<LOG_INFO>(L"%1% || Zoom boundaries X %2% %3% Y %4% %5%  ") % __func__ % pd % pu % 0.0 % (std::max(graphClone->Eval(pu), graphClone->Eval(pd)) * 1.1);
+
+                    TLine* line1 = new TLine(pd, 1, pu, 1);
+                    line1->SetLineStyle(3);
+                    line1->SetLineWidth(1);
+                    line1->SetLineColor(kBlack);
+                    line1->Draw();
+
+                    TLine* line2 = new TLine(vd, graphClone->Eval(vd), vd, 0);
+                    line2->SetLineStyle(3);
+                    line2->SetLineWidth(1);
+                    line2->SetLineColor(kBlack);
+                    line2->Draw();
+
+                    TLine* line3 = new TLine(vu, graphClone->Eval(vu), vu, 0);
+                    line3->SetLineStyle(3);
+                    line3->SetLineWidth(1);
+                    line3->SetLineColor(kBlack);
+                    line3->Draw();
+                });
+            }
         }
     }
 
-    c->SaveAs((filename+".pdf").c_str(),"pdf");
+    // Now draw plots page by page
+    for(size_t i = 0; i < plotFunctions.size(); i++) {
+        int padIdx = (i % plotsPerPage) + 1;
+
+        // Start of a new page (except for the first plot)
+        if(i > 0 && padIdx == 1) {
+            c->Print((filename+".pdf").c_str());
+            c->Clear();
+            c->Divide(nCols, nRows);
+        }
+
+        c->cd(padIdx);
+        plotFunctions[i]();
+    }
+
+    // Print the last page and close the PDF
+    c->Print((filename+".pdf").c_str());
+    c->Print((filename+".pdf]").c_str());
 
     delete c;
 

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -563,6 +563,12 @@ void PROsyst::FillSpline(const SystStruct& syst) {
     spline.bins = nbins;
     spline.segments_per_bin = knobvals.size(); 
 
+    if(syst.knobval.size() != syst.p_multi_spec.size()){
+        log<LOG_ERROR>(L"%1% || number of knobvals specified (%2%) does not match number of weight universes in file (%3%) for systematic %4%!") % __func__ % syst.knobval.size() % syst.p_multi_spec.size() % syst.systname.c_str();
+        log<LOG_ERROR>(L"Terminating.");
+        exit(EXIT_FAILURE);
+    }
+
     std::vector<SplineSegment> all_segments;
 
     for (size_t i = 0; i < nbins; ++i) {

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -531,6 +531,13 @@ void PROsyst::FillSpline(const SystStruct& syst) {
         }
 
         float mod = shape_only ? cv_integral / syst.p_multi_spec[i]->Spec().sum() : 1.0;
+        /*
+        if (mod < 0) {
+            log<LOG_ERROR>(L"%1% || Spline shift weight is negative with value %2% for systematic %3%") % __func__ % mod % syst.systname.c_str();
+            log<LOG_ERROR>(L"Terminating.");
+            exit(EXIT_FAILURE);
+        }
+        */
         ratios.push_back(((*syst.p_multi_spec[i]) * mod) / *syst.p_cv);
         knobvals.push_back(syst.knobval[i]);
     }

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -516,14 +516,19 @@ void PROsyst::FillSpline(const SystStruct& syst) {
 
 
     bool found0 = false;
+    int knob0_index = -1;  // Index of knobval=0 in ratios vector
     std::vector<float> knobvals;
     for (size_t i = 0; i < syst.p_multi_spec.size(); ++i) {
         if (syst.knobval[i] > 0 && !found0) {
             ratios.push_back(*syst.p_cv / *syst.p_cv);
             knobvals.push_back(0);
+            knob0_index = ratios.size() - 1;
             found0 = true;
         }
-        if (syst.knobval[i] == 0) found0 = true;
+        if (syst.knobval[i] == 0) {
+            found0 = true;
+            knob0_index = ratios.size();  // Will be set after push_back below
+        }
 
         float mod = shape_only ? cv_integral / syst.p_multi_spec[i]->Spec().sum() : 1.0;
         ratios.push_back(((*syst.p_multi_spec[i]) * mod) / *syst.p_cv);
@@ -532,6 +537,18 @@ void PROsyst::FillSpline(const SystStruct& syst) {
     if (!found0) {
         ratios.push_back(*syst.p_cv / *syst.p_cv);
         knobvals.push_back(0);
+        knob0_index = ratios.size() - 1;
+    }
+
+    // If force_0_cv is set, normalize all ratios by the ratio at knob=0
+    // This ensures that at shift=0, the spline returns exactly 1.0 (no change to CV)
+    if (syst.force_0_cv && knob0_index >= 0) {
+        log<LOG_INFO>(L"%1% || Applying force_0_cv normalization for systematic %2%") % __func__ % syst.systname.c_str();
+        // IMPORTANT: Make a copy, not a reference! Otherwise we modify the divisor during the loop.
+        PROspec ratio_at_0 = ratios[knob0_index];
+        for (size_t i = 0; i < ratios.size(); ++i) {
+            ratios[i] = ratios[i] / ratio_at_0;
+        }
     }
 
     int nbins = syst.p_cv->GetNbins();

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -32,9 +32,10 @@
 </model>
 
 <!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/nu_overlay_splines_50.root, 4.1 GB -->
-<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19"> -->
+<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.692e19"> -->
 <!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/run4b_nuoverlay_retuple_splines.root, 65 GB -->
 <!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_nuoverlay_retuple_splines.root" scale = "1.0" pot="7.378e20"> -->
+
 <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.692e19">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
@@ -105,6 +106,35 @@
 
 </MCFile>
 
+<!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/run4b_dirt_surprise_200_splines.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_dirt_surprise_200_splines.root" scale = "1.0" pot="1.664e19">
+	<friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="wcpselection/T_BDTvars" />
+	<friend treename="spline_weights" />
+	<friend treename="nuselection/NeutrinoSelectionFilter" />
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_dirt"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_dirt"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+</MCFile>
+
 <!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root -->
 <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root" scale = "1.0" pot="3.874e20">
 	<friend treename="wcpselection/T_eval" />
@@ -133,39 +163,10 @@
 </MCFile>
 
 
-<!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/run4b_dirt_surprise_200_splines.root -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_dirt_surprise_200_splines.root" scale = "1.0" pot="1.664e19">
-	<friend treename="wcpselection/T_eval" />
-	<friend treename="wcpselection/T_PFeval" />
-	<friend treename="wcpselection/T_BDTvars" />
-
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCCNpFC_dirt"
-			incl_systematics      = "false"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCC0pFC_dirt"
-			incl_systematics      = "false"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-</MCFile>
-
 <variation_list>
 
     <!-- MC Statistics -->
 	<allowlist type="mcstat" plotname="MC Stats" tag="other">MCStat</allowlist>
-
 
     <!-- Cross Section Systematics, 55 splines -->
 	

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -2,7 +2,7 @@
 
 <mode name="nu" />
 
-<detector name="uBooNE" pot="4.733e19" />
+<detector name="uBooNE" pot="4.031e19" />
 
 <channel name="numuCCNpFC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
@@ -106,7 +106,7 @@
 </MCFile>
 
 <!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root" scale = "1.0" pot="1.466e20">
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root" scale = "1.0" pot="3.874e20">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
 	<friend treename="wcpselection/T_BDTvars" />

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -4,7 +4,31 @@
 
 <detector name="UBOONE" pot="4.733e19" />
 
-<channel name="numu" plotname="Reconstructed Neutrino Energy [MeV]">
+<channel name="numuCCNpFC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
+	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
+</channel>
+<channel name="numuCC0pFC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
+	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
+</channel>
+<channel name="numuCCNpPC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
+	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
+</channel>
+<channel name="numuCC0pPC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
 	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
@@ -29,11 +53,40 @@
 	<friend treename="wcpselection/T_BDTvars" />
 	<friend treename="spline_weights" />
 	<friend treename="nuselection/NeutrinoSelectionFilter" />
-
 	<branch
-        	associated_subchannel = "nu_UBOONE_numu_overlay"
+        	associated_subchannel = "nu_UBOONE_numuCCNpFC_overlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pFC_overlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+		<branch
+        	associated_subchannel = "nu_UBOONE_numuCCNpPC_overlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pPC_overlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
@@ -47,36 +100,98 @@
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
 	<friend treename="wcpselection/T_BDTvars" />
-
 	<branch
-        	associated_subchannel = "nu_UBOONE_numu_ext"
+        	associated_subchannel = "nu_UBOONE_numuCCNpFC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
+		<variable>0</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pFC_ext"
+			incl_systematics      = "false"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+		>
+		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
+		<variable>0</variable>	
+	</branch>
+		<branch
+        	associated_subchannel = "nu_UBOONE_numuCCNpPC_ext"
+			incl_systematics      = "false"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pPC_ext"
+			incl_systematics      = "false"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>	
 	</branch>
 </MCFile>
 
-<!-- TEMPORARY: No systematics for dirt file -->
-<!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_BNB_dirt_surpise_reco2_hist.root -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_BNB_dirt_surpise_reco2_hist.root" scale = "1.0" pot="4.692e19">
+
+<!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/run4b_dirt_surprise_200_splines.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_dirt_surprise_200_splines.root" scale = "1.0" pot="1.664e19">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
 	<friend treename="wcpselection/T_BDTvars" />
 
 	<branch
-        	associated_subchannel = "nu_UBOONE_numu_dirt"
+        	associated_subchannel = "nu_UBOONE_numuCCNpFC_dirt"
 			incl_systematics      = "false"
-        	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
-		<variable>0</variable>
-		<variable>0</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pFC_dirt"
+			incl_systematics      = "false"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+		<branch
+        	associated_subchannel = "nu_UBOONE_numuCCNpPC_dirt"
+			incl_systematics      = "false"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pPC_dirt"
+			incl_systematics      = "false"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 </MCFile>
 

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -64,8 +64,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpFC_numuCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -74,8 +74,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpFC_nueCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -84,8 +84,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpFC_NCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -95,8 +95,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pFC_numuCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -105,8 +105,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pFC_nueCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -115,8 +115,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pFC_NCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -126,8 +126,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpPC_numuCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -136,8 +136,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpPC_nueCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -146,8 +146,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpPC_NCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -157,8 +157,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pPC_numuCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -167,8 +167,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pPC_nueCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -177,8 +177,8 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pPC_NCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -195,7 +195,7 @@
         	associated_subchannel = "nu_uBooNE_numuCCNpFC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -205,7 +205,7 @@
         	associated_subchannel = "nu_uBooNE_numuCC0pFC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -215,7 +215,7 @@
         	associated_subchannel = "nu_uBooNE_numuCCNpPC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -225,7 +225,7 @@
         	associated_subchannel = "nu_uBooNE_numuCC0pPC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -244,8 +244,7 @@
         	associated_subchannel = "nu_uBooNE_numuCCNpFC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -255,8 +254,7 @@
         	associated_subchannel = "nu_uBooNE_numuCC0pFC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -266,8 +264,7 @@
         	associated_subchannel = "nu_uBooNE_numuCCNpPC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -277,8 +274,7 @@
         	associated_subchannel = "nu_uBooNE_numuCC0pPC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -292,86 +288,86 @@
 	<allowlist type="mcstat" plotname="MC Stats" tag="other">MCStat</allowlist>
 
 
-    <!-- Cross Section Systematics -->
+    <!-- Cross Section Systematics, 55 splines -->
 	
-	<allowlist type="spline" binning="var0" plotname="MACCQE" tag="QE" force_0_cv="true" no_xs_weight_spline="true">MaCCQE_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="AxFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" no_xs_weight_spline="true">AxFFCCQEshape_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="VecFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" no_xs_weight_spline="true">VecFFCCQEshape_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="RPA_CCQE" tag="QE" force_0_cv="true" no_xs_weight_spline="true">RPA_CCQE_UBGenie</allowlist> 
-	<allowlist type="spline" binning="var0" plotname="CoulombCCQE" tag="QE" force_0_cv="true" no_xs_weight_spline="true">CoulombCCQE_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MACCQE" tag="QE" force_0_cv="true" include_only_weights="1">MaCCQE_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AxFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" include_only_weights="1">AxFFCCQEshape_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="VecFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" include_only_weights="1">VecFFCCQEshape_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RPA_CCQE" tag="QE" force_0_cv="true" include_only_weights="1">RPA_CCQE_UBGenie</allowlist> 
+	<allowlist type="spline" binning="var0" plotname="CoulombCCQE" tag="QE" force_0_cv="true" include_only_weights="1">CoulombCCQE_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="NormCCMEC" knobvals="-2, -1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">NormCCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NormNCMEC" knobvals="-1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">NormNCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="XSecShape_CCMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">XSecShape_CCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="DecayAngMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">DecayAngMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FracPN_CCMEC" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">FracPN_CCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FracDelta_CCMEC" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">FracDelta_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormCCMEC" knobvals="-2, -1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" include_only_weights="1">NormCCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormNCMEC" knobvals="-1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" include_only_weights="1">NormNCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="XSecShape_CCMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" include_only_weights="1">XSecShape_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="DecayAngMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" include_only_weights="1">DecayAngMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FracPN_CCMEC" tag="MEC" force_0_cv="true" include_only_weights="1">FracPN_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FracDelta_CCMEC" tag="MEC" force_0_cv="true" include_only_weights="1">FracDelta_CCMEC_UBGenie</allowlist>
 	
-	<allowlist type="spline" binning="var0" plotname="MaCCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MaCCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MvCCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MvCCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MaNCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MaNCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MvNCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MvNCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="RDecBR1eta" tag="RES" force_0_cv="true" no_xs_weight_spline="true">RDecBR1eta_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="Theta_Delta2Npi" knobvals="0, 1" tag="RES" force_0_cv="true" no_xs_weight_spline="true">Theta_Delta2Npi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="RDecBR1gamma" tag="RES" force_0_cv="true" no_xs_weight_spline="true">RDecBR1gamma_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="ThetaDelta2NRad" knobvals="0, 1" tag="RES" force_0_cv="true" no_xs_weight_spline="true">ThetaDelta2NRad_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MaCCRES" tag="RES" force_0_cv="true" include_only_weights="1">MaCCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MvCCRES" tag="RES" force_0_cv="true" include_only_weights="1">MvCCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MaNCRES" tag="RES" force_0_cv="true" include_only_weights="1">MaNCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MvNCRES" tag="RES" force_0_cv="true" include_only_weights="1">MvNCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RDecBR1eta" tag="RES" force_0_cv="true" include_only_weights="1">RDecBR1eta_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="Theta_Delta2Npi" knobvals="0, 1" tag="RES" force_0_cv="true" include_only_weights="1">Theta_Delta2Npi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RDecBR1gamma" tag="RES" force_0_cv="true" include_only_weights="1">RDecBR1gamma_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="ThetaDelta2NRad" knobvals="0, 1" tag="RES" force_0_cv="true" include_only_weights="1">ThetaDelta2NRad_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="NormCCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" no_xs_weight_spline="true">NormCCCOH_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NormNCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" no_xs_weight_spline="true">NormNCCOH_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormCCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" include_only_weights="1">NormCCCOH_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormNCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" include_only_weights="1">NormNCCOH_UBGenie</allowlist>
 	
-	<allowlist type="spline" binning="var0" plotname="MaNCEL" tag="NC" force_0_cv="true" no_xs_weight_spline="true">MaNCEL_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="EtaNCEL" tag="NC" force_0_cv="true" no_xs_weight_spline="true">EtaNCEL_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MaNCEL" tag="NC" force_0_cv="true" include_only_weights="1">MaNCEL_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="EtaNCEL" tag="NC" force_0_cv="true" include_only_weights="1">EtaNCEL_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="AGKYxF1pi" tag="Hadr." force_0_cv="true" no_xs_weight_spline="true">AGKYxF1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="AGKYpT1pi" tag="Hadr." force_0_cv="true" no_xs_weight_spline="true">AGKYpT1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AGKYxF1pi" tag="Hadr." force_0_cv="true" include_only_weights="1">AGKYxF1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AGKYpT1pi" tag="Hadr." force_0_cv="true" include_only_weights="1">AGKYpT1pi_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnCC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpCC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnCC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpCC2pi_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="AhtBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">AhtBY_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="BhtBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">BhtBY_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="CV1uBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">CV1uBY_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="CV2uBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">CV2uBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AhtBY" tag="Struct." force_0_cv="true" include_only_weights="1">AhtBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="BhtBY" tag="Struct." force_0_cv="true" include_only_weights="1">BhtBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="CV1uBY" tag="Struct." force_0_cv="true" include_only_weights="1">CV1uBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="CV2uBY" tag="Struct." force_0_cv="true" include_only_weights="1">CV2uBY_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="MFP_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">MFP_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MFP_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">MFP_N_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrCEx_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrCEx_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrInel_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrInel_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrAbs_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrAbs_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrCEx_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrCEx_N_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrInel_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrInel_N_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrAbs_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrAbs_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MFP_pi" tag="FSI" force_0_cv="true" include_only_weights="1">MFP_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MFP_N" tag="FSI" force_0_cv="true" include_only_weights="1">MFP_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrCEx_pi" tag="FSI" force_0_cv="true" include_only_weights="1">FrCEx_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrInel_pi" tag="FSI" force_0_cv="true" include_only_weights="1">FrInel_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrAbs_pi" tag="FSI" force_0_cv="true" include_only_weights="1">FrAbs_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrCEx_N" tag="FSI" force_0_cv="true" include_only_weights="1">FrCEx_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrInel_N" tag="FSI" force_0_cv="true" include_only_weights="1">FrInel_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrAbs_N" tag="FSI" force_0_cv="true" include_only_weights="1">FrAbs_N_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fa3_SCC" tag="SCC" force_0_cv="true" no_xs_weight_spline="true">xsr_scc_Fa3_SCC</allowlist>
-	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fv3_SCC" tag="SCC" force_0_cv="true" no_xs_weight_spline="true">xsr_scc_Fv3_SCC</allowlist>
+	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fa3_SCC" tag="SCC" force_0_cv="true" include_only_weights="1">xsr_scc_Fa3_SCC</allowlist>
+	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fv3_SCC" tag="SCC" force_0_cv="true" include_only_weights="1">xsr_scc_Fv3_SCC</allowlist>
 
 	
-	<!-- Flux Systematics -->
-	<allowlist type="spline" binning="var0" plotname="horncurrent" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">horncurrent_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="expskin" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">expskin_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="kminus" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">kminus_PrimaryHadronNormalization</allowlist>
-	<allowlist type="spline" binning="var0" plotname="kplus" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">kplus_PrimaryHadronFeynmanScaling</allowlist>
-	<allowlist type="spline" binning="var0" plotname="kzero" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">kzero_PrimaryHadronSanfordWang</allowlist>
-	<allowlist type="spline" binning="var0" plotname="nucleoninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">nucleoninexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="nucleonqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">nucleonqexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="nucleontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">nucleontotxsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="pioninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">pioninexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="pionqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">pionqexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="piontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">piontotxsec_FluxUnisim</allowlist>
+	<!-- Flux Systematics, 11 splines -->
+	<allowlist type="spline" binning="var0" plotname="horncurrent" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">horncurrent_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="expskin" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">expskin_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kminus" tag="Flux" force_0_cv="true" include_only_weights="1">kminus_PrimaryHadronNormalization</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kplus" tag="Flux" force_0_cv="true" include_only_weights="1">kplus_PrimaryHadronFeynmanScaling</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kzero" tag="Flux" force_0_cv="true" include_only_weights="1">kzero_PrimaryHadronSanfordWang</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleoninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">nucleoninexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleonqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">nucleonqexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">nucleontotxsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="pioninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">pioninexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="pionqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">pionqexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="piontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" include_only_weights="1">piontotxsec_FluxUnisim</allowlist>
 	<allowlist type="covariance" plotname="piplus_prod" tag="piprod">piplus_PrimaryHadronSWCentralSplineVariation</allowlist>
 	<allowlist type="covariance" plotname="piminus_prod" tag="piprod">piminus_PrimaryHadronSWCentralSplineVariation</allowlist>
 

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -24,26 +24,6 @@
 	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
 	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
 </channel>
-<channel name="numuCCNpPC" plotname="Reconstructed Neutrino Energy [MeV]">
-	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
-	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
-	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
-	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
-	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
-	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
-	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
-</channel>
-<channel name="numuCC0pPC" plotname="Reconstructed Neutrino Energy [MeV]">
-	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
-	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
-	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
-	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
-	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
-	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
-	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
-</channel>
 
 <model tag="numudis">
     <rule index="0" name="No Osc"/>
@@ -123,67 +103,6 @@
 		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCCNpPC_numuCCoverlay"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
-			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCCNpPC_nueCCoverlay"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
-			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCCNpPC_NCoverlay"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
-			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCC0pPC_numuCCoverlay"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
-			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCC0pPC_nueCCoverlay"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
-			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCC0pPC_NCoverlay"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
-			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
 </MCFile>
 
 <!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root -->
@@ -206,26 +125,6 @@
 			incl_systematics      = "false"
         	model_rule            = "0"
 			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>0</variable>
-		<variable>0</variable>	
-	</branch>
-		<branch
-        	associated_subchannel = "nu_uBooNE_numuCCNpPC_ext"
-			incl_systematics      = "false"
-        	model_rule            = "0"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>0</variable>
-		<variable>0</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCC0pPC_ext"
-			incl_systematics      = "false"
-        	model_rule            = "0"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -255,26 +154,6 @@
 			incl_systematics      = "false"
         	model_rule            = "1"
 			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-		<branch
-        	associated_subchannel = "nu_uBooNE_numuCCNpPC_dirt"
-			incl_systematics      = "false"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCC0pPC_dirt"
-			incl_systematics      = "false"
-        	model_rule            = "1"
-			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -33,7 +33,8 @@
 	<branch
         	associated_subchannel = "nu_UBOONE_numu_overlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9)) * (weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -71,6 +72,7 @@
 			incl_systematics      = "false"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -2,13 +2,15 @@
 
 <mode name="nu" />
 
-<detector name="UBOONE" pot="1" />
+<detector name="UBOONE" pot="4.733e19" />
 
-<channel name="nuoverlay" plotname="Reconstructed Neutrino Energy">
+<channel name="numu" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
 	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-	<subchannel name="overlay" plotname="Overlay" color="#FF6961"/>
+	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
+	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
 </channel>
 
 <model tag="numudis">
@@ -18,24 +20,17 @@
 </model>
 
 <!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/nu_overlay_splines_50.root, 4.1 GB -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="1">
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="wcpselection/T_BDTvars" />
 	<friend treename="spline_weights" />
 	<friend treename="nuselection/NeutrinoSelectionFilter" />
 
-	<!--
-	For additional weight:
-		kine_reco_Enu > 0 is the reco selection.
-		Then we have genie_weight if genie_weight is reasonable,
-		or we have 1 if the genie_weight is not reasonable.
-			additional_weight     = "(0 < kine_reco_Enu) * (weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		For some reason, using this below makes the systematics look much more asymmetric.
-	-->
 	<branch
-        	associated_subchannel = "nu_UBOONE_nuoverlay_overlay"
+        	associated_subchannel = "nu_UBOONE_numu_overlay"
         	model_rule            = "1"
-			additional_weight     = "(0 < kine_reco_Enu) * (weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9)) * (weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -43,6 +38,42 @@
 	</branch>
 </MCFile>
 
+<!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root" scale = "1.0" pot="1.476e20">
+	<friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="wcpselection/T_BDTvars" />
+
+	<branch
+        	associated_subchannel = "nu_UBOONE_numu_ext"
+			incl_systematics      = "false"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+</MCFile>
+
+<!-- TEMPORARY: No systematics for dirt file -->
+<!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_BNB_dirt_surpise_reco2_hist.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_BNB_dirt_surpise_reco2_hist.root" scale = "1.0" pot="4.692e19">
+	<friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="wcpselection/T_BDTvars" />
+
+	<branch
+        	associated_subchannel = "nu_UBOONE_numu_dirt"
+			incl_systematics      = "false"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+</MCFile>
 
 <variation_list>
 

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -22,8 +22,8 @@
 <!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/nu_overlay_splines_50.root, 4.1 GB -->
 <!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19"> -->
 <!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/run4b_nuoverlay_retuple_splines.root, 65 GB -->
-<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19"> -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_nuoverlay_retuple_splines.root" scale = "1.0" pot="7.378e20">
+<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_nuoverlay_retuple_splines.root" scale = "1.0" pot="7.378e20"> -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
 	<friend treename="wcpselection/T_BDTvars" />

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -20,7 +20,10 @@
 </model>
 
 <!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/nu_overlay_splines_50.root, 4.1 GB -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19">
+<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19"> -->
+<!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/run4b_nuoverlay_retuple_splines.root, 65 GB -->
+<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19"> -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_nuoverlay_retuple_splines.root" scale = "1.0" pot="7.378e20">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
 	<friend treename="wcpselection/T_BDTvars" />

--- a/xml/uboone_nu_overlay_data_numu_dis.xml
+++ b/xml/uboone_nu_overlay_data_numu_dis.xml
@@ -2,39 +2,47 @@
 
 <mode name="nu" />
 
-<detector name="UBOONE" pot="4.733e19" />
+<detector name="uBooNE" pot="4.733e19" />
 
 <channel name="numuCCNpFC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
 	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
+	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
+	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
 	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
-	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
+	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
 </channel>
 <channel name="numuCC0pFC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
 	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
+	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
+	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
 	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
-	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
+	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
 </channel>
 <channel name="numuCCNpPC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
 	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
+	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
+	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
 	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
-	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
+	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
 </channel>
 <channel name="numuCC0pPC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
 	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-	<subchannel name="ext" plotname="Ext" color="#3BB143"/>
+	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
+	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
+	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
 	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
-	<subchannel name="overlay" plotname="Overlay" color="#21B1FF"/>
+	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
 </channel>
 
 <model tag="numudis">
@@ -47,16 +55,16 @@
 <!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19"> -->
 <!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/run4b_nuoverlay_retuple_splines.root, 65 GB -->
 <!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run4b_nuoverlay_retuple_splines.root" scale = "1.0" pot="7.378e20"> -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.69e19">
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="4.692e19">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
 	<friend treename="wcpselection/T_BDTvars" />
 	<friend treename="spline_weights" />
 	<friend treename="nuselection/NeutrinoSelectionFilter" />
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpFC_overlay"
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_numuCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
 			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
@@ -64,19 +72,9 @@
 		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pFC_overlay"
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_nueCCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
-			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>truth_nuEnergy</variable>
-		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
-	</branch>
-		<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpPC_overlay"
-        	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
 			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
@@ -84,9 +82,102 @@
 		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pPC_overlay"
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_NCoverlay"
         	model_rule            = "1"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_numuCCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_nueCCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_NCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpPC_numuCCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpPC_nueCCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpPC_NCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pPC_numuCCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pPC_nueCCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pPC_NCoverlay"
+        	model_rule            = "1"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
 			xs_weight             = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
@@ -96,12 +187,12 @@
 </MCFile>
 
 <!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root" scale = "1.0" pot="1.476e20">
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root" scale = "1.0" pot="1.466e20">
 	<friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_PFeval" />
 	<friend treename="wcpselection/T_BDTvars" />
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpFC_ext"
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
@@ -111,7 +202,7 @@
 		<variable>0</variable>	
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pFC_ext"
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
@@ -121,7 +212,7 @@
 		<variable>0</variable>	
 	</branch>
 		<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpPC_ext"
+        	associated_subchannel = "nu_uBooNE_numuCCNpPC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
@@ -131,7 +222,7 @@
 		<variable>0</variable>	
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pPC_ext"
+        	associated_subchannel = "nu_uBooNE_numuCC0pPC_ext"
 			incl_systematics      = "false"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
@@ -150,7 +241,7 @@
 	<friend treename="wcpselection/T_BDTvars" />
 
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpFC_dirt"
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
@@ -161,7 +252,7 @@
 		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pFC_dirt"
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
@@ -172,7 +263,7 @@
 		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 		<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpPC_dirt"
+        	associated_subchannel = "nu_uBooNE_numuCCNpPC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
@@ -183,7 +274,7 @@
 		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pPC_dirt"
+        	associated_subchannel = "nu_uBooNE_numuCC0pPC_dirt"
 			incl_systematics      = "false"
         	model_rule            = "1"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
@@ -289,6 +380,6 @@
 	<allowlist type="covariance" tag="Reint" scale="0.001">weightsReint</allowlist>
 
 	<!-- Other Systematics -->
-	<allowlist type="norm" binning="reco" plotname="Targets_POT" tag="norm">nu_UBOONE_nuoverlay_overlay:0.02</allowlist>
+	<allowlist type="norm" binning="reco" plotname="Targets_POT" tag="norm">nu_uBooNE_nuoverlay_overlay:0.02</allowlist>
 
 </variation_list>

--- a/xml/uboone_nu_overlay_numu_dis_test.xml
+++ b/xml/uboone_nu_overlay_numu_dis_test.xml
@@ -39,7 +39,7 @@
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
-		<variable>1000*470/truth_nuEnergy</variable>	
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>	
 	</branch>
 </MCFile>
 

--- a/xml/uboone_nu_overlay_numu_dis_test.xml
+++ b/xml/uboone_nu_overlay_numu_dis_test.xml
@@ -35,7 +35,7 @@
 	<branch
         	associated_subchannel = "nu_UBOONE_nuoverlay_overlay"
         	model_rule            = "1"
-			additional_weight     = "0 < kine_reco_Enu"
+			additional_weight     = "(0 < kine_reco_Enu) * (weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>truth_nuEnergy</variable>
@@ -45,90 +45,91 @@
 
 
 <variation_list>
+
     <!-- MC Statistics -->
 	<allowlist type="mcstat" plotname="MC Stats" tag="other">MCStat</allowlist>
 
 
     <!-- Cross Section Systematics -->
 	
-	<allowlist type="spline" binning="var0" plotname="MACCQE" tag="QE" force_0_cv="true">MaCCQE_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="AxFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true">AxFFCCQEshape_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="VecFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true">VecFFCCQEshape_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="RPA_CCQE" tag="QE" force_0_cv="true">RPA_CCQE_UBGenie</allowlist> 
-	<allowlist type="spline" binning="var0" plotname="CoulombCCQE" tag="QE" force_0_cv="true">CoulombCCQE_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MACCQE" tag="QE" force_0_cv="true" no_xs_weight_spline="true">MaCCQE_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AxFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" no_xs_weight_spline="true">AxFFCCQEshape_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="VecFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" no_xs_weight_spline="true">VecFFCCQEshape_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RPA_CCQE" tag="QE" force_0_cv="true" no_xs_weight_spline="true">RPA_CCQE_UBGenie</allowlist> 
+	<allowlist type="spline" binning="var0" plotname="CoulombCCQE" tag="QE" force_0_cv="true" no_xs_weight_spline="true">CoulombCCQE_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="NormCCMEC" knobvals="-2, -1, 0, 1, 2, 3" tag="MEC" force_0_cv="true">NormCCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NormNCMEC" knobvals="-1, 0, 1, 2, 3" tag="MEC" force_0_cv="true">NormNCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="XSecShape_CCMEC" knobvals="0, 1" tag="MEC" force_0_cv="true">XSecShape_CCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="DecayAngMEC" knobvals="0, 1" tag="MEC" force_0_cv="true">DecayAngMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FracPN_CCMEC" tag="MEC" force_0_cv="true">FracPN_CCMEC_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FracDelta_CCMEC" tag="MEC" force_0_cv="true">FracDelta_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormCCMEC" knobvals="-2, -1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">NormCCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormNCMEC" knobvals="-1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">NormNCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="XSecShape_CCMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">XSecShape_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="DecayAngMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">DecayAngMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FracPN_CCMEC" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">FracPN_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FracDelta_CCMEC" tag="MEC" force_0_cv="true" no_xs_weight_spline="true">FracDelta_CCMEC_UBGenie</allowlist>
 	
-	<allowlist type="spline" binning="var0" plotname="MaCCRES" tag="RES" force_0_cv="true">MaCCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MvCCRES" tag="RES" force_0_cv="true">MvCCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MaNCRES" tag="RES" force_0_cv="true">MaNCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MvNCRES" tag="RES" force_0_cv="true">MvNCRES_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="RDecBR1eta" tag="RES" force_0_cv="true">RDecBR1eta_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="Theta_Delta2Npi" knobvals="0, 1" tag="RES" force_0_cv="true">Theta_Delta2Npi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="RDecBR1gamma" tag="RES" force_0_cv="true">RDecBR1gamma_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="ThetaDelta2NRad" knobvals="0, 1" tag="RES" force_0_cv="true">ThetaDelta2NRad_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MaCCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MaCCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MvCCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MvCCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MaNCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MaNCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MvNCRES" tag="RES" force_0_cv="true" no_xs_weight_spline="true">MvNCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RDecBR1eta" tag="RES" force_0_cv="true" no_xs_weight_spline="true">RDecBR1eta_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="Theta_Delta2Npi" knobvals="0, 1" tag="RES" force_0_cv="true" no_xs_weight_spline="true">Theta_Delta2Npi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RDecBR1gamma" tag="RES" force_0_cv="true" no_xs_weight_spline="true">RDecBR1gamma_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="ThetaDelta2NRad" knobvals="0, 1" tag="RES" force_0_cv="true" no_xs_weight_spline="true">ThetaDelta2NRad_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="NormCCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true">NormCCCOH_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NormNCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true">NormNCCOH_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormCCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" no_xs_weight_spline="true">NormCCCOH_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormNCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" no_xs_weight_spline="true">NormNCCOH_UBGenie</allowlist>
 	
-	<allowlist type="spline" binning="var0" plotname="MaNCEL" tag="NC" force_0_cv="true">MaNCEL_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="EtaNCEL" tag="NC" force_0_cv="true">EtaNCEL_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MaNCEL" tag="NC" force_0_cv="true" no_xs_weight_spline="true">MaNCEL_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="EtaNCEL" tag="NC" force_0_cv="true" no_xs_weight_spline="true">EtaNCEL_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="AGKYxF1pi" tag="Hadr." force_0_cv="true">AGKYxF1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="AGKYpT1pi" tag="Hadr." force_0_cv="true">AGKYpT1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AGKYxF1pi" tag="Hadr." force_0_cv="true" no_xs_weight_spline="true">AGKYxF1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AGKYpT1pi" tag="Hadr." force_0_cv="true" no_xs_weight_spline="true">AGKYpT1pi_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvnNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvnNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvpNC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvpNC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnCC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpCC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvnCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvnCC2pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvpCC1pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvpCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarnCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvbarpCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvnCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC1pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC2pi" tag="Non-RES" force_0_cv="true" no_xs_weight_spline="true">NonRESBGvpCC2pi_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="AhtBY" tag="Struct." force_0_cv="true">AhtBY_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="BhtBY" tag="Struct." force_0_cv="true">BhtBY_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="CV1uBY" tag="Struct." force_0_cv="true">CV1uBY_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="CV2uBY" tag="Struct." force_0_cv="true">CV2uBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AhtBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">AhtBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="BhtBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">BhtBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="CV1uBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">CV1uBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="CV2uBY" tag="Struct." force_0_cv="true" no_xs_weight_spline="true">CV2uBY_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="MFP_pi" tag="FSI" force_0_cv="true">MFP_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="MFP_N" tag="FSI" force_0_cv="true">MFP_N_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrCEx_pi" tag="FSI" force_0_cv="true">FrCEx_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrInel_pi" tag="FSI" force_0_cv="true">FrInel_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrAbs_pi" tag="FSI" force_0_cv="true">FrAbs_pi_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrCEx_N" tag="FSI" force_0_cv="true">FrCEx_N_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrInel_N" tag="FSI" force_0_cv="true">FrInel_N_UBGenie</allowlist>
-	<allowlist type="spline" binning="var0" plotname="FrAbs_N" tag="FSI" force_0_cv="true">FrAbs_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MFP_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">MFP_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MFP_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">MFP_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrCEx_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrCEx_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrInel_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrInel_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrAbs_pi" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrAbs_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrCEx_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrCEx_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrInel_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrInel_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrAbs_N" tag="FSI" force_0_cv="true" no_xs_weight_spline="true">FrAbs_N_UBGenie</allowlist>
 
-	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fa3_SCC" tag="SCC" force_0_cv="true">xsr_scc_Fa3_SCC</allowlist>
-	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fv3_SCC" tag="SCC" force_0_cv="true">xsr_scc_Fv3_SCC</allowlist>
+	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fa3_SCC" tag="SCC" force_0_cv="true" no_xs_weight_spline="true">xsr_scc_Fa3_SCC</allowlist>
+	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fv3_SCC" tag="SCC" force_0_cv="true" no_xs_weight_spline="true">xsr_scc_Fv3_SCC</allowlist>
 
 	
 	<!-- Flux Systematics -->
-	<allowlist type="spline" binning="var0" plotname="horncurrent" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">horncurrent_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="expskin" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">expskin_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="kminus" tag="Flux" force_0_cv="true">kminus_PrimaryHadronNormalization</allowlist>
-	<allowlist type="spline" binning="var0" plotname="kplus" tag="Flux" force_0_cv="true">kplus_PrimaryHadronFeynmanScaling</allowlist>
-	<allowlist type="spline" binning="var0" plotname="kzero" tag="Flux" force_0_cv="true">kzero_PrimaryHadronSanfordWang</allowlist>
-	<allowlist type="spline" binning="var0" plotname="nucleoninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">nucleoninexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="nucleonqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">nucleonqexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="nucleontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">nucleontotxsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="pioninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">pioninexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="pionqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">pionqexsec_FluxUnisim</allowlist>
-	<allowlist type="spline" binning="var0" plotname="piontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">piontotxsec_FluxUnisim</allowlist> -->
+	<allowlist type="spline" binning="var0" plotname="horncurrent" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">horncurrent_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="expskin" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">expskin_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kminus" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">kminus_PrimaryHadronNormalization</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kplus" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">kplus_PrimaryHadronFeynmanScaling</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kzero" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">kzero_PrimaryHadronSanfordWang</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleoninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">nucleoninexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleonqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">nucleonqexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">nucleontotxsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="pioninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">pioninexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="pionqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">pionqexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="piontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true" no_xs_weight_spline="true">piontotxsec_FluxUnisim</allowlist>
 	<allowlist type="covariance" plotname="piplus_prod" tag="piprod">piplus_PrimaryHadronSWCentralSplineVariation</allowlist>
 	<allowlist type="covariance" plotname="piminus_prod" tag="piprod">piminus_PrimaryHadronSWCentralSplineVariation</allowlist>
 

--- a/xml/uboone_nu_overlay_numu_dis_test.xml
+++ b/xml/uboone_nu_overlay_numu_dis_test.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" ?>
+
+<mode name="nu" />
+
+<detector name="UBOONE" pot="1" />
+
+<channel name="nuoverlay" plotname="Reconstructed Neutrino Energy">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+	<subchannel name="overlay" plotname="Overlay" color="#FF6961"/>
+</channel>
+
+<model tag="numudis">
+    <rule index="0" name="No Osc"/>
+    <rule index="1" name="Numu Dis"/>
+    <parameter name="L/E" variable_index="2"/>
+</model>
+
+<!-- This file is available at /exp/uboone/data/users/lhagaman/PROfit_files/nu_overlay_splines_50.root, 4.1 GB -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/nu_overlay_splines_50.root" scale = "1.0" pot="1">
+	<friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="spline_weights" />
+	<friend treename="nuselection/NeutrinoSelectionFilter" />
+
+	<!--
+	For additional weight:
+		kine_reco_Enu > 0 is the reco selection.
+		Then we have genie_weight if genie_weight is reasonable,
+		or we have 1 if the genie_weight is not reasonable.
+			additional_weight     = "(0 < kine_reco_Enu) * (weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		For some reason, using this below makes the systematics look much more asymmetric.
+	-->
+	<branch
+        	associated_subchannel = "nu_UBOONE_nuoverlay_overlay"
+        	model_rule            = "1"
+			additional_weight     = "0 < kine_reco_Enu"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000*470/truth_nuEnergy</variable>	
+	</branch>
+</MCFile>
+
+
+<variation_list>
+    <!-- MC Statistics -->
+	<allowlist type="mcstat" plotname="MC Stats" tag="other">MCStat</allowlist>
+
+
+    <!-- Cross Section Systematics -->
+	
+	<allowlist type="spline" binning="var0" plotname="MACCQE" tag="QE" force_0_cv="true">MaCCQE_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AxFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true">AxFFCCQEshape_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="VecFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true">VecFFCCQEshape_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RPA_CCQE" tag="QE" force_0_cv="true">RPA_CCQE_UBGenie</allowlist> 
+	<allowlist type="spline" binning="var0" plotname="CoulombCCQE" tag="QE" force_0_cv="true">CoulombCCQE_UBGenie</allowlist>
+
+	<allowlist type="spline" binning="var0" plotname="NormCCMEC" knobvals="-2, -1, 0, 1, 2, 3" tag="MEC" force_0_cv="true">NormCCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormNCMEC" knobvals="-1, 0, 1, 2, 3" tag="MEC" force_0_cv="true">NormNCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="XSecShape_CCMEC" knobvals="0, 1" tag="MEC" force_0_cv="true">XSecShape_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="DecayAngMEC" knobvals="0, 1" tag="MEC" force_0_cv="true">DecayAngMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FracPN_CCMEC" tag="MEC" force_0_cv="true">FracPN_CCMEC_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FracDelta_CCMEC" tag="MEC" force_0_cv="true">FracDelta_CCMEC_UBGenie</allowlist>
+	
+	<allowlist type="spline" binning="var0" plotname="MaCCRES" tag="RES" force_0_cv="true">MaCCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MvCCRES" tag="RES" force_0_cv="true">MvCCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MaNCRES" tag="RES" force_0_cv="true">MaNCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MvNCRES" tag="RES" force_0_cv="true">MvNCRES_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RDecBR1eta" tag="RES" force_0_cv="true">RDecBR1eta_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="Theta_Delta2Npi" knobvals="0, 1" tag="RES" force_0_cv="true">Theta_Delta2Npi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="RDecBR1gamma" tag="RES" force_0_cv="true">RDecBR1gamma_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="ThetaDelta2NRad" knobvals="0, 1" tag="RES" force_0_cv="true">ThetaDelta2NRad_UBGenie</allowlist>
+
+	<allowlist type="spline" binning="var0" plotname="NormCCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true">NormCCCOH_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NormNCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true">NormNCCOH_UBGenie</allowlist>
+	
+	<allowlist type="spline" binning="var0" plotname="MaNCEL" tag="NC" force_0_cv="true">MaNCEL_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="EtaNCEL" tag="NC" force_0_cv="true">EtaNCEL_UBGenie</allowlist>
+
+	<allowlist type="spline" binning="var0" plotname="AGKYxF1pi" tag="Hadr." force_0_cv="true">AGKYxF1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="AGKYpT1pi" tag="Hadr." force_0_cv="true">AGKYpT1pi_UBGenie</allowlist>
+
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvnNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvnNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvpNC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpNC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvpNC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarnCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarnCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvbarpCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvbarpCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvnCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvnCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvnCC2pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC1pi" tag="Non-RES" force_0_cv="true">NonRESBGvpCC1pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="NonRESBGvpCC2pi" tag="Non-RES" force_0_cv="true">NonRESBGvpCC2pi_UBGenie</allowlist>
+
+	<allowlist type="spline" binning="var0" plotname="AhtBY" tag="Struct." force_0_cv="true">AhtBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="BhtBY" tag="Struct." force_0_cv="true">BhtBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="CV1uBY" tag="Struct." force_0_cv="true">CV1uBY_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="CV2uBY" tag="Struct." force_0_cv="true">CV2uBY_UBGenie</allowlist>
+
+	<allowlist type="spline" binning="var0" plotname="MFP_pi" tag="FSI" force_0_cv="true">MFP_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="MFP_N" tag="FSI" force_0_cv="true">MFP_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrCEx_pi" tag="FSI" force_0_cv="true">FrCEx_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrInel_pi" tag="FSI" force_0_cv="true">FrInel_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrAbs_pi" tag="FSI" force_0_cv="true">FrAbs_pi_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrCEx_N" tag="FSI" force_0_cv="true">FrCEx_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrInel_N" tag="FSI" force_0_cv="true">FrInel_N_UBGenie</allowlist>
+	<allowlist type="spline" binning="var0" plotname="FrAbs_N" tag="FSI" force_0_cv="true">FrAbs_N_UBGenie</allowlist>
+
+	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fa3_SCC" tag="SCC" force_0_cv="true">xsr_scc_Fa3_SCC</allowlist>
+	<allowlist type="spline" binning="var0" plotname="xsr_scc_Fv3_SCC" tag="SCC" force_0_cv="true">xsr_scc_Fv3_SCC</allowlist>
+
+	
+	<!-- Flux Systematics -->
+	<allowlist type="spline" binning="var0" plotname="horncurrent" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">horncurrent_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="expskin" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">expskin_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kminus" tag="Flux" force_0_cv="true">kminus_PrimaryHadronNormalization</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kplus" tag="Flux" force_0_cv="true">kplus_PrimaryHadronFeynmanScaling</allowlist>
+	<allowlist type="spline" binning="var0" plotname="kzero" tag="Flux" force_0_cv="true">kzero_PrimaryHadronSanfordWang</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleoninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">nucleoninexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleonqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">nucleonqexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="nucleontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">nucleontotxsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="pioninexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">pioninexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="pionqexsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">pionqexsec_FluxUnisim</allowlist>
+	<allowlist type="spline" binning="var0" plotname="piontotxsec" knobvals="-1, 0, 1" tag="Flux" force_0_cv="true">piontotxsec_FluxUnisim</allowlist> -->
+	<allowlist type="covariance" plotname="piplus_prod" tag="piprod">piplus_PrimaryHadronSWCentralSplineVariation</allowlist>
+	<allowlist type="covariance" plotname="piminus_prod" tag="piprod">piminus_PrimaryHadronSWCentralSplineVariation</allowlist>
+
+
+	<!-- Re-interaction Systematics -->
+	<allowlist type="covariance" tag="Reint" scale="0.001">weightsReint</allowlist>
+
+	<!-- Other Systematics -->
+	<allowlist type="norm" binning="reco" plotname="Targets_POT" tag="norm">nu_UBOONE_nuoverlay_overlay:0.02</allowlist>
+
+</variation_list>

--- a/xml/uboone_run4b_opendata.xml
+++ b/xml/uboone_run4b_opendata.xml
@@ -11,6 +11,9 @@
     <subchannel name="data" plotname="Data" color="#99CCFF"/>
 </channel>
 
+<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/houston/home/leehagaman/PROfit/uboone_spline_testing/temp_data_file_list_test.txt" scale = "1.0" pot="4.733e19"> -->
+
+
 <!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root, 4.6 GB -->
 <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root" scale = "1.0" pot="4.733e19">
     <friend treename="wcpselection/T_eval" />

--- a/xml/uboone_run4b_opendata.xml
+++ b/xml/uboone_run4b_opendata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+
+<mode name="nu" />
+
+<detector name="UBOONE" pot="4.733e19" />
+
+<channel name="numu" unit="Reconstructed Neutrino Energy [MeV]">
+    <bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20" plot="false"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+    <subchannel name="data" plotname="Data" color="#99CCFF"/>
+</channel>
+
+<!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root, 4.6 GB -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root" scale = "1.0" pot="4.733e19">
+    <friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_BDTvars" />
+	<branch
+        associated_subchannel = "nu_UBOONE_numu_data"
+        incl_systematics      = "false"
+        model_rule            = "0"
+		additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
+        >
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+</MCFile>

--- a/xml/uboone_run4b_opendata.xml
+++ b/xml/uboone_run4b_opendata.xml
@@ -16,18 +16,6 @@
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
     <subchannel name="data" plotname="Data" color="#99CCFF"/>
 </channel>
-<channel name="numuCCNpPC" plotname="Reconstructed Neutrino Energy [MeV]">
-	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
-	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
-	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-    <subchannel name="data" plotname="Data" color="#99CCFF"/>
-</channel>
-<channel name="numuCC0pPC" plotname="Reconstructed Neutrino Energy [MeV]">
-	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
-	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
-	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
-    <subchannel name="data" plotname="Data" color="#99CCFF"/>
-</channel>
 
 
 <!-- This contains two files: /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root,
@@ -50,24 +38,6 @@
         	associated_subchannel = "nu_uBooNE_numuCC0pFC_data"
         	model_rule            = "0"
 			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>0</variable>
-		<variable>0</variable>
-	</branch>
-		<branch
-        	associated_subchannel = "nu_uBooNE_numuCCNpPC_data"
-        	model_rule            = "0"
-			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
-		>
-		<variable>kine_reco_Enu</variable>
-		<variable>0</variable>
-		<variable>0</variable>	
-	</branch>
-	<branch
-        	associated_subchannel = "nu_uBooNE_numuCC0pPC_data"
-        	model_rule            = "0"
-			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>

--- a/xml/uboone_run4b_opendata.xml
+++ b/xml/uboone_run4b_opendata.xml
@@ -40,7 +40,7 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpFC_data"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -49,7 +49,7 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pFC_data"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -58,7 +58,7 @@
 		<branch
         	associated_subchannel = "nu_uBooNE_numuCCNpPC_data"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
@@ -67,7 +67,7 @@
 	<branch
         	associated_subchannel = "nu_uBooNE_numuCC0pPC_data"
         	model_rule            = "0"
-			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>

--- a/xml/uboone_run4b_opendata.xml
+++ b/xml/uboone_run4b_opendata.xml
@@ -2,7 +2,7 @@
 
 <mode name="nu" />
 
-<detector name="UBOONE" pot="7.801e19" />
+<detector name="uBooNE" pot="4.733e19" />
 
 <channel name="numuCCNpFC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
@@ -32,12 +32,13 @@
 
 <!-- This contains two files: /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root,
 /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4a_BNB_beam_on_data_surprise_reco2_hist_opendata_19550.root -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run_4_open_data_surprise_files.txt" scale = "1.0" pot="7.801e19">
+<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run_4_open_data_surprise_files.txt" scale = "1.0" pot="7.801e19"> -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root" scale = "1.0" pot="4.733e19">
     <friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_BDTvars" />
-	
+
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpFC_data"
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_data"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
@@ -46,7 +47,7 @@
 		<variable>0</variable>
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pFC_data"
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_data"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>
@@ -55,7 +56,7 @@
 		<variable>0</variable>
 	</branch>
 		<branch
-        	associated_subchannel = "nu_UBOONE_numuCCNpPC_data"
+        	associated_subchannel = "nu_uBooNE_numuCCNpPC_data"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
 		>
@@ -64,7 +65,7 @@
 		<variable>0</variable>	
 	</branch>
 	<branch
-        	associated_subchannel = "nu_UBOONE_numuCC0pPC_data"
+        	associated_subchannel = "nu_uBooNE_numuCC0pPC_data"
         	model_rule            = "0"
 			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
 		>

--- a/xml/uboone_run4b_opendata.xml
+++ b/xml/uboone_run4b_opendata.xml
@@ -2,7 +2,7 @@
 
 <mode name="nu" />
 
-<detector name="uBooNE" pot="4.733e19" />
+<detector name="uBooNE" pot="4.031e19" />
 
 <channel name="numuCCNpFC" plotname="Reconstructed Neutrino Energy [MeV]">
 	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
@@ -21,7 +21,7 @@
 <!-- This contains two files: /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root,
 /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4a_BNB_beam_on_data_surprise_reco2_hist_opendata_19550.root -->
 <!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run_4_open_data_surprise_files.txt" scale = "1.0" pot="7.801e19"> -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root" scale = "1.0" pot="4.733e19">
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root" scale = "1.0" pot="4.031e19">
     <friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_BDTvars" />
 

--- a/xml/uboone_run4b_opendata.xml
+++ b/xml/uboone_run4b_opendata.xml
@@ -2,28 +2,72 @@
 
 <mode name="nu" />
 
-<detector name="UBOONE" pot="4.733e19" />
+<detector name="UBOONE" pot="7.801e19" />
 
-<channel name="numu" unit="Reconstructed Neutrino Energy [MeV]">
-    <bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
-	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20" plot="false"/>
+<channel name="numuCCNpFC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+    <subchannel name="data" plotname="Data" color="#99CCFF"/>
+</channel>
+<channel name="numuCC0pFC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+    <subchannel name="data" plotname="Data" color="#99CCFF"/>
+</channel>
+<channel name="numuCCNpPC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+    <subchannel name="data" plotname="Data" color="#99CCFF"/>
+</channel>
+<channel name="numuCC0pPC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
 	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
     <subchannel name="data" plotname="Data" color="#99CCFF"/>
 </channel>
 
-<!-- <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/houston/home/leehagaman/PROfit/uboone_spline_testing/temp_data_file_list_test.txt" scale = "1.0" pot="4.733e19"> -->
 
-
-<!-- This file is available at /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root, 4.6 GB -->
-<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root" scale = "1.0" pot="4.733e19">
+<!-- This contains two files: /pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root,
+/pnfs/uboone/persistent/users/uboonepro/surprise/opendata/BNB/checkout_MCC9.10_Run4a_BNB_beam_on_data_surprise_reco2_hist_opendata_19550.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/run_4_open_data_surprise_files.txt" scale = "1.0" pot="7.801e19">
     <friend treename="wcpselection/T_eval" />
 	<friend treename="wcpselection/T_BDTvars" />
+	
 	<branch
-        associated_subchannel = "nu_UBOONE_numu_data"
-        incl_systematics      = "false"
-        model_rule            = "0"
-		additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9))"
-        >
+        	associated_subchannel = "nu_UBOONE_numuCCNpFC_data"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pFC_data"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+		<branch
+        	associated_subchannel = "nu_UBOONE_numuCCNpPC_data"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>	
+	</branch>
+	<branch
+        	associated_subchannel = "nu_UBOONE_numuCC0pPC_data"
+        	model_rule            = "0"
+			additional_weight     = "((0 < kine_reco_Enu) && (match_isFC == 0) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+		>
 		<variable>kine_reco_Enu</variable>
 		<variable>0</variable>
 		<variable>0</variable>


### PR DESCRIPTION
This adds the capability to use PROfit with MicroBooNE's SURPRISE files, including the use of newly added spline systematics.

- Adds TChain cleanup in the PROcess step, since this was causing a segmentation error when reading the root file.

- Adds the optional `force_0_cv` parameter in the spline xml statement. This causes spline spectra to be treated as fractional differences from the zero-sigma knob value, allowing it to work even when the zero-sigma knob value doesn't match the CV.

- Adds optional `weight_1`, `weight_2`, etc. (optionally replacing `additional_weight`). These get multiplied together to create the final event weight, but optionally with `include_only_weights`, we can ignore certain weights when building splines. This is necessary for MicroBooNE uncertainties, since we have GENIE CV adjustments to the event weight, but we need to ignore these cross section weights when filling spline spectra since the spline event weights already contain the CV cross section weight.

- Adds the optional `scale` parameter in the spline xml statement. This allows us to use MicroBooNE re-interaction weight values which are stored as integers relative to 1000 (rather than floats relative to 1).

- Makes zero-content bins poisson fluctuate to zero rather than erroring

- Added and then commented out checks for negative spline weights (I wanted to check this since negative weights are sometimes stored for reweighting errors in MicroBooNE, but I'm not sure if we definitely want this situation to always cause an error)

- Made some plots look nicer with a large number of pull terms

- Fixed an issue with parameter indexing using `--syst-only`

- Masked out empty data bins for chi2 calculations with Neyman data statistical uncertainties

- Adds capability for a .txt file containing a list of root files for data (already worked for MC files)

- Adds log output suppression for more than 1000 identical messages (helps avoid accidentally making very large log files)

- Swaps index accesses in PROconfig::SameChannels to fix an error

- Adds filename printout to the first iteration of file loading in the PROcess step (can be slow for certain files)

- Includes an example MicroBooNE numu disappearance xml using the WC numuCC selection.
