### PR TITLE
Changing Surface 2D color map from red-blue to Viridis

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1382,6 +1382,7 @@ int main(int argc, char* argv[])
             if(logx)
                 c.SetLogx();
             c.SetLogz();
+            gStyle->SetPalette(kViridis);
             surf.Draw("colz");
             c.Print((final_output_tag+"_surface.pdf").c_str());
         }

--- a/pybind/profit.cxx
+++ b/pybind/profit.cxx
@@ -164,7 +164,8 @@ void savePROsurf(const PROfit::PROsurf &surface,
     if(logy) c.SetLogy();
     if(logx) c.SetLogx();
     c.SetLogz();
-    
+
+    gStyle->SetPalette(kViridis);
     surf.Draw("colz");
     c.Print(pdffile.c_str());
   }


### PR DESCRIPTION
Changing the surface 2D color map from red-blue to Viridis. This is perceptually uniform, and avoids the confusion caused by intermediate chi^2 values being the same color (white) as very low chi^2 values (less than one, off the bottom of the log scale).