### PR TITLE
Add build_param_index call for 3p1_3A model

### DIFF
--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -772,7 +772,7 @@ public:
         pretty_param_names = {"#Deltam^{2}", "sin^{2}2#theta_{ee}", "sin^{2}#theta_{24}"}; 
         pretty_param_units = {"eV^{2}", "",""};
         is_log10 = {true, true, true};
-
+        build_param_index();
         lb = Eigen::VectorXf(3);
         ub = Eigen::VectorXf(3);
         default_val = Eigen::VectorXf(3);


### PR DESCRIPTION
Added a `build_param_index()` call for the "3+1_3A" model. Verified that `process` now completes without errors.