### PR TITLE
Fix Logging Typo

### DIFF
--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -323,7 +323,7 @@ namespace PROfit {
                         log<LOG_DEBUG>(L"%1% || Checking if branch %2% is in allowlist") % __func__ %  branch->GetName();
 
                         if (std::find(inconfig.m_mcgen_variation_allowlist.begin(), inconfig.m_mcgen_variation_allowlist.end(), branch->GetName()) != inconfig.m_mcgen_variation_allowlist.end()) {
-                            log<LOG_INFO>(L"%1% || Setting up eventweight map for this branch: %2% for fid %3$") % __func__ %  branch->GetName() % fid;
+                            log<LOG_INFO>(L"%1% || Setting up eventweight map for this branch: %2% for fid %3%") % __func__ %  branch->GetName() % fid;
                             chains[fid]->SetBranchAddress(branch->GetName(), &(f_event_weights[fid][0][branch->GetName()]));
                             allowlist_check.push_back(branch->GetName());
                         } else if(strlen(branch->GetName()) > 6 && strcmp(branch->GetName() + strlen(branch->GetName()) - 6, "_sigma") == 0) {


### PR DESCRIPTION
Fixing a simple bug that causes a crash, caused by a dollar sign rather than a percentage sign. Originally encountered by Anthony.