### PR TITLE
Ability to load a TMatrix from external root file as an fractional_covariance_matrix

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -339,8 +339,7 @@ namespace PROfit{
             std::vector<std::string> m_mcgen_variation_allowlist;
             std::vector<std::string> m_mcgen_variation_denylist;
             std::vector<std::string> m_mcgen_variation_type;
-            std::vector<std::string> m_mcgen_variation_external_filename;
-            std::vector<std::string> m_mcgen_variation_external_matrixname;
+            std::map<std::string, std::string> m_mcgen_variation_external_filename_map;
             std::map<std::string, std::string> m_mcgen_variation_type_map;
             std::map<std::string, std::string> m_mcgen_variation_plotname_map;
             std::map<std::string, int> m_mcgen_variation_binning_map;

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -309,6 +309,7 @@ namespace PROfit{
             bool m_form_covariance;
             std::string m_write_out_tag;
             int m_num_variation_type_covariance = 0;
+            int m_num_variation_type_external_covariance = 0;
             int m_num_variation_type_spline = 0;
             int m_num_variation_type_flat = 0;
             int m_num_variation_type_norm = 0;
@@ -338,6 +339,8 @@ namespace PROfit{
             std::vector<std::string> m_mcgen_variation_allowlist;
             std::vector<std::string> m_mcgen_variation_denylist;
             std::vector<std::string> m_mcgen_variation_type;
+            std::vector<std::string> m_mcgen_variation_external_filename;
+            std::vector<std::string> m_mcgen_variation_external_matrixname;
             std::map<std::string, std::string> m_mcgen_variation_type_map;
             std::map<std::string, std::string> m_mcgen_variation_plotname_map;
             std::map<std::string, int> m_mcgen_variation_binning_map;

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -46,8 +46,10 @@ namespace PROfit{
         //members
         std::string systname;
         int n_univ;
-        std::string mode;  //'multisim', 'minmax', and 'multisig'
+        std::string mode;  //covar, spline, external...
         std::string weight_formula;
+        std::string external_filename;
+        std::string external_matrixname;
 
         std::vector<eweight_type> knobval;
         std::vector<eweight_type> knob_index;
@@ -73,6 +75,8 @@ namespace PROfit{
             ar & n_univ;
             ar & mode;
             ar & weight_formula;
+            ar & external_filename;
+            ar & external_matrixname;
             ar & knobval;
             ar & knob_index;
             ar & index;
@@ -100,6 +104,8 @@ namespace PROfit{
         inline
             void SetWeightFormula(const std::string& in_formula){weight_formula = in_formula; return;}
 
+        inline 
+            void SetExternalData(const std::string &infile, const std::string &inmat){ external_filename=infile, external_matrixname=inmat; return;}
 
         std::vector<std::vector<eweight_type>> GetCovVec();
         std::vector<eweight_type> GetKnobs(int index, std::string variation);

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -8,6 +8,10 @@
 #include <map>
 #include <cmath>
 
+//annoying root headers for file input
+#include "TMatrixD.h"
+#include "TFile.h"
+
 // Our include
 #include "PROconfig.h"
 #include "PROcreate.h"
@@ -85,6 +89,10 @@ namespace PROfit {
              * Note: this function is lazy. It wouldn't do anything if it found covariance matrix with the same name already in the map.
              */
             void CreateFlatMatrix(const PROconfig& config, const SystStruct& syst);
+
+            /* Function: Given a SystStruct, load an external fractinal covariance matrix, and calculate correlation matrix, and add matrices to covmat_map and corrtmat_map
+             */
+            void LoadExternalCovarianceMatrix(const PROconfig& config, const SystStruct& syst);
 
             /* Function: given a syst struct with cv and variation spectra, build fractional covariance matrix for the systematics, as well as correlation matrix 
              * Return: {fractional covariance matrix, correlation covariance matrix}

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -838,7 +838,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(text) wt = std::string(text);
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center","filename","matrixname"};
+                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center","filename"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -856,16 +856,13 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *prior = pAllowList->Attribute("prior");
                 const char *center = pAllowList->Attribute("center");
                 const char *filename = pAllowList->Attribute("filename");
-                const char *matrixname = pAllowList->Attribute("matrixname");
 
 
                 m_mcgen_variation_type.push_back(variation_type);
                 m_mcgen_variation_type_map[wt] = variation_type;
                 m_mcgen_variation_allowlist.push_back(wt);
                 if(prior) m_mcgen_variation_prior[wt] = std::strtof(prior, NULL);
-                if(filename) m_mcgen_variation_external_filename.push_back(filename);
-                if(matrixname) m_mcgen_variation_external_matrixname.push_back(matrixname);
-                if(center) m_mcgen_variation_prior_centers[wt] = std::strtof(center, NULL);
+                if(filename) m_mcgen_variation_external_filename_map[wt] = filename;
                 m_mcgen_variation_plotname_map[wt] = plot_name ? plot_name : wt;
                 if(!binning || strcmp(binning, "reco") == 0) {
                     m_mcgen_variation_binning_map[wt] = i_prime;

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -838,7 +838,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(text) wt = std::string(text);
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center"};
+                const std::vector<std::string> expected_attrs = {"type", "plotname", "binning", "knobvals", "tag", "prior", "center","filename","matrixname"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -855,13 +855,16 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *tags = pAllowList->Attribute("tag");
                 const char *prior = pAllowList->Attribute("prior");
                 const char *center = pAllowList->Attribute("center");
-
+                const char *filename = pAllowList->Attribute("filename");
+                const char *matrixname = pAllowList->Attribute("matrixname");
 
 
                 m_mcgen_variation_type.push_back(variation_type);
                 m_mcgen_variation_type_map[wt] = variation_type;
                 m_mcgen_variation_allowlist.push_back(wt);
                 if(prior) m_mcgen_variation_prior[wt] = std::strtof(prior, NULL);
+                if(filename) m_mcgen_variation_external_filename.push_back(filename);
+                if(matrixname) m_mcgen_variation_external_matrixname.push_back(matrixname);
                 if(center) m_mcgen_variation_prior_centers[wt] = std::strtof(center, NULL);
                 m_mcgen_variation_plotname_map[wt] = plot_name ? plot_name : wt;
                 if(!binning || strcmp(binning, "reco") == 0) {
@@ -1199,11 +1202,14 @@ int PROconfig::LoadFromXML(const std::string &filename){
             m_mcgen_variation_allowlist[i] = "mcstat";
             m_mcgen_variation_type_map["mcstat"] = "mcstat";
             m_use_mcstats = true;
+        }else if(m_mcgen_variation_type[i] == "external_covariance"){
+            m_num_variation_type_external_covariance+=1;
         }
 
     }
 
     log<LOG_INFO>(L"%1% || num_variation_type_covariance: %2% ") % __func__ % m_num_variation_type_covariance;
+    log<LOG_INFO>(L"%1% || num_variation_type_external_ovariance: %2% ") % __func__ % m_num_variation_type_external_covariance;
     log<LOG_INFO>(L"%1% || num_variation_type_flat: %2% ") % __func__ % m_num_variation_type_flat;
     log<LOG_INFO>(L"%1% || num_variation_type_norm: %2% ") % __func__ % m_num_variation_type_norm;
     log<LOG_INFO>(L"%1% || num_variation_type_spline: %2% ") % __func__ % m_num_variation_type_spline; 

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -384,6 +384,16 @@ namespace PROfit {
             }
         }
 
+        //Do we have any external systeatics?
+        if(inconfig.m_num_variation_type_external_covariance>0){
+            for(auto& allow_sys : inconfig.m_mcgen_variation_type_map){
+                if(allow_sys.second=="external_covariance"){
+                    map_systematic_num_universe[allow_sys.first] = -1;
+                }
+            }
+        }
+
+
 
         size_t total_num_systematics = map_systematic_num_universe.size();
         log<LOG_INFO>(L"%1% || Found %2% unique variations") % __func__ % total_num_systematics;
@@ -426,6 +436,12 @@ namespace PROfit {
                 }
                 if(sys_mode == "flat"){
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a flat covariance systematic. Processing a such. ") % __func__ % sys_name.c_str();
+                }
+                if(sys_mode == "external_covariance"){
+                    log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for an externally loaded covariance systematic. Processing a such. ") % __func__ % sys_name.c_str();
+                    sv.back().external_filename = "test";
+                    sv.back().external_matrixname = "test";
+                    log<LOG_INFO>(L"%1% || External filename:  %2%, External Matrix :%3% ") % __func__ % sv.back().external_filename.c_str() % sv.back().external_matrixname.c_str();
                 }
                 if(sys_mode == "norm") {
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a spline norm systematic. Processing a such. ") % __func__ % sys_name.c_str();

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -438,10 +438,10 @@ namespace PROfit {
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a flat covariance systematic. Processing a such. ") % __func__ % sys_name.c_str();
                 }
                 if(sys_mode == "external_covariance"){
+                    sv.back().external_filename = inconfig.m_mcgen_variation_external_filename_map.at(sys_name);
+                    sv.back().binning = binningindex;
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for an externally loaded covariance systematic. Processing a such. ") % __func__ % sys_name.c_str();
-                    sv.back().external_filename = "test";
-                    sv.back().external_matrixname = "test";
-                    log<LOG_INFO>(L"%1% || External filename:  %2%, External Matrix :%3% ") % __func__ % sv.back().external_filename.c_str() % sv.back().external_matrixname.c_str();
+                    log<LOG_INFO>(L"%1% || External filename:  %2%, External Matrix :%3% . Use for variable number %4%") % __func__ % sv.back().external_filename.c_str() % sys_name.c_str() % sv.back().binning;
                 }
                 if(sys_mode == "norm") {
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a spline norm systematic. Processing a such. ") % __func__ % sys_name.c_str();
@@ -520,10 +520,10 @@ namespace PROfit {
         for(size_t i = 0; i < syst_vector.size(); ++i){
             auto &sv = syst_vector[i];
             for(auto &s: sv) {
-                if(s.mode=="flat")
+                if(s.mode=="flat" || s.mode=="external_covariance")
                     continue;
                 //Get these binnings right
-                s.CreateSpecs( s.mode == "covariance" ? inconfig.m_num_variable_bins_total[i] : inconfig.m_num_variable_bins_total[s.binning]);
+                s.CreateSpecs( (s.mode == "covariance" ) ? inconfig.m_num_variable_bins_total[i] : inconfig.m_num_variable_bins_total[s.binning]);
                 // use the binnign from the variable if covariance, otherise use the binning fdefined for the spline
             }
         }

--- a/src/PROfc.cxx
+++ b/src/PROfc.cxx
@@ -3,92 +3,106 @@
 namespace PROfit {
 
 
-void fc_worker(fc_args args) {
-    log<LOG_INFO>(L"%1% || FC for point %2%") % __func__ % args.phy_params;
-    std::mt19937 rng{args.seed};
-    std::unique_ptr<PROmodel> model = get_model_from_string(args.config, args.prop);
-    std::unique_ptr<PROmodel> null_model = std::make_unique<NullModel>(args.prop);
+    void fc_worker(fc_args args) {
+        log<LOG_INFO>(L"%1% || FC for point %2%") % __func__ % args.phy_params;
+        std::mt19937 rng{args.seed};
+        std::unique_ptr<PROmodel> model = get_model_from_string(args.config, args.prop);
+        std::unique_ptr<PROmodel> null_model = std::make_unique<NullModel>(args.prop);
 
-    PROchi::EvalStrategy strat = args.binned ? PROchi::BinnedChi2 : PROchi::EventByEvent;
-    Eigen::VectorXf throws = Eigen::VectorXf::Constant(model->nparams + args.systs.GetNSplines(), 0);
-    for(size_t i = 0; i < model->nparams; ++i) throws(i) = args.phy_params(i);
-    size_t nparams = model->nparams + args.systs.GetNSplines();
-    Eigen::VectorXf lb_osc = Eigen::VectorXf::Constant(nparams, -3.0);
-    Eigen::VectorXf ub_osc = Eigen::VectorXf::Constant(nparams, 3.0);
-    Eigen::VectorXf lb = Eigen::VectorXf::Constant(nparams, -3.0);
-    Eigen::VectorXf ub = Eigen::VectorXf::Constant(nparams, 3.0);
-    size_t nphys = model->nparams;
-    //set physics to correct values
-    for(size_t j=0; j<nphys; j++){
-        ub_osc(j) = model->ub(j);
-        lb_osc(j) = model->lb(j); 
-        lb(j) = args.phy_params(j);
-        ub(j) =  args.phy_params(j);
-    }
-    //upper lower bounds for splines
-    for(size_t j = nphys; j < nparams; ++j) {
-        lb_osc(j) = args.systs.spline_lo[j-nphys];
-        ub_osc(j) = args.systs.spline_hi[j-nphys];
-        lb(j) = args.systs.spline_lo[j-nphys];
-        ub(j) = args.systs.spline_hi[j-nphys];
-    }
-    std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
-    Eigen::VectorXf seed_pt = Eigen::VectorXf::Zero(nparams);
-    for(size_t u = 0; u < args.todo; ++u) {
-        log<LOG_INFO>(L"%1% | Thread #%2% Throw #%3%") % __func__ % args.thread % u;
-        std::normal_distribution<float> d;
-
-        Eigen::VectorXf throwC = Eigen::VectorXf::Constant(args.config.m_num_variable_bins_total_collapsed[args.config.i_prime], 0);
-        for(size_t i = 0; i < args.systs.GetNSplines(); i++) {
-            do {
-                throws(i+nphys) = d(rng);
-            } while(throws(i+nphys) < args.systs.spline_lo[i]
-                    || throws(i+nphys) > args.systs.spline_hi[i]);
+        PROchi::EvalStrategy strat = args.binned ? PROchi::BinnedChi2 : PROchi::EventByEvent;
+        Eigen::VectorXf throws = Eigen::VectorXf::Constant(model->nparams + args.systs.GetNSplines(), 0);
+        for(size_t i = 0; i < model->nparams; ++i) throws(i) = args.phy_params(i);
+        size_t nparams = model->nparams + args.systs.GetNSplines();
+        Eigen::VectorXf lb_osc = Eigen::VectorXf::Constant(nparams, -3.0);
+        Eigen::VectorXf ub_osc = Eigen::VectorXf::Constant(nparams, 3.0);
+        Eigen::VectorXf lb = Eigen::VectorXf::Constant(nparams, -3.0);
+        Eigen::VectorXf ub = Eigen::VectorXf::Constant(nparams, 3.0);
+        size_t nphys = model->nparams;
+        //set physics to correct values
+        for(size_t j=0; j<nphys; j++){
+            ub_osc(j) = model->ub(j);
+            lb_osc(j) = model->lb(j); 
+            lb(j) = args.phy_params(j);
+            ub(j) =  args.phy_params(j);
         }
-        for(size_t i = 0; i < args.config.m_num_variable_bins_total_collapsed[args.config.i_prime]; i++)
-            throwC(i) = d(rng);
-        PROspec shifted = FillSpectra(args.config, args.prop, args.systs, *model, throws, strat);
-        log<LOG_DEBUG>(L"%1% || Shifted spectrum %2%\nfor throw %3%")
-            % __func__ % shifted.Spec() % throws;
-
-        PROspec newSpec = PROspec::PoissonVariation(PROspec(CollapseMatrix(args.config, shifted.Spec()) + args.L * throwC, CollapseMatrix(args.config, shifted.Error())), dseed(rng));
-        PROdata data(newSpec.Spec(), newSpec.Error());
-        //Metric Time
-        PROmetric *metric;
-        if(args.chi2 == "PROchi") {
-            metric = new PROchi("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
-        } else if(args.chi2 == "PROCNP") {
-            metric = new PROCNP("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
-        } else if(args.chi2 == "Poisson") {
-            metric = new PROpoisson("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
-        } else {
-            log<LOG_ERROR>(L"%1% || Unrecognized chi2 function %2%") % __func__ % args.chi2.c_str();
-            abort();
+        //upper lower bounds for splines
+        for(size_t j = nphys; j < nparams; ++j) {
+            lb_osc(j) = args.systs.spline_lo[j-nphys];
+            ub_osc(j) = args.systs.spline_hi[j-nphys];
+            lb(j) = args.systs.spline_lo[j-nphys];
+            ub(j) = args.systs.spline_hi[j-nphys];
         }
+        std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
+        Eigen::VectorXf seed_pt = Eigen::VectorXf::Zero(nparams);
+        for(size_t u = 0; u < args.todo; ++u) {
+            log<LOG_INFO>(L"%1% | Thread #%2% Throw #%3%") % __func__ % args.thread % u;
+            std::normal_distribution<float> d;
 
-        // No oscillations
-        PROfitter fitter(ub, lb, args.fitconfig, dseed(rng));
-        float chi2_syst = fitter.Fit(*metric);
+            Eigen::VectorXf throwC = Eigen::VectorXf::Constant(args.config.m_num_variable_bins_total_collapsed[args.config.i_prime], 0);
+            for(size_t i = 0; i < args.systs.GetNSplines(); i++) {
+                do {
+                    throws(i+nphys) = d(rng);
+                } while(throws(i+nphys) < args.systs.spline_lo[i]
+                        || throws(i+nphys) > args.systs.spline_hi[i]);
+            }
+            for(size_t i = 0; i < args.config.m_num_variable_bins_total_collapsed[args.config.i_prime]; i++)
+                throwC(i) = d(rng);
+            PROspec shifted = FillSpectra(args.config, args.prop, args.systs, *model, throws, strat);
+            log<LOG_DEBUG>(L"%1% || Shifted spectrum %2%\nfor throw %3%")
+                % __func__ % shifted.Spec() % throws;
 
-        for(size_t i = nphys; i < nparams; ++i) seed_pt(i) = fitter.best_fit(i);
+            PROspec newSpec = PROspec::PoissonVariation(PROspec(CollapseMatrix(args.config, shifted.Spec()) + args.L * throwC, CollapseMatrix(args.config, shifted.Error())), dseed(rng));
+            
+            PROdata data(newSpec.Spec(), newSpec.Error());
+            //Metric Time
+            PROmetric *metric;
+            if(args.chi2 == "PROchi") {
+                metric = new PROchi("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
+            } else if(args.chi2 == "PROCNP") {
+                metric = new PROCNP("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
+            } else if(args.chi2 == "Poisson") {
+                metric = new PROpoisson("", args.config, args.prop, &args.systs, *model, data, !args.binned ? PROmetric::EventByEvent : PROmetric::BinnedChi2);
+            } else {
+                log<LOG_ERROR>(L"%1% || Unrecognized chi2 function %2%") % __func__ % args.chi2.c_str();
+                abort();
+            }
 
-        // With oscillations
-        PROfitter fitter_osc(ub_osc, lb_osc, args.fitconfig, dseed(rng));
-        float chi2_osc = fitter_osc.Fit(*metric, seed_pt); 
-        //float chi2_osc = fitter_osc.Fit(*metric); 
+            // No oscillations
+            PROfitter fitter(ub, lb, args.fitconfig, dseed(rng));
+            metric->setBounds(lb,ub);
+            float chi2_syst = fitter.Fit(*metric);
+            metric->freeParams();
 
-        Eigen::VectorXf t = Eigen::VectorXf::Map(throws.data(), throws.size());
+            for(size_t i = nphys; i < nparams; ++i) seed_pt(i) = fitter.best_fit(i);
 
-        args.out->push_back({
-                chi2_syst, chi2_osc, 
-                (model->is_log10[0] ? std::pow(10.0f, fitter_osc.best_fit(0)) : fitter_osc.best_fit(0)),
-                (model->is_log10[1] ? std::pow(10.0f, fitter_osc.best_fit(1)) : fitter_osc.best_fit(1)),
-                fitter.best_fit.segment(2, nparams - 2) , 
-                fitter_osc.best_fit.segment(2, nparams-2),t  });
+            // With oscillations
+            PROfitter fitter_osc(ub_osc, lb_osc, args.fitconfig, dseed(rng));
+                         
+            float chi2_osc = -999;
+                metric->setBounds(lb_osc,ub_osc);
+                chi2_osc = fitter_osc.Fit(*metric, seed_pt); 
+                int nminima = fitter_osc.calcFreqSeedPoints(*metric);
+                for(size_t i=0; i< fitter_osc.freq_seed_points.size(); i++){
+                    float chi_freq = fitter_osc.freq_seed_values.at(i);
+                    if(chi_freq<chi2_osc){
+                        chi2_osc = chi_freq;
+                        fitter_osc.best_fit = fitter_osc.freq_seed_points.at(i);
+                    }
+                }
 
-        args.dchi2s->push_back(std::abs(chi2_syst - chi2_osc ));
-        delete metric;
-    }
-};
+
+            Eigen::VectorXf t = Eigen::VectorXf::Map(throws.data(), throws.size());
+
+            args.out->push_back({
+                    chi2_syst, chi2_osc, 
+                    (model->is_log10[0] ? std::pow(10.0f, fitter_osc.best_fit(0)) : fitter_osc.best_fit(0)),
+                    (model->is_log10[1] ? std::pow(10.0f, fitter_osc.best_fit(1)) : fitter_osc.best_fit(1)),
+                    fitter.best_fit.segment(2, nparams - 2) , 
+                    fitter_osc.best_fit.segment(2, nparams-2),t  });
+
+            args.dchi2s->push_back(std::abs(chi2_syst - chi2_osc ));
+            delete metric;
+        }
+    };
 
 }

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -27,8 +27,12 @@ namespace PROfit {
                 covar_names.push_back(syst.systname); 
                 ++n_covar;
             }else if(syst.mode == "external_covariance"){
-                //this->LoadExternalCovariance(syst);
-                covar_names.push_back(syst.systname);
+                if(other_index == syst.binning){
+                    //external covariances are only created for specific binning
+                    this->LoadExternalCovarianceMatrix(config,syst);
+                    covar_names.push_back(syst.systname);
+                    ++n_covar;
+                }
             }
         }
 
@@ -99,7 +103,7 @@ namespace PROfit {
                         tmp_centers(ret.n_splines) = spline_centers(idx);
                         ++ret.n_splines;
                         break;
-                        }
+                    }
                 case SystType::Covariance:
                     ret.syst_map[name] = std::make_pair(ret.covmat.size(), SystType::Covariance);
                     ret.covar_names.push_back(name);
@@ -342,7 +346,72 @@ namespace PROfit {
 
         return;
     }
+    void PROsyst::LoadExternalCovarianceMatrix(const PROconfig &config, const SystStruct& syst){
+        //this is matrix name
+        std::string matrixname = syst.GetSysName();
+        std::string filename = syst.external_filename;
+        log<LOG_INFO>(L"%1% || Loading a TMatrix from %2% named %3%") % __func__ % filename.c_str() % matrixname.c_str();
+        int nbins = config.m_num_variable_bins_total[other_index];
+        Eigen::MatrixXf fracM = Eigen::MatrixXf::Zero(nbins, nbins);
+        Eigen::MatrixXf corrM = Eigen::MatrixXf::Identity(nbins, nbins);
 
+        TFile* file = TFile::Open(filename.c_str(), "READ");
+        if(!file || file->IsZombie()){
+            log<LOG_ERROR>(L"%1% || Failed to open file: %2%") % __func__ % filename.c_str();
+            exit(EXIT_FAILURE);
+        }
+
+        TMatrixD* tmatrix = dynamic_cast<TMatrixD*>(file->Get(matrixname.c_str()));
+        if(!tmatrix){
+            log<LOG_ERROR>(L"%1% || Failed to load TMatrixD named %2% from file %3%") % __func__ % matrixname.c_str() % filename.c_str();
+            file->Close();
+            delete file;
+            exit(EXIT_FAILURE);
+        }
+
+        // Check dimensions match expected size
+        int nrows = tmatrix->GetNrows();
+        int ncols = tmatrix->GetNcols();
+        if(nrows != nbins || ncols != nbins){
+            log<LOG_ERROR>(L"%1% || Dimension mismatch: TMatrixD is %2%x%3% but expected %4%x%4%") 
+                % __func__ % nrows % ncols % nbins;
+            file->Close();
+            delete file;
+            exit(EXIT_FAILURE);
+        }
+
+        // Copy TMatrixD values into Eigen matrix
+        for(int i = 0; i < nbins; ++i){
+            for(int j = 0; j < nbins; ++j){
+                fracM(i, j) = static_cast<float>((*tmatrix)(i, j));
+            }
+        }
+
+        // Clean up ROOT objects
+        file->Close();
+        delete file;
+
+        // Zero out any NaN or infinite values
+        PROsyst::toFiniteMatrix(fracM);
+
+        // Check if matrix is positive semi-definite
+        if(!PROsyst::isPositiveSemiDefinite_WithTolerance(fracM, 2.0*Eigen::NumTraits<float>::dummy_precision())){
+            log<LOG_WARNING>(L"%1% || External covariance matrix %2% is not positive semi-definite!") 
+                % __func__ % matrixname.c_str();
+        }
+
+        // Generate correlation matrix from fractional covariance
+        corrM = PROsyst::GenerateCorrMatrix(fracM);
+
+        syst_map[matrixname] = {covmat.size(), SystType::Covariance};
+        covmat.push_back(fracM);
+        corrmat.push_back(corrM);
+
+        log<LOG_INFO>(L"%1% || Successfully loaded %2%x%3% covariance matrix %4%") 
+            % __func__ % nbins % nbins % matrixname.c_str();
+
+        return;
+    }
 
     std::pair<Eigen::MatrixXf, Eigen::MatrixXf>  PROsyst::GenerateCovarMatrices(const SystStruct& sys_obj){
         //get fractional covar
@@ -494,335 +563,335 @@ namespace PROfit {
 
     }
 
-    
-float PROsyst::GetSplineShift(int spline_num, float shift, int bin) const {
-    const Spline& spline = splines[spline_num];
-    if (bin < 0 || bin >= spline.bins) return -1;
 
-    // Find the right segment with egments are sorted by knob value
-    int offset = bin * spline.segments_per_bin;
-    const SplineSegment* segs = &spline.segments[offset];
+    float PROsyst::GetSplineShift(int spline_num, float shift, int bin) const {
+        const Spline& spline = splines[spline_num];
+        if (bin < 0 || bin >= spline.bins) return -1;
 
-    float lowest_knobval = segs[0].knot;
-    int shiftBin = std::clamp(int(shift - lowest_knobval), 0, spline.segments_per_bin - 1);
+        // Find the right segment with egments are sorted by knob value
+        int offset = bin * spline.segments_per_bin;
+        const SplineSegment* segs = &spline.segments[offset];
 
-    const SplineSegment& seg = segs[shiftBin];
-    float x = shift - seg.knot;
-    const auto& c = seg.coeffs;
-    return c[0] + x*(c[1] + x*(c[2] + x*c[3]));
-}
+        float lowest_knobval = segs[0].knot;
+        int shiftBin = std::clamp(int(shift - lowest_knobval), 0, spline.segments_per_bin - 1);
 
-void PROsyst::FillSpline(const SystStruct& syst) {
-    std::vector<PROspec> ratios;
-    ratios.reserve(syst.p_multi_spec.size());
-    float cv_integral = syst.p_cv->Spec().sum();
+        const SplineSegment& seg = segs[shiftBin];
+        float x = shift - seg.knot;
+        const auto& c = seg.coeffs;
+        return c[0] + x*(c[1] + x*(c[2] + x*c[3]));
+    }
+
+    void PROsyst::FillSpline(const SystStruct& syst) {
+        std::vector<PROspec> ratios;
+        ratios.reserve(syst.p_multi_spec.size());
+        float cv_integral = syst.p_cv->Spec().sum();
 
 
-    bool found0 = false;
-    std::vector<float> knobvals;
-    for (size_t i = 0; i < syst.p_multi_spec.size(); ++i) {
-        if (syst.knobval[i] > 0 && !found0) {
+        bool found0 = false;
+        std::vector<float> knobvals;
+        for (size_t i = 0; i < syst.p_multi_spec.size(); ++i) {
+            if (syst.knobval[i] > 0 && !found0) {
+                ratios.push_back(*syst.p_cv / *syst.p_cv);
+                knobvals.push_back(0);
+                found0 = true;
+            }
+            if (syst.knobval[i] == 0) found0 = true;
+
+            float mod = shape_only ? cv_integral / syst.p_multi_spec[i]->Spec().sum() : 1.0;
+            ratios.push_back(((*syst.p_multi_spec[i]) * mod) / *syst.p_cv);
+            knobvals.push_back(syst.knobval[i]);
+        }
+        if (!found0) {
             ratios.push_back(*syst.p_cv / *syst.p_cv);
             knobvals.push_back(0);
-            found0 = true;
         }
-        if (syst.knobval[i] == 0) found0 = true;
 
-        float mod = shape_only ? cv_integral / syst.p_multi_spec[i]->Spec().sum() : 1.0;
-        ratios.push_back(((*syst.p_multi_spec[i]) * mod) / *syst.p_cv);
-        knobvals.push_back(syst.knobval[i]);
-    }
-    if (!found0) {
-        ratios.push_back(*syst.p_cv / *syst.p_cv);
-        knobvals.push_back(0);
-    }
+        int nbins = syst.p_cv->GetNbins();
+        Spline spline;
+        spline.bins = nbins;
+        spline.segments_per_bin = knobvals.size(); 
 
-    int nbins = syst.p_cv->GetNbins();
-    Spline spline;
-    spline.bins = nbins;
-    spline.segments_per_bin = knobvals.size(); 
+        std::vector<SplineSegment> all_segments;
 
-    std::vector<SplineSegment> all_segments;
+        for (size_t i = 0; i < nbins; ++i) {
+            std::vector<SplineSegment> bin_segments;
 
-    for (size_t i = 0; i < nbins; ++i) {
-        std::vector<SplineSegment> bin_segments;
-
-    // This comment is copy-pasted from CAFAna:
-    // This is cubic interpolation. For each adjacent set of four points we
-    // determine coefficients for a cubic which will be the curve between the
-    // center two. We constrain the function to match the two center points
-    // and to have the right mean gradient at them. This causes this patch to
-    // match smoothly with the next one along. The resulting function is
-    // continuous and first and second differentiable. At the ends of the
-    // range we fit a quadratic instead with only one constraint on the
-    // slope. The coordinate conventions are that point y1 sits at x=0 and y2
-    // at x=1. The matrices are simply the inverses of writing out the
-    // constraints expressed above.
+            // This comment is copy-pasted from CAFAna:
+            // This is cubic interpolation. For each adjacent set of four points we
+            // determine coefficients for a cubic which will be the curve between the
+            // center two. We constrain the function to match the two center points
+            // and to have the right mean gradient at them. This causes this patch to
+            // match smoothly with the next one along. The resulting function is
+            // continuous and first and second differentiable. At the ends of the
+            // range we fit a quadratic instead with only one constraint on the
+            // slope. The coordinate conventions are that point y1 sits at x=0 and y2
+            // at x=1. The matrices are simply the inverses of writing out the
+            // constraints expressed above.
 
 
-        if (ratios.size() < 3) {
-            const float y1 = ratios[0].GetBinContent(i);
-            const float y2 = ratios[1].GetBinContent(i);
-            const float slope = (y2 - y1) / (knobvals[1] - knobvals[0]);
-            bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {y2, -slope, 0, 0}});
-            bin_segments.push_back(SplineSegment{(float)knobvals[0], {slope * (float)knobvals[0] + y1, slope, 0, 0}});
-        } else {
-            {
+            if (ratios.size() < 3) {
                 const float y1 = ratios[0].GetBinContent(i);
                 const float y2 = ratios[1].GetBinContent(i);
-                const float y3 = ratios[2].GetBinContent(i);
-                const Eigen::Vector3f v{y1, y2, (y3 - y1) / 2};
-                const Eigen::Matrix3f m{{1, -1, 1},
-                                        {-2, 2, -1},
-                                        {1, 0, 0}};
-                const Eigen::Vector3f res = m * v;
-                bin_segments.push_back(SplineSegment{(float)knobvals[0], {res(2), res(1), res(0), 0}});
-            }
-            for (unsigned int shiftIdx = 1; shiftIdx < ratios.size() - 2; ++shiftIdx) {
-                const float y0 = ratios[shiftIdx - 1].GetBinContent(i);
-                const float y1 = ratios[shiftIdx].GetBinContent(i);
-                const float y2 = ratios[shiftIdx + 1].GetBinContent(i);
-                const float y3 = ratios[shiftIdx + 2].GetBinContent(i);
-                const Eigen::Vector4f v{y1, y2, (y2 - y0) / 2, (y3 - y1) / 2};
-                const Eigen::Matrix4f m{{2, -2, 1, 1},
-                                        {-3, 3, -2, -1},
-                                        {0, 0, 1, 0},
-                                        {1, 0, 0, 0}};
-                const Eigen::Vector4f res = m * v;
-                float knobval = knobvals[shiftIdx];
-                if (!found0 && knobval >= 0)
-                    knobval = knobvals[shiftIdx] == 1 ? 0 : knobvals[shiftIdx - 1];
-                bin_segments.push_back(SplineSegment{knobval, {res(3), res(2), res(1), res(0)}});
-            }
-            {
-                const float y4 = ratios[ratios.size() - 3].GetBinContent(i);
-                const float y5 = ratios[ratios.size() - 2].GetBinContent(i);
-                const float y6 = ratios[ratios.size() - 1].GetBinContent(i);
-                const Eigen::Vector3f vp{y5, y6, (y6 - y4) / 2};
-                const Eigen::Matrix3f mp{{-1, 1, -1},
-                                         {0, 0, 1},
-                                         {1, 0, 0}};
-                const Eigen::Vector3f resp = mp * vp;
-                bin_segments.push_back(SplineSegment{(float)knobvals[knobvals.size() - 2], {resp(2), resp(1), resp(0), 0}});
-            }
-        }
-
-        all_segments.insert(all_segments.end(), bin_segments.begin(), bin_segments.end());
-    }
-
-    // If all bins have the same number of segments, keep as knobvals.size(); else update
-    spline.segments_per_bin = all_segments.size() / nbins;
-    spline.segments = std::move(all_segments);
-
-    syst_map[syst.systname] = {splines.size(), SystType::Spline};
-    splines.push_back(std::move(spline));
-    spline_names.push_back(syst.systname);
-    spline_lo.push_back(knobvals[0]);
-    spline_hi.push_back(knobvals.back());
-    spline_binnings.push_back(syst.binning);
-
-}
-float PROsyst::GetSplineShift(std::string name, float shift, int bin) const {
-    if(syst_map.count(name) == 0) {
-        log<LOG_ERROR>(L"%1% || Unrecognized systematic %2%") % __func__ % name.c_str();
-        return 1;
-    }
-    return GetSplineShift(syst_map.at(name).first, shift, bin);
-}
-
-PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::string name, float shift) const {
-    int nbins = config.m_num_variable_bins_total[other_index];
-    int binning = spline_binnings[syst_map.at(name).first];
-    PROspec ret(nbins);
-    for(size_t i = 0; i < prop.NEvent(); ++i) {
-        const int spline_bin = prop.VariableBinIndex(binning, i);
-        const int reco_bin = prop.VariableBinIndex(other_index, i);
-        ret.Fill(reco_bin, GetSplineShift(name, shift, spline_bin) * prop.added_weights[i]);
-    }
-    return ret;
-}
-
-PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, int syst_num, float shift) const {
-    int nbins = config.m_num_variable_bins_total[other_index];
-    int binning = spline_binnings[syst_num];
-    PROspec ret(nbins);
-    for(size_t i = 0; i < prop.NEvent(); ++i) {
-        const int spline_bin = prop.VariableBinIndex(binning, i);
-        const int reco_bin = prop.VariableBinIndex(other_index, i);
-        ret.Fill(reco_bin, GetSplineShift(syst_num, shift, spline_bin) * prop.added_weights[i]);
-    }
-    return ret;
-}
-
-PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::vector<std::string> names, std::vector<float> shifts) const {
-    assert(names.size() == shifts.size());
-    int nbins = config.m_num_variable_bins_total[other_index];
-    PROspec ret(nbins);
-    for(size_t i = 0; i < prop.NEvent(); ++i) {
-        const int reco_bin = prop.VariableBinIndex(other_index, i);
-        float weight = 1;
-        for(size_t j = 0; j < names.size(); ++j) {
-            int binning = spline_binnings[syst_map.at(names[j]).first];
-            const int spline_bin = prop.VariableBinIndex(binning, i);
-            weight *= GetSplineShift(names[j], shifts[j], spline_bin);
-        }
-        ret.Fill(reco_bin, weight * prop.added_weights[i]);
-    }
-    return ret;
-}
-
-PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::vector<int> syst_nums, std::vector<float> shifts) const {
-    assert(syst_nums.size() == shifts.size());
-    int nbins = config.m_num_variable_bins_total[other_index];
-    PROspec ret(nbins);
-    for(size_t i = 0; i < prop.NEvent(); ++i) {
-        const int reco_bin = prop.VariableBinIndex(other_index, i);
-        float weight = 1;
-        for(size_t j = 0; j < syst_nums.size(); ++j) {
-            int binning = spline_binnings[syst_nums[j]];
-            const int spline_bin = prop.VariableBinIndex(binning, i);
-            weight *= GetSplineShift(syst_nums[j], shifts[j], spline_bin);
-        }
-        ret.Fill(reco_bin, weight * prop.added_weights[i]);
-    }
-    return ret;
-}
-
-PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::vector<float> shifts) const {
-    assert(shifts.size() == splines.size());
-    int nbins = config.m_num_variable_bins_total[other_index];
-    PROspec ret(nbins);
-    for(size_t i = 0; i < prop.NEvent(); ++i) {
-        const int reco_bin = prop.VariableBinIndex(other_index, i);
-        float weight = 1;
-        for(size_t j = 0; j < shifts.size(); ++j) {
-            int binning = spline_binnings[j];
-            const int spline_bin = prop.VariableBinIndex(binning, i);
-            weight *= GetSplineShift(j, shifts[j], spline_bin);
-        }
-        ret.Fill(reco_bin, weight * prop.added_weights[i]);
-    }
-    return ret;
-}
-
-Eigen::MatrixXf PROsyst::GrabMatrix(const std::string& sys) const{
-    if(syst_map.find(sys) != syst_map.end())
-        return covmat.at(syst_map.at(sys).first);	
-    else{
-        log<LOG_ERROR>(L"%1% || Systematic you asked for : %2% doesn't have matrix saved yet..") % __func__ % sys.c_str();
-        log<LOG_ERROR>(L"%1% || Return empty matrix .") % __func__ ;
-        return Eigen::MatrixXf();
-    }
-}
-
-Eigen::MatrixXf PROsyst::GrabCorrMatrix(const std::string& sys) const{
-    if(syst_map.find(sys) != syst_map.end())
-        return corrmat.at(syst_map.at(sys).first);	
-    else{
-        log<LOG_ERROR>(L"%1% || Systematic you asked for : %2% doesn't have matrix saved yet..") % __func__ % sys.c_str();
-        log<LOG_ERROR>(L"%1% || Return empty matrix .") % __func__ ;
-        return Eigen::MatrixXf();
-    }
-}
-
-Spline PROsyst::GrabSpline(const std::string& sys) const{
-    if(syst_map.find(sys) != syst_map.end())
-        return splines.at(syst_map.at(sys).first);	
-    else{
-        log<LOG_ERROR>(L"%1% || Systematic you asked for : %2% doesn't have spline saved yet..") % __func__ % sys.c_str();
-        return {};
-    }
-}
-
-PROsyst::SystType PROsyst::GetSystType(const std::string &syst) const {
-    return syst_map.at(syst).second;
-}
-
-Eigen::MatrixXf PROsyst::DecomposeFractionalCovariance(const PROconfig &config, const Eigen::VectorXf &cv_vec) const {
-    Eigen::MatrixXf diag = cv_vec.asDiagonal();
-    Eigen::MatrixXf full_cov = diag * fractional_covariance * diag;
-    Eigen::MatrixXf coll = other_index < 0 ? CollapseMatrix(config, full_cov) : CollapseMatrix(config, full_cov, other_index);
-    /*Eigen::LDLT<Eigen::MatrixXf> ldlt(coll);
-      Eigen::MatrixXf L = ldlt.matrixL(); 
-      Eigen::VectorXf D_sqrt = ldlt.vectorD().array().sqrt();  
-      Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
-
-      if (ldlt.info() != Eigen::Success) {
-      log<LOG_ERROR>(L"%1% | Eigen LLT has failed!") % __func__ ;
-      Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(coll);
-      int rank = lu_decomp.rank();
-      int size = coll.rows();
-      if (!coll.isApprox(coll.transpose())) {
-      log<LOG_ERROR>(L"%1% | Matrix is not symmetric! Rank %2% and size %3%") % __func__ % rank % size ;
-      }
-      Eigen::SelfAdjointEigenSolver<Eigen::MatrixXf> eigensolver(coll);
-      if (eigensolver.eigenvalues().minCoeff() <= 0) {
-      log<LOG_ERROR>(L"%1% | Matrix is not positive semi definite, minCoeff is %2%. Rank %3% and size %4% ") % __func__ % eigensolver.eigenvalues().minCoeff() % rank % size;
-      }
-      Eigen::JacobiSVD<Eigen::MatrixXf> svd(coll);
-      log<LOG_ERROR>(L"%1% | Singular values: %2% ") % __func__ % svd.singularValues();
-
-      Eigen::IOFormat fmt(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", "\n", "", "", "", "");
-      std::ostringstream oss;
-      oss << coll.format(fmt);
-      log<LOG_ERROR>(L"%1% | Matrix is %2% ") % __func__ % oss.str().c_str();
-      exit(EXIT_FAILURE);
-      }
-      return P * L * D_sqrt.asDiagonal();*/
-    Eigen::JacobiSVD<Eigen::MatrixXf> svd(coll, Eigen::ComputeThinU | Eigen::ComputeThinV);
-    const auto& U = svd.matrixU();
-    const auto& S = svd.singularValues();
-
-    log<LOG_DEBUG>(L"%1% | Singular values: %2% ") % __func__ % svd.singularValues();
-
-    Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(coll);
-    int rank = lu_decomp.rank();
-    int size = coll.rows();
-    log<LOG_DEBUG>(L"%1% | Matrix is Rank %2% and size %3%") % __func__ % rank % size ;
-
-    float tol = 1e-8f * S.maxCoeff(); // Some cutoff? is this value impactful on out matricies? need to test
-    std::vector<int> keep;
-    for (int i = 0; i < S.size(); ++i) {
-        if (S(i) > tol) keep.push_back(i);
-    }
-
-    if (keep.empty()) {
-        log<LOG_ERROR>(L"%1% | All singular values are below tolerance, cannot sample. Blarg.") % __func__;
-        exit(EXIT_FAILURE);
-    }
-
-    //going to keep only the singular values that give meaningful variance
-    Eigen::MatrixXf fallback_sampler = Eigen::MatrixXf::Zero(coll.rows(), coll.cols());
-    for (size_t i = 0; i < keep.size(); ++i) {
-        fallback_sampler.col(i) = U.col(keep[i]) * std::sqrt(S(keep[i]));
-    }
-
-    return fallback_sampler;
-
-}
-
-void PROsyst::PrintSplines(){
-    std::cout << "=== NEW FLAT SPLINE STRUCTURE ===\n";
-    for (size_t spline_idx = 0; spline_idx < splines.size(); ++spline_idx) {
-        const auto &spline = splines[spline_idx];
-        std::cout << "Spline #" << spline_idx << ":\n";
-        for (int bin_idx = 0; bin_idx < spline.bins; ++bin_idx) {
-            std::cout << "  Bin " << bin_idx << ":\n";
-            for (int seg_idx = 0; seg_idx < spline.segments_per_bin; ++seg_idx) {
-                const auto &seg = spline.segments[bin_idx * spline.segments_per_bin + seg_idx];
-                std::cout << std::fixed << std::setprecision(4)
-                    << "    Segment " << seg_idx
-                    << ": knot=" << seg.knot
-                    << ", coeffs=[";
-                for (int c = 0; c < 4; ++c) {
-                    std::cout << seg.coeffs[c];
-                    if (c < 3) std::cout << ", ";
+                const float slope = (y2 - y1) / (knobvals[1] - knobvals[0]);
+                bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {y2, -slope, 0, 0}});
+                bin_segments.push_back(SplineSegment{(float)knobvals[0], {slope * (float)knobvals[0] + y1, slope, 0, 0}});
+            } else {
+                {
+                    const float y1 = ratios[0].GetBinContent(i);
+                    const float y2 = ratios[1].GetBinContent(i);
+                    const float y3 = ratios[2].GetBinContent(i);
+                    const Eigen::Vector3f v{y1, y2, (y3 - y1) / 2};
+                    const Eigen::Matrix3f m{{1, -1, 1},
+                        {-2, 2, -1},
+                        {1, 0, 0}};
+                    const Eigen::Vector3f res = m * v;
+                    bin_segments.push_back(SplineSegment{(float)knobvals[0], {res(2), res(1), res(0), 0}});
                 }
-                std::cout << "]\n";
+                for (unsigned int shiftIdx = 1; shiftIdx < ratios.size() - 2; ++shiftIdx) {
+                    const float y0 = ratios[shiftIdx - 1].GetBinContent(i);
+                    const float y1 = ratios[shiftIdx].GetBinContent(i);
+                    const float y2 = ratios[shiftIdx + 1].GetBinContent(i);
+                    const float y3 = ratios[shiftIdx + 2].GetBinContent(i);
+                    const Eigen::Vector4f v{y1, y2, (y2 - y0) / 2, (y3 - y1) / 2};
+                    const Eigen::Matrix4f m{{2, -2, 1, 1},
+                        {-3, 3, -2, -1},
+                        {0, 0, 1, 0},
+                        {1, 0, 0, 0}};
+                    const Eigen::Vector4f res = m * v;
+                    float knobval = knobvals[shiftIdx];
+                    if (!found0 && knobval >= 0)
+                        knobval = knobvals[shiftIdx] == 1 ? 0 : knobvals[shiftIdx - 1];
+                    bin_segments.push_back(SplineSegment{knobval, {res(3), res(2), res(1), res(0)}});
+                }
+                {
+                    const float y4 = ratios[ratios.size() - 3].GetBinContent(i);
+                    const float y5 = ratios[ratios.size() - 2].GetBinContent(i);
+                    const float y6 = ratios[ratios.size() - 1].GetBinContent(i);
+                    const Eigen::Vector3f vp{y5, y6, (y6 - y4) / 2};
+                    const Eigen::Matrix3f mp{{-1, 1, -1},
+                        {0, 0, 1},
+                        {1, 0, 0}};
+                    const Eigen::Vector3f resp = mp * vp;
+                    bin_segments.push_back(SplineSegment{(float)knobvals[knobvals.size() - 2], {resp(2), resp(1), resp(0), 0}});
+                }
+            }
+
+            all_segments.insert(all_segments.end(), bin_segments.begin(), bin_segments.end());
+        }
+
+        // If all bins have the same number of segments, keep as knobvals.size(); else update
+        spline.segments_per_bin = all_segments.size() / nbins;
+        spline.segments = std::move(all_segments);
+
+        syst_map[syst.systname] = {splines.size(), SystType::Spline};
+        splines.push_back(std::move(spline));
+        spline_names.push_back(syst.systname);
+        spline_lo.push_back(knobvals[0]);
+        spline_hi.push_back(knobvals.back());
+        spline_binnings.push_back(syst.binning);
+
+    }
+    float PROsyst::GetSplineShift(std::string name, float shift, int bin) const {
+        if(syst_map.count(name) == 0) {
+            log<LOG_ERROR>(L"%1% || Unrecognized systematic %2%") % __func__ % name.c_str();
+            return 1;
+        }
+        return GetSplineShift(syst_map.at(name).first, shift, bin);
+    }
+
+    PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::string name, float shift) const {
+        int nbins = config.m_num_variable_bins_total[other_index];
+        int binning = spline_binnings[syst_map.at(name).first];
+        PROspec ret(nbins);
+        for(size_t i = 0; i < prop.NEvent(); ++i) {
+            const int spline_bin = prop.VariableBinIndex(binning, i);
+            const int reco_bin = prop.VariableBinIndex(other_index, i);
+            ret.Fill(reco_bin, GetSplineShift(name, shift, spline_bin) * prop.added_weights[i]);
+        }
+        return ret;
+    }
+
+    PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, int syst_num, float shift) const {
+        int nbins = config.m_num_variable_bins_total[other_index];
+        int binning = spline_binnings[syst_num];
+        PROspec ret(nbins);
+        for(size_t i = 0; i < prop.NEvent(); ++i) {
+            const int spline_bin = prop.VariableBinIndex(binning, i);
+            const int reco_bin = prop.VariableBinIndex(other_index, i);
+            ret.Fill(reco_bin, GetSplineShift(syst_num, shift, spline_bin) * prop.added_weights[i]);
+        }
+        return ret;
+    }
+
+    PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::vector<std::string> names, std::vector<float> shifts) const {
+        assert(names.size() == shifts.size());
+        int nbins = config.m_num_variable_bins_total[other_index];
+        PROspec ret(nbins);
+        for(size_t i = 0; i < prop.NEvent(); ++i) {
+            const int reco_bin = prop.VariableBinIndex(other_index, i);
+            float weight = 1;
+            for(size_t j = 0; j < names.size(); ++j) {
+                int binning = spline_binnings[syst_map.at(names[j]).first];
+                const int spline_bin = prop.VariableBinIndex(binning, i);
+                weight *= GetSplineShift(names[j], shifts[j], spline_bin);
+            }
+            ret.Fill(reco_bin, weight * prop.added_weights[i]);
+        }
+        return ret;
+    }
+
+    PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::vector<int> syst_nums, std::vector<float> shifts) const {
+        assert(syst_nums.size() == shifts.size());
+        int nbins = config.m_num_variable_bins_total[other_index];
+        PROspec ret(nbins);
+        for(size_t i = 0; i < prop.NEvent(); ++i) {
+            const int reco_bin = prop.VariableBinIndex(other_index, i);
+            float weight = 1;
+            for(size_t j = 0; j < syst_nums.size(); ++j) {
+                int binning = spline_binnings[syst_nums[j]];
+                const int spline_bin = prop.VariableBinIndex(binning, i);
+                weight *= GetSplineShift(syst_nums[j], shifts[j], spline_bin);
+            }
+            ret.Fill(reco_bin, weight * prop.added_weights[i]);
+        }
+        return ret;
+    }
+
+    PROspec PROsyst::GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::vector<float> shifts) const {
+        assert(shifts.size() == splines.size());
+        int nbins = config.m_num_variable_bins_total[other_index];
+        PROspec ret(nbins);
+        for(size_t i = 0; i < prop.NEvent(); ++i) {
+            const int reco_bin = prop.VariableBinIndex(other_index, i);
+            float weight = 1;
+            for(size_t j = 0; j < shifts.size(); ++j) {
+                int binning = spline_binnings[j];
+                const int spline_bin = prop.VariableBinIndex(binning, i);
+                weight *= GetSplineShift(j, shifts[j], spline_bin);
+            }
+            ret.Fill(reco_bin, weight * prop.added_weights[i]);
+        }
+        return ret;
+    }
+
+    Eigen::MatrixXf PROsyst::GrabMatrix(const std::string& sys) const{
+        if(syst_map.find(sys) != syst_map.end())
+            return covmat.at(syst_map.at(sys).first);	
+        else{
+            log<LOG_ERROR>(L"%1% || Systematic you asked for : %2% doesn't have matrix saved yet..") % __func__ % sys.c_str();
+            log<LOG_ERROR>(L"%1% || Return empty matrix .") % __func__ ;
+            return Eigen::MatrixXf();
+        }
+    }
+
+    Eigen::MatrixXf PROsyst::GrabCorrMatrix(const std::string& sys) const{
+        if(syst_map.find(sys) != syst_map.end())
+            return corrmat.at(syst_map.at(sys).first);	
+        else{
+            log<LOG_ERROR>(L"%1% || Systematic you asked for : %2% doesn't have matrix saved yet..") % __func__ % sys.c_str();
+            log<LOG_ERROR>(L"%1% || Return empty matrix .") % __func__ ;
+            return Eigen::MatrixXf();
+        }
+    }
+
+    Spline PROsyst::GrabSpline(const std::string& sys) const{
+        if(syst_map.find(sys) != syst_map.end())
+            return splines.at(syst_map.at(sys).first);	
+        else{
+            log<LOG_ERROR>(L"%1% || Systematic you asked for : %2% doesn't have spline saved yet..") % __func__ % sys.c_str();
+            return {};
+        }
+    }
+
+    PROsyst::SystType PROsyst::GetSystType(const std::string &syst) const {
+        return syst_map.at(syst).second;
+    }
+
+    Eigen::MatrixXf PROsyst::DecomposeFractionalCovariance(const PROconfig &config, const Eigen::VectorXf &cv_vec) const {
+        Eigen::MatrixXf diag = cv_vec.asDiagonal();
+        Eigen::MatrixXf full_cov = diag * fractional_covariance * diag;
+        Eigen::MatrixXf coll = other_index < 0 ? CollapseMatrix(config, full_cov) : CollapseMatrix(config, full_cov, other_index);
+        /*Eigen::LDLT<Eigen::MatrixXf> ldlt(coll);
+          Eigen::MatrixXf L = ldlt.matrixL(); 
+          Eigen::VectorXf D_sqrt = ldlt.vectorD().array().sqrt();  
+          Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> P(ldlt.transpositionsP());
+
+          if (ldlt.info() != Eigen::Success) {
+          log<LOG_ERROR>(L"%1% | Eigen LLT has failed!") % __func__ ;
+          Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(coll);
+          int rank = lu_decomp.rank();
+          int size = coll.rows();
+          if (!coll.isApprox(coll.transpose())) {
+          log<LOG_ERROR>(L"%1% | Matrix is not symmetric! Rank %2% and size %3%") % __func__ % rank % size ;
+          }
+          Eigen::SelfAdjointEigenSolver<Eigen::MatrixXf> eigensolver(coll);
+          if (eigensolver.eigenvalues().minCoeff() <= 0) {
+          log<LOG_ERROR>(L"%1% | Matrix is not positive semi definite, minCoeff is %2%. Rank %3% and size %4% ") % __func__ % eigensolver.eigenvalues().minCoeff() % rank % size;
+          }
+          Eigen::JacobiSVD<Eigen::MatrixXf> svd(coll);
+          log<LOG_ERROR>(L"%1% | Singular values: %2% ") % __func__ % svd.singularValues();
+
+          Eigen::IOFormat fmt(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", "\n", "", "", "", "");
+          std::ostringstream oss;
+          oss << coll.format(fmt);
+          log<LOG_ERROR>(L"%1% | Matrix is %2% ") % __func__ % oss.str().c_str();
+          exit(EXIT_FAILURE);
+          }
+          return P * L * D_sqrt.asDiagonal();*/
+        Eigen::JacobiSVD<Eigen::MatrixXf> svd(coll, Eigen::ComputeThinU | Eigen::ComputeThinV);
+        const auto& U = svd.matrixU();
+        const auto& S = svd.singularValues();
+
+        log<LOG_DEBUG>(L"%1% | Singular values: %2% ") % __func__ % svd.singularValues();
+
+        Eigen::FullPivLU<Eigen::MatrixXf> lu_decomp(coll);
+        int rank = lu_decomp.rank();
+        int size = coll.rows();
+        log<LOG_DEBUG>(L"%1% | Matrix is Rank %2% and size %3%") % __func__ % rank % size ;
+
+        float tol = 1e-8f * S.maxCoeff(); // Some cutoff? is this value impactful on out matricies? need to test
+        std::vector<int> keep;
+        for (int i = 0; i < S.size(); ++i) {
+            if (S(i) > tol) keep.push_back(i);
+        }
+
+        if (keep.empty()) {
+            log<LOG_ERROR>(L"%1% | All singular values are below tolerance, cannot sample. Blarg.") % __func__;
+            exit(EXIT_FAILURE);
+        }
+
+        //going to keep only the singular values that give meaningful variance
+        Eigen::MatrixXf fallback_sampler = Eigen::MatrixXf::Zero(coll.rows(), coll.cols());
+        for (size_t i = 0; i < keep.size(); ++i) {
+            fallback_sampler.col(i) = U.col(keep[i]) * std::sqrt(S(keep[i]));
+        }
+
+        return fallback_sampler;
+
+    }
+
+    void PROsyst::PrintSplines(){
+        std::cout << "=== NEW FLAT SPLINE STRUCTURE ===\n";
+        for (size_t spline_idx = 0; spline_idx < splines.size(); ++spline_idx) {
+            const auto &spline = splines[spline_idx];
+            std::cout << "Spline #" << spline_idx << ":\n";
+            for (int bin_idx = 0; bin_idx < spline.bins; ++bin_idx) {
+                std::cout << "  Bin " << bin_idx << ":\n";
+                for (int seg_idx = 0; seg_idx < spline.segments_per_bin; ++seg_idx) {
+                    const auto &seg = spline.segments[bin_idx * spline.segments_per_bin + seg_idx];
+                    std::cout << std::fixed << std::setprecision(4)
+                        << "    Segment " << seg_idx
+                        << ": knot=" << seg.knot
+                        << ", coeffs=[";
+                    for (int c = 0; c < 4; ++c) {
+                        std::cout << seg.coeffs[c];
+                        if (c < 3) std::cout << ", ";
+                    }
+                    std::cout << "]\n";
+                }
             }
         }
     }
-}
 
 };
 

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -26,6 +26,9 @@ namespace PROfit {
                 this->CreateFlatMatrix(config, syst); 
                 covar_names.push_back(syst.systname); 
                 ++n_covar;
+            }else if(syst.mode == "external_covariance"){
+                //this->LoadExternalCovariance(syst);
+                covar_names.push_back(syst.systname);
             }
         }
 


### PR DESCRIPTION
Added the ability to load TMatrixD from an extenral file. The matrix should be a fractional_covariance for the entire 
for the binning `binning`. The element name itself is the TMatrix name, with the "filename" being the root file

**WARNING**! there is no checks the subchannels match up, as there cant be. We check the total binning.

`<allowlist type="external_covariance" binning="var0" filename="test_covariance.root" plotname="test" tag="OtherXSec">test_cov</allowlist>
`