### PR TITLE
New XML systematic name options, improved xml reading error messages

### DIFF
--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -103,17 +103,23 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
     //Setup TiXml documents
     tinyxml2::XMLDocument doc;
-    doc.LoadFile(filename.c_str());
-    bool loadOkay = !doc.ErrorID();
+    tinyxml2::XMLError loadResult = doc.LoadFile(filename.c_str());
 
     bool use_universe = 1; //FIX
-    try{
-        if(loadOkay) log<LOG_INFO>(L"%1% || Correctly loaded and parsed XML, continuing") % __func__;
-        else throw 404;    
-    }
-    catch (int ernum) {
-        log<LOG_ERROR>(L"%1% || ERROR: Failed to load XML configuration file names %4%. @ line %2% in %3% ") % __func__ % __LINE__  % __FILE__ % filename.c_str();
-        log<LOG_ERROR>(L"This generally means broken brackets or attribute syntax in xml itself.");
+    if(loadResult == tinyxml2::XML_SUCCESS) {
+        log<LOG_INFO>(L"%1% || Correctly loaded and parsed XML, continuing") % __func__;
+    } else {
+        log<LOG_ERROR>(L"%1% || ERROR: Failed to load XML configuration file: %2%") % __func__ % filename.c_str();
+        if(loadResult == tinyxml2::XML_ERROR_FILE_NOT_FOUND) {
+            log<LOG_ERROR>(L"The XML file was not found. Check the file path and name.");
+        } else if(loadResult == tinyxml2::XML_ERROR_FILE_COULD_NOT_BE_OPENED) {
+            log<LOG_ERROR>(L"The XML file could not be opened. Check file permissions.");
+        } else if(loadResult == tinyxml2::XML_ERROR_FILE_READ_ERROR) {
+            log<LOG_ERROR>(L"Error reading the XML file.");
+        } else {
+            log<LOG_ERROR>(L"XML parsing error: %1%") % doc.ErrorStr();
+            log<LOG_ERROR>(L"This generally means broken brackets or attribute syntax in the XML itself.");
+        }
         log<LOG_ERROR>(L"Terminating.");
         exit(EXIT_FAILURE);
     }
@@ -124,7 +130,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
     //Temp usage
     i_prime=0;
-    std::vector<std::string> allowed_elements = {"mode", "detector", "channel", "MCFile","WeightMaps","model","variation_list","correlation","varied_spectrum", "ShapeOnlyUncertainty"   };
+    std::vector<std::string> allowed_elements = {"mode", "detector", "channel", "MCFile","WeightMaps","model","variation_list","systematics","correlation","varied_spectrum", "ShapeOnlyUncertainty"   };
     for (tinyxml2::XMLElement* elem = doc.FirstChildElement(); elem; elem = elem->NextSiblingElement()) {
         std::string name = elem->Name();
         if (std::find(allowed_elements.begin(), allowed_elements.end(), name) == allowed_elements.end()) {
@@ -544,6 +550,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
     pMC   = doc.FirstChildElement("MCFile");
     pWeiMaps = doc.FirstChildElement("WeightMaps");
     pList = doc.FirstChildElement("variation_list");
+    if(!pList) pList = doc.FirstChildElement("systematics"); // alternative name for variation_list
     pCorrelations = doc.FirstChildElement("correlation");
     pSpec = doc.FirstChildElement("varied_spectrum");
     pShapeOnlyMap = doc.FirstChildElement("ShapeOnlyUncertainty");
@@ -831,7 +838,9 @@ int PROconfig::LoadFromXML(const std::string &filename){
     }else{
         while(pList){
 
+            // Support both old naming (allowlist) and new naming (systematic)
             tinyxml2::XMLElement *pAllowList = pList->FirstChildElement("allowlist");
+            if(!pAllowList) pAllowList = pList->FirstChildElement("systematic");
             while(pAllowList){
                 const char *text = pAllowList->GetText();
                 std::string wt = "null";
@@ -842,9 +851,9 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
-                        log<LOG_ERROR>(L"%1% || ERROR! Attribute [%2%] in the <allowlist> element is not expected.") % __func__ % name.c_str()  ;
+                        log<LOG_ERROR>(L"%1% || ERROR! Attribute [%2%] in the <allowlist>/<systematic> element is not expected.") % __func__ % name.c_str()  ;
                         log<LOG_ERROR>(L"%1% || -- Check spelling: allowed attributes are %2%") % __func__ % expected_attrs ;
-                        throw std::invalid_argument(std::string("<allowlist> attribute not allowed : ") + name);
+                        throw std::invalid_argument(std::string("<allowlist>/<systematic> attribute not allowed : ") + name);
                     }
                 }
 
@@ -916,7 +925,9 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     m_mcgen_variation_tags[wt] = tags_vec;
                 }
                 log<LOG_DEBUG>(L"%1% || Allowlisting variations: %2%") % __func__ % wt.c_str() ;
-                pAllowList = pAllowList->NextSiblingElement("allowlist");
+                tinyxml2::XMLElement *pNext = pAllowList->NextSiblingElement("allowlist");
+                if(!pNext) pNext = pAllowList->NextSiblingElement("systematic");
+                pAllowList = pNext;
             }
 
             tinyxml2::XMLElement *pDenyList = pList->FirstChildElement("denylist");
@@ -926,7 +937,9 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 log<LOG_DEBUG>(L"%1% || Denylisting variations: %2%") % __func__ % bt.c_str() ;
                 pDenyList = pDenyList->NextSiblingElement("denylist");
             }
-            pList = pList->NextSiblingElement("variation_list");
+            tinyxml2::XMLElement *pNextList = pList->NextSiblingElement("variation_list");
+            if(!pNextList) pNextList = pList->NextSiblingElement("systematics");
+            pList = pNextList;
         }
     }
 

--- a/xml/PROfit_Tutorial_Oct2025v1_FullSBN_nue_app.xml
+++ b/xml/PROfit_Tutorial_Oct2025v1_FullSBN_nue_app.xml
@@ -115,63 +115,63 @@
 
 </MCFile>
 
-<variation_list>
+<systematics>
     <!-- Inlcude MC stats, uncomment out to remove -->
-    <allowlist type="mcstat" plotname="MC Stats" tag="Other">MCStat</allowlist>
+    <systematic type="mcstat" plotname="MC Stats" tag="Other">MCStat</systematic>
 
-    <allowlist type="norm" plotname="SBNDDet" tag="Other">nu_SBND:0.02</allowlist>
-    <allowlist type="norm" plotname="ICARUSDet" tag="Other">nu_ICARUS:0.02</allowlist>
+    <systematic type="norm" plotname="SBNDDet" tag="Other">nu_SBND:0.02</systematic>
+    <systematic type="norm" plotname="ICARUSDet" tag="Other">nu_ICARUS:0.02</systematic>
 
-    <allowlist type="spline"  binning="var1" plotname="ZExpA1CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA1CCQE</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="ZExpA2CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA2CCQE</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="ZExpA3CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA3CCQE</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="ZExpA4CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA4CCQE</allowlist>
+    <systematic type="spline"  binning="var1" plotname="ZExpA1CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA1CCQE</systematic>
+    <systematic type="spline"  binning="var1" plotname="ZExpA2CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA2CCQE</systematic>
+    <systematic type="spline"  binning="var1" plotname="ZExpA3CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA3CCQE</systematic>
+    <systematic type="spline"  binning="var1" plotname="ZExpA4CCQE" tag="Zexpansion">GENIEReWeight_SBN_v1_multisigma_ZExpA4CCQE</systematic>
 
-    <allowlist type="spline"  binning="var1"  plotname="MaCCRES" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_MaCCRES</allowlist>
-    <allowlist type="spline"  binning="var1"  plotname="MvCCRES" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_MvCCRES</allowlist>
-    <allowlist type="spline"  binning="var1"  plotname="RPA_CCQE" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_RPA_CCQE</allowlist>
-    <allowlist type="spline"  binning="var1"  plotname="CoulombCCQE" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_CoulombCCQE</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="NormCCMEC" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_NormCCMEC</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="FrCEx_N" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_N</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="FrCEx_pi" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_pi</allowlist>
+    <systematic type="spline"  binning="var1"  plotname="MaCCRES" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_MaCCRES</systematic>
+    <systematic type="spline"  binning="var1"  plotname="MvCCRES" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_MvCCRES</systematic>
+    <systematic type="spline"  binning="var1"  plotname="RPA_CCQE" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_RPA_CCQE</systematic>
+    <systematic type="spline"  binning="var1"  plotname="CoulombCCQE" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_CoulombCCQE</systematic>
+    <systematic type="spline"  binning="var1" plotname="NormCCMEC" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisigma_NormCCMEC</systematic>
+    <systematic type="spline"  binning="var1" plotname="FrCEx_N" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_N</systematic>
+    <systematic type="spline"  binning="var1" plotname="FrCEx_pi" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_pi</systematic>
 
-    <allowlist type="covariance" plotname="NCELVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_NCELVariationResponse</allowlist>
-    <allowlist type="covariance" plotname="NCRESVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_NCRESVariationResponse</allowlist>
-    <allowlist type="covariance" plotname="COHVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_COHVariationResponse</allowlist>
-    <allowlist type="covariance" plotname="DISBYVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_DISBYVariationResponse</allowlist>
-    <allowlist type="covariance" plotname="FSI_pi" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisim_FSI_pi_VariationResponse</allowlist>
-    <allowlist type="covariance" plotname="FSI_N" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisim_FSI_N_VariationResponse</allowlist>
-    <allowlist type="covariance" plotname="NormNCMEC" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_NormNCMEC</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC2pi</allowlist>
+    <systematic type="covariance" plotname="NCELVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_NCELVariationResponse</systematic>
+    <systematic type="covariance" plotname="NCRESVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_NCRESVariationResponse</systematic>
+    <systematic type="covariance" plotname="COHVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_COHVariationResponse</systematic>
+    <systematic type="covariance" plotname="DISBYVariationResponse" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_DISBYVariationResponse</systematic>
+    <systematic type="covariance" plotname="FSI_pi" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisim_FSI_pi_VariationResponse</systematic>
+    <systematic type="covariance" plotname="FSI_N" tag="Cross-Section-II-FSI">GENIEReWeight_SBN_v1_multisim_FSI_N_VariationResponse</systematic>
+    <systematic type="covariance" plotname="NormNCMEC" tag="Cross-Section-I">GENIEReWeight_SBN_v1_multisim_NormNCMEC</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnCC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnCC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnNC1pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnNC2pi" tag="Cross-Section-III-NonRes">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC2pi</systematic>
     <!-- use all flux covariance systs from multisimTree-->
-    <allowlist type="covariance" tag="Flux">expskin_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">horncurrent_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">nucleoninexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">nucleonqexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">nucleontotxsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">pioninexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">pionqexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">piontotxsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">piplus_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">piminus_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">kplus_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">kminus_Flux</allowlist>  
-    <allowlist type="covariance" tag="Flux">kzero_Flux</allowlist> 
-</variation_list>
+    <systematic type="covariance" tag="Flux">expskin_Flux</systematic>
+    <systematic type="covariance" tag="Flux">horncurrent_Flux</systematic>
+    <systematic type="covariance" tag="Flux">nucleoninexsec_Flux</systematic>
+    <systematic type="covariance" tag="Flux">nucleonqexsec_Flux</systematic>
+    <systematic type="covariance" tag="Flux">nucleontotxsec_Flux</systematic>
+    <systematic type="covariance" tag="Flux">pioninexsec_Flux</systematic>
+    <systematic type="covariance" tag="Flux">pionqexsec_Flux</systematic>
+    <systematic type="covariance" tag="Flux">piontotxsec_Flux</systematic>
+    <systematic type="covariance" tag="Flux">piplus_Flux</systematic>
+    <systematic type="covariance" tag="Flux">piminus_Flux</systematic>
+    <systematic type="covariance" tag="Flux">kplus_Flux</systematic>
+    <systematic type="covariance" tag="Flux">kminus_Flux</systematic>
+    <systematic type="covariance" tag="Flux">kzero_Flux</systematic>
+</systematics>
 
 

--- a/xml/PROfit_Tutorial_Oct2025v1_SPINE_ICARUS_numu_dis.xml
+++ b/xml/PROfit_Tutorial_Oct2025v1_SPINE_ICARUS_numu_dis.xml
@@ -78,81 +78,81 @@
     </branch>
 </MCFile>
 
-<variation_list>
+<systematics>
     <!-- MC Statistics -->
-    <allowlist type="mcstat" plotname="MC Stats" tag="other">MCStat</allowlist>
-    
+    <systematic type="mcstat" plotname="MC Stats" tag="other">MCStat</systematic>
+
     <!-- Interaction Model Systematics -->
-    <allowlist type="spline" binning="var1" plotname="ZExp_b1" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b1</allowlist>
-    <allowlist type="spline" binning="var1" plotname="ZExp_b2" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b2</allowlist>
-    <allowlist type="spline" binning="var1" plotname="ZExp_b3" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b3</allowlist>
-    <allowlist type="spline" binning="var1" plotname="ZExp_b4" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b4</allowlist>
-    <allowlist type="covariance" plotname="NCELVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_NCELVariationResponse</allowlist>
-    <allowlist type="spline" binning="var1" plotname="MaCCRES" tag="OtherXSec">GENIEReWeight_SBN_v1_multisigma_MaCCRES</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="MvCCRES" tag="OtherXSec">GENIEReWeight_SBN_v1_multisigma_MvCCRES</allowlist>
-    <allowlist type="covariance" plotname="NCRESVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_NCRESVariationResponse</allowlist>
-    <allowlist type="covariance" plotname="COHVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_COHVariationResponse</allowlist>
-    <allowlist type="covariance" plotname="DISBYVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_DISBYVariationResponse</allowlist>
-    <allowlist type="covariance" plotname="FSI_pi" tag="FSI">GENIEReWeight_SBN_v1_multisim_FSI_pi_VariationResponse</allowlist>
-    <allowlist type="covariance" plotname="FSI_N" tag="FSI">GENIEReWeight_SBN_v1_multisim_FSI_N_VariationResponse</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="RPA_CCQE" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_RPA_CCQE</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="CoulombCCQE" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_CoulombCCQE</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="NormCCMEC" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_NormCCMEC</allowlist>
-    <allowlist type="covariance" plotname="NormNCMEC" tag="QE-MEC">GENIEReWeight_SBN_v1_multisim_NormNCMEC</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvpNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvnNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarpNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC2pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC1pi</allowlist>
-    <allowlist type="covariance" plotname="NonRESBGvbarnNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC2pi</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="FrCEx_N" tag="FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_N</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="FrCEx_pi" tag="FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_pi</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="DecayAngMEC" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_DecayAngMEC</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="XSecShape_CCMEC" tag="QE-MEC">GENIEReWeight_SBNNuSyst_GENIE_multisigma_XSecShape_CCMEC</allowlist>
-    <allowlist type="spline"  binning="var1" plotname="FracPN_CCMEC" tag="QE-MEC">GENIEReWeight_SBNNuSyst_GENIE_multisigma_FracPN_CCMEC</allowlist>
+    <systematic type="spline" binning="var1" plotname="ZExp_b1" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b1</systematic>
+    <systematic type="spline" binning="var1" plotname="ZExp_b2" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b2</systematic>
+    <systematic type="spline" binning="var1" plotname="ZExp_b3" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b3</systematic>
+    <systematic type="spline" binning="var1" plotname="ZExp_b4" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b4</systematic>
+    <systematic type="covariance" plotname="NCELVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_NCELVariationResponse</systematic>
+    <systematic type="spline" binning="var1" plotname="MaCCRES" tag="OtherXSec">GENIEReWeight_SBN_v1_multisigma_MaCCRES</systematic>
+    <systematic type="spline"  binning="var1" plotname="MvCCRES" tag="OtherXSec">GENIEReWeight_SBN_v1_multisigma_MvCCRES</systematic>
+    <systematic type="covariance" plotname="NCRESVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_NCRESVariationResponse</systematic>
+    <systematic type="covariance" plotname="COHVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_COHVariationResponse</systematic>
+    <systematic type="covariance" plotname="DISBYVariationResponse" tag="OtherXSec">GENIEReWeight_SBN_v1_multisim_DISBYVariationResponse</systematic>
+    <systematic type="covariance" plotname="FSI_pi" tag="FSI">GENIEReWeight_SBN_v1_multisim_FSI_pi_VariationResponse</systematic>
+    <systematic type="covariance" plotname="FSI_N" tag="FSI">GENIEReWeight_SBN_v1_multisim_FSI_N_VariationResponse</systematic>
+    <systematic type="spline"  binning="var1" plotname="RPA_CCQE" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_RPA_CCQE</systematic>
+    <systematic type="spline"  binning="var1" plotname="CoulombCCQE" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_CoulombCCQE</systematic>
+    <systematic type="spline"  binning="var1" plotname="NormCCMEC" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_NormCCMEC</systematic>
+    <systematic type="covariance" plotname="NormNCMEC" tag="QE-MEC">GENIEReWeight_SBN_v1_multisim_NormNCMEC</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvpNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpNC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvnNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvnNC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarpNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarpNC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnCC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnCC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnCC2pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnNC1pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC1pi</systematic>
+    <systematic type="covariance" plotname="NonRESBGvbarnNC2pi" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvbarnNC2pi</systematic>
+    <systematic type="spline"  binning="var1" plotname="FrCEx_N" tag="FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_N</systematic>
+    <systematic type="spline"  binning="var1" plotname="FrCEx_pi" tag="FSI">GENIEReWeight_SBN_v1_multisigma_FrCEx_pi</systematic>
+    <systematic type="spline"  binning="var1" plotname="DecayAngMEC" tag="QE-MEC">GENIEReWeight_SBN_v1_multisigma_DecayAngMEC</systematic>
+    <systematic type="spline"  binning="var1" plotname="XSecShape_CCMEC" tag="QE-MEC">GENIEReWeight_SBNNuSyst_GENIE_multisigma_XSecShape_CCMEC</systematic>
+    <systematic type="spline"  binning="var1" plotname="FracPN_CCMEC" tag="QE-MEC">GENIEReWeight_SBNNuSyst_GENIE_multisigma_FracPN_CCMEC</systematic>
 
     <!--- Flux covariance syststematics -->
-    <allowlist type="covariance" tag="fluxsyst">expskin_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">horncurrent_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">nucleoninexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">nucleonqexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">nucleontotxsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">pioninexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">pionqexsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">piontotxsec_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">piplus_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">piminus_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">kplus_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">kminus_Flux</allowlist>  
-    <allowlist type="covariance" tag="fluxsyst">kzero_Flux</allowlist> 
+    <systematic type="covariance" tag="fluxsyst">expskin_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">horncurrent_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">nucleoninexsec_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">nucleonqexsec_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">nucleontotxsec_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">pioninexsec_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">pionqexsec_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">piontotxsec_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">piplus_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">piminus_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">kplus_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">kminus_Flux</systematic>
+    <systematic type="covariance" tag="fluxsyst">kzero_Flux</systematic>
 
     <!--- Detector and Reconstruction Systematics -->
-    <allowlist type="spline" binning="var0" plotname="8msLifetime" tag="detsyst">var01</allowlist>
-    <allowlist type="spline" binning="var0" plotname="Ind1WireGap" tag="detsyst">var04</allowlist>
-    <allowlist type="spline" binning="var0" plotname="Ind2ShapingTime" tag="detsyst">var11</allowlist>
-    <allowlist type="spline" binning="var0" plotname="Recomb" tag="detsyst">var05</allowlist>
-    <allowlist type="spline" binning="var0" plotname="PMTQE" tag="detsyst">var06</allowlist>
-    <allowlist type="spline" binning="var0" plotname="CohNoise" tag="detsyst">var10</allowlist>
-    <allowlist type="spline" binning="var0" plotname="IntNoise" tag="detsyst">var13</allowlist>
-    <allowlist type="spline" binning="var0" plotname="TPCYZNonUni" tag="detsyst">var07</allowlist>
-    <allowlist type="spline" binning="var0" plotname="SignalShape" tag="detsyst">var12</allowlist>
+    <systematic type="spline" binning="var0" plotname="8msLifetime" tag="detsyst">var01</systematic>
+    <systematic type="spline" binning="var0" plotname="Ind1WireGap" tag="detsyst">var04</systematic>
+    <systematic type="spline" binning="var0" plotname="Ind2ShapingTime" tag="detsyst">var11</systematic>
+    <systematic type="spline" binning="var0" plotname="Recomb" tag="detsyst">var05</systematic>
+    <systematic type="spline" binning="var0" plotname="PMTQE" tag="detsyst">var06</systematic>
+    <systematic type="spline" binning="var0" plotname="CohNoise" tag="detsyst">var10</systematic>
+    <systematic type="spline" binning="var0" plotname="IntNoise" tag="detsyst">var13</systematic>
+    <systematic type="spline" binning="var0" plotname="TPCYZNonUni" tag="detsyst">var07</systematic>
+    <systematic type="spline" binning="var0" plotname="SignalShape" tag="detsyst">var12</systematic>
 
     <!-- Unused Detector and Reconstruction Systematics -->
-    <!--<allowlist type="spline" binning="reco" plotname="OldIntrinsicNoise" tag="det">var09</allowlist>-->
-    <!--<allowlist type="spline" binning="reco" plotname="FrontInductionGain" tag="det">var03</allowlist>-->
+    <!--<systematic type="spline" binning="reco" plotname="OldIntrinsicNoise" tag="det">var09</systematic>-->
+    <!--<systematic type="spline" binning="reco" plotname="FrontInductionGain" tag="det">var03</systematic>-->
 
     <!--- Normalization Systematics -->
-    <allowlist type="norm" binning="reco" plotname="FluxNorm" tag="other">nu_ICARUS_numu_n:0.02</allowlist>
-    <allowlist type="norm" plotname="FiducialVol" tag="other">nu_ICARUS:0.01</allowlist>
-</variation_list>
+    <systematic type="norm" binning="reco" plotname="FluxNorm" tag="other">nu_ICARUS_numu_n:0.02</systematic>
+    <systematic type="norm" plotname="FiducialVol" tag="other">nu_ICARUS:0.01</systematic>
+</systematics>
 


### PR DESCRIPTION
Adds clearer naming options in xml tags: `systematics` optionally replaces `variation_list`, and `systematic` optionally replaces `allowlist`. Switches to these for the included tutorial xmls.

Also adds clearer and more detailed xml reading error messages. Previously, it said `generally means broken brackets or attribute syntax in xml itself` when the xml file did not exist.