### PR TITLE
Adding restrict option to adjust spline systematic limits

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -2136,8 +2136,9 @@ int main(int argc, char* argv[])
                 ub(i) = metric->GetModel().default_val(i);
             }
             for(size_t i = nphys; i < nparams; ++i) {
-                lb(i) = metric->GetSysts().spline_lo[i-nphys];
-                ub(i) = metric->GetSysts().spline_hi[i-nphys];
+                size_t si = i - nphys;
+                lb(i) = metric->GetSysts().spline_has_restrict[si] ? metric->GetSysts().spline_restrict_lo[si] : metric->GetSysts().spline_lo[si];
+                ub(i) = metric->GetSysts().spline_has_restrict[si] ? metric->GetSysts().spline_restrict_hi[si] : metric->GetSysts().spline_hi[si];
             }
             metric->setBounds(lb, ub);
             PROfitter fitter(metric->UpperBound(), metric->LowerBound(), fitConfig);

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1168,7 +1168,7 @@ int main(int argc, char* argv[])
         log<LOG_INFO>(L"%1% || fakedataparams for Plot (true_params/red stars): %2%") % __func__ % fakedataparams;
         profile.Plot(config, metric->GetSysts(), metric->GetModel(), *metric, myseed,
                 final_output_tag+"_PROfile", !systs_only, best_fit,
-                fakedataparams);
+                fakedataparams, spline_covariance);
         TFile fout((final_output_tag+"_PROfile.root").c_str(), "RECREATE");
         profile.onesig.Write("one_sigma_errs");
         pre_hist.Write("cv");

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1085,6 +1085,7 @@ int main(int argc, char* argv[])
 
         std::vector<TH1D> priors, posteriors;
         Eigen::MatrixXf prior_covariance, spline_covariance;
+        Eigen::VectorXf prior_param_lo, prior_param_hi, post_param_lo, post_param_hi;
         // Fix physics parameters
         std::vector<int> fixed_pars;
         for(size_t i = 0; i < N_phys_params; ++i) fixed_pars.push_back(i);
@@ -1098,15 +1099,15 @@ int main(int argc, char* argv[])
         //log<LOG_INFO>(L"%1% ||ARSOut %2% ") % __func__ % cv.Spec();
         //log<LOG_INFO>(L"%1% || address %2%") % __func__ % &cv;
 
-        PROerrorbar  err_band = 
+        PROerrorbar  err_band =
             MCMC_prefit_errors
-            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, binwidth_scale,config.i_prime)
+            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
         //Metropolis mh_post(simple_target{*metric}, simple_proposal(*metric, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
         Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
-        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, binwidth_scale,config.i_prime);
+        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, post_param_lo, post_param_hi, binwidth_scale,config.i_prime);
 
         std::vector<TPaveText> texts;
         TPaveText chi2text(0.55, 0.50, 0.85, 0.58, "NDC");
@@ -1168,7 +1169,7 @@ int main(int argc, char* argv[])
         log<LOG_INFO>(L"%1% || fakedataparams for Plot (true_params/red stars): %2%") % __func__ % fakedataparams;
         profile.Plot(config, metric->GetSysts(), metric->GetModel(), *metric, myseed,
                 final_output_tag+"_PROfile", !systs_only, best_fit,
-                fakedataparams, spline_covariance);
+                fakedataparams, spline_covariance, post_param_lo, post_param_hi);
         TFile fout((final_output_tag+"_PROfile.root").c_str(), "RECREATE");
         profile.onesig.Write("one_sigma_errs");
         pre_hist.Write("cv");
@@ -2455,6 +2456,7 @@ int main(int argc, char* argv[])
 
         std::vector<TH1D> priors, posteriors;
         Eigen::MatrixXf prior_covariance, spline_covariance;
+        Eigen::VectorXf prior_param_lo, prior_param_hi, post_param_lo, post_param_hi;
         // Fix physics parameters
         std::vector<int> fixed_pars;
         for(size_t i = 0; i < N_phys_params; ++i) fixed_pars.push_back(i);
@@ -2466,14 +2468,14 @@ int main(int argc, char* argv[])
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
         Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
-        PROerrorbar  err_band = 
+        PROerrorbar  err_band =
             MCMC_prefit_errors
-            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, binwidth_scale,config.i_prime)
+            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
         Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
-        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, binwidth_scale,config.i_prime);
+        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, post_param_lo, post_param_hi, binwidth_scale,config.i_prime);
 
         std::vector<TPaveText> texts;
         TPaveText chi2text(0.55, 0.50, 0.85, 0.58, "NDC");

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -288,8 +288,16 @@ namespace PROfit {
                         return false;
                 } else {
                     size_t si = i - nparams;
-                    float lo = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_lo[si] : metric.GetSysts().spline_lo[si];
-                    float hi = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_hi[si] : metric.GetSysts().spline_hi[si];
+                    float lo, hi;
+                    if(metric.GetSysts().spline_has_restrict[si]) {
+                        lo = metric.GetSysts().spline_restrict_lo[si];
+                        hi = metric.GetSysts().spline_restrict_hi[si];
+                    } else if(metric.GetSysts().spline_hi[si] == 1.0f) {
+                        lo = -1.0f; hi = 1.0f;
+                    } else {
+                        lo = metric.GetSysts().spline_lo[si];
+                        hi = metric.GetSysts().spline_hi[si];
+                    }
                     if(value(i) < lo || value(i) > hi) return false;
                 }
             }
@@ -409,8 +417,16 @@ namespace PROfit {
                         return false;
                 } else {
                     size_t si = i - nparams;
-                    float lo = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_lo[si] : metric.GetSysts().spline_lo[si];
-                    float hi = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_hi[si] : metric.GetSysts().spline_hi[si];
+                    float lo, hi;
+                    if(metric.GetSysts().spline_has_restrict[si]) {
+                        lo = metric.GetSysts().spline_restrict_lo[si];
+                        hi = metric.GetSysts().spline_restrict_hi[si];
+                    } else if(metric.GetSysts().spline_hi[si] == 1.0f) {
+                        lo = -1.0f; hi = 1.0f;
+                    } else {
+                        lo = metric.GetSysts().spline_lo[si];
+                        hi = metric.GetSysts().spline_hi[si];
+                    }
                     if(value(i) < lo || value(i) > hi) return false;
                 }
             }

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -286,11 +286,11 @@ namespace PROfit {
                 if(i < nparams) {
                     if(value(i) > metric.GetModel().ub(i) || value(i) < metric.GetModel().lb(i) || value(i) < -5.0f)
                         return false;
-                } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
-                    if(value(i) < -1 || value(i) > 1) return false;
                 } else {
-                    if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
-                        return false;
+                    size_t si = i - nparams;
+                    float lo = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_lo[si] : metric.GetSysts().spline_lo[si];
+                    float hi = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_hi[si] : metric.GetSysts().spline_hi[si];
+                    if(value(i) < lo || value(i) > hi) return false;
                 }
             }
             return true;
@@ -407,11 +407,11 @@ namespace PROfit {
                 if(i < nparams) {
                     if(value(i) > metric.GetModel().ub(i) || value(i) < std::max(metric.GetModel().lb(i),-5.0f))
                         return false;
-                } else if(metric.GetSysts().spline_hi[i-nparams] == 1.0) {
-                    if(value(i) < -1 || value(i) > 1) return false;
                 } else {
-                    if(value(i) < metric.GetSysts().spline_lo[i-nparams] || value(i) > metric.GetSysts().spline_hi[i-nparams])
-                        return false;
+                    size_t si = i - nparams;
+                    float lo = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_lo[si] : metric.GetSysts().spline_lo[si];
+                    float hi = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_hi[si] : metric.GetSysts().spline_hi[si];
+                    if(value(i) < lo || value(i) > hi) return false;
                 }
             }
             return true;

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -437,6 +437,7 @@ namespace PROfit{
             std::map<std::string, float> m_mcgen_variation_prior_centers;
             std::map<std::string, bool> m_mcgen_variation_force_0_cv; //map of systematics with force_0_cv=true (normalize shifts by shift at knob=0)
             std::map<std::string, std::vector<int>> m_mcgen_variation_include_only_weights; //map of systematics with include_only_weights (1-based indices of which weights to include in spline universes)
+            std::map<std::string, std::pair<float,float>> m_mcgen_variation_restrict; //map of systematics with restrict="lo, hi" (clamp knob value during evaluation and fitting)
             std::map<std::string, float> m_mcgen_variation_scale; //map of systematics with scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
       
             //FIX skepic

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -82,6 +82,9 @@ namespace PROfit{
         bool force_0_cv = false;    ///< If true, normalise spline shifts by the shift at knob=0.
         std::vector<int> include_only_weights; ///< 1-based indices of weight universes to include; empty = all.
         float scale = 1.0f;         ///< Scale factor applied to all weights (e.g. 0.001 for weights stored as x1000).
+        bool has_restrict = false;  ///< If true, clamp the knob value to [restrict_lo, restrict_hi] during evaluation and fitting.
+        float restrict_lo = 0.0f;   ///< Lower clamp bound (used only when has_restrict is true).
+        float restrict_hi = 0.0f;   ///< Upper clamp bound (used only when has_restrict is true).
 
         //boost serialization
         template<class Archive>
@@ -104,6 +107,9 @@ namespace PROfit{
             ar & force_0_cv;
             ar & include_only_weights;
             ar & scale;
+            ar & has_restrict;
+            ar & restrict_lo;
+            ar & restrict_hi;
         }
 
 

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -45,6 +45,7 @@
 //Boost
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/version.hpp>
 
 namespace PROfit{
 
@@ -88,7 +89,7 @@ namespace PROfit{
 
         //boost serialization
         template<class Archive>
-        void serialize(Archive &ar, [[maybe_unused]] const unsigned int version) {
+        void serialize(Archive &ar, const unsigned int version) {
             ar & systname;
             ar & n_univ;
             ar & mode;
@@ -100,16 +101,18 @@ namespace PROfit{
             ar & spline_coeffs;
             ar & binning;
             ar & p_cv;
-            ar & p_multi_spec;  
+            ar & p_multi_spec;
             ar & hash;
             ar & norm_bins;
             ar & norm_value;
             ar & force_0_cv;
             ar & include_only_weights;
             ar & scale;
-            ar & has_restrict;
-            ar & restrict_lo;
-            ar & restrict_hi;
+            if (version >= 1) {
+                ar & has_restrict;
+                ar & restrict_lo;
+                ar & restrict_hi;
+            }
         }
 
 
@@ -313,4 +316,7 @@ namespace PROfit{
 
 
 };
+
+BOOST_CLASS_VERSION(PROfit::SystStruct, 1)
+
 #endif

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -289,13 +289,13 @@ namespace PROfit{
      * @return PROerrorbar with per-bin asymmetric uncertainties and the histogram covariance.
      */
     template<class T, class P>
-        PROerrorbar getMCMCErrorBand(Metropolis<T, P> met, size_t burnin, size_t iterations, const PROconfig &config, const PROpeller &prop, PROmetric &metric, const Eigen::VectorXf &best_fit, std::vector<TH1D> &posteriors, Eigen::MatrixXf &post_covar,  bool scale = false,int var_index=0) {
+        PROerrorbar getMCMCErrorBand(Metropolis<T, P> met, size_t burnin, size_t iterations, const PROconfig &config, const PROpeller &prop, PROmetric &metric, const Eigen::VectorXf &best_fit, std::vector<TH1D> &posteriors, Eigen::MatrixXf &post_covar, Eigen::VectorXf &param_err_lo, Eigen::VectorXf &param_err_hi, bool scale = false, int var_index=0) {
             for(size_t i = 0; i < metric.GetSysts().GetNSplines(); ++i)
                 posteriors.emplace_back("", (";"+config.m_mcgen_variation_plotname_map.at(metric.GetSysts().spline_names[i])).c_str(), 60, -3, 3);
 
             Eigen::VectorXf cv = FillSpectra(config, prop, metric.GetSysts(), metric.GetModel(), best_fit, true, var_index).Spec();
             Eigen::VectorXf cv_coll = CollapseMatrix(config, cv);
-            Eigen::MatrixXf L; 
+            Eigen::MatrixXf L;
             if(metric.GetSysts().GetNCovar() > 0) L = metric.GetSysts().DecomposeFractionalCovariance(config, cv);
             else L = Eigen::MatrixXf::Zero(config.m_num_variable_bins_total_collapsed[var_index], config.m_num_variable_bins_total_collapsed[var_index]);
             std::normal_distribution<float> nd;
@@ -305,16 +305,19 @@ namespace PROfit{
             int nphys = metric.GetModel().nparams;
             Eigen::VectorXf splines_bf = best_fit.segment(nphys, nspline);
             post_covar = Eigen::MatrixXf::Constant(nspline, nspline, 0);
-	    Eigen::MatrixXf post_hist_covar = Eigen::MatrixXf::Constant(cv_coll.size(), cv_coll.size(), 0);
+            Eigen::MatrixXf post_hist_covar = Eigen::MatrixXf::Constant(cv_coll.size(), cv_coll.size(), 0);
             size_t nsteps = 0;
             std::vector<Eigen::VectorXf> specs;
+            std::vector<std::vector<float>> param_samples(nspline);
             const auto action = [&](const Eigen::VectorXf &value) {
                 nsteps += 1;
                 for(size_t i = 0; i < config.m_num_variable_bins_total_collapsed[var_index]; ++i)
                     throws(i) = nd(PROseed::global_rng);
                 specs.push_back(CollapseMatrix(config, FillSpectra(config, prop, metric.GetSysts(), metric.GetModel(), value, true,var_index).Spec())+L*throws);
-                for(size_t i = 0; i < metric.GetSysts().GetNSplines(); ++i)
+                for(int i = 0; i < nspline; ++i) {
                     posteriors[i].Fill(value(i+nphys));
+                    param_samples[i].push_back(value(i+nphys));
+                }
                 Eigen::VectorXf splines = value.segment(nphys, nspline);
                 Eigen::VectorXf diff = splines-splines_bf;
                 Eigen::VectorXf diff_hist = specs.back() - cv_coll;
@@ -324,6 +327,16 @@ namespace PROfit{
             met.run(burnin, iterations, action);
             post_hist_covar /= nsteps;
             post_covar /= nsteps;
+
+            param_err_lo = Eigen::VectorXf::Zero(nspline);
+            param_err_hi = Eigen::VectorXf::Zero(nspline);
+            for(int i = 0; i < nspline; ++i) {
+                auto &v = param_samples[i];
+                std::sort(v.begin(), v.end());
+                float bf_val = best_fit(nphys + i);
+                param_err_lo(i) = std::abs(bf_val - v[int(0.160f * v.size())]);
+                param_err_hi(i) = std::abs(v[int(0.840f * v.size())] - bf_val);
+            }
             log<LOG_INFO>(L"%1% || Acceptance rate %2%") % __func__ % ((float)met.naccept / iterations);
 
             cv = CollapseMatrix(config, cv);

--- a/inc/PROsurf.h
+++ b/inc/PROsurf.h
@@ -95,7 +95,7 @@ namespace PROfit {
 
             PROfile(const PROconfig &config, const PROsyst &systs, const PROmodel &model, PROmetric &metric, PROseed &proseed, const PROfitterConfig &fitconfig, std::string filename, float minchi = 0, bool with_osc = false, int nThreads = 1, const std::vector<Eigen::VectorXf> &seed_points = {}, const Eigen::VectorXf& true_params = Eigen::VectorXf() ) ;
 
-            void Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, PROmetric &metric, PROseed &proseed, std::string filename, bool with_osc = false, const Eigen::VectorXf& init_seed = Eigen::VectorXf(), const Eigen::VectorXf& true_params = Eigen::VectorXf(), const Eigen::MatrixXf& spline_covariance = Eigen::MatrixXf{}, bool mask_osc = false) ;
+            void Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, PROmetric &metric, PROseed &proseed, std::string filename, bool with_osc = false, const Eigen::VectorXf& init_seed = Eigen::VectorXf(), const Eigen::VectorXf& true_params = Eigen::VectorXf(), const Eigen::MatrixXf& spline_covariance = Eigen::MatrixXf{}, const Eigen::VectorXf& param_err_lo = Eigen::VectorXf{}, const Eigen::VectorXf& param_err_hi = Eigen::VectorXf{}, bool mask_osc = false) ;
 
             std::vector<profOut> PROfilePointHelper(const PROsyst *systs, const PROfitterConfig &fitconfig, int offset, int stride, float minchi, bool with_osc, MultiPROgressBar& progressbar, const std::vector<Eigen::VectorXf> &seed_points = {}, uint32_t seed=0);
     };

--- a/inc/PROsurf.h
+++ b/inc/PROsurf.h
@@ -95,7 +95,7 @@ namespace PROfit {
 
             PROfile(const PROconfig &config, const PROsyst &systs, const PROmodel &model, PROmetric &metric, PROseed &proseed, const PROfitterConfig &fitconfig, std::string filename, float minchi = 0, bool with_osc = false, int nThreads = 1, const std::vector<Eigen::VectorXf> &seed_points = {}, const Eigen::VectorXf& true_params = Eigen::VectorXf() ) ;
 
-            void Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, PROmetric &metric, PROseed &proseed, std::string filename, bool with_osc = false, const Eigen::VectorXf& init_seed = Eigen::VectorXf(), const Eigen::VectorXf& true_params = Eigen::VectorXf(), bool mask_osc = false) ;
+            void Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, PROmetric &metric, PROseed &proseed, std::string filename, bool with_osc = false, const Eigen::VectorXf& init_seed = Eigen::VectorXf(), const Eigen::VectorXf& true_params = Eigen::VectorXf(), const Eigen::MatrixXf& spline_covariance = Eigen::MatrixXf{}, bool mask_osc = false) ;
 
             std::vector<profOut> PROfilePointHelper(const PROsyst *systs, const PROfitterConfig &fitconfig, int offset, int stride, float minchi, bool with_osc, MultiPROgressBar& progressbar, const std::vector<Eigen::VectorXf> &seed_points = {}, uint32_t seed=0);
     };

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -226,6 +226,9 @@ namespace PROfit {
             std::vector<std::string> covar_names;    ///< Names of all covariance systematics in order.
             std::vector<float> spline_lo;            ///< Lower nuisance-parameter bound for each spline.
             std::vector<float> spline_hi;            ///< Upper nuisance-parameter bound for each spline.
+            std::vector<bool> spline_has_restrict;   ///< Whether each spline has an explicit restrict range.
+            std::vector<float> spline_restrict_lo;   ///< Lower clamp bound for each spline (used only when spline_has_restrict is true).
+            std::vector<float> spline_restrict_hi;   ///< Upper clamp bound for each spline (used only when spline_has_restrict is true).
             std::vector<int> spline_binnings;        ///< Binning-scheme index for each spline.
             Eigen::VectorXf spline_priors;           ///< Prior width (sigma) for each spline nuisance parameter.
             Eigen::VectorXf spline_centers;          ///< Prior centre for each spline nuisance parameter.

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1168,7 +1168,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 }
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar"};
+                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar", "restrict"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -1187,6 +1187,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *center = pAllowList->Attribute("center");
                 const char *force_0_cv = pAllowList->Attribute("force_0_cv");
                 const char *include_only_weights_str = pAllowList->Attribute("include_only_weights");
+                const char *restrict_str = pAllowList->Attribute("restrict");
                 const char *scale = pAllowList->Attribute("scale");
                 const char *filename = pAllowList->Attribute("filename");
                 const char *xvar = pAllowList->Attribute("xvar");
@@ -1302,6 +1303,16 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     if(begin) iow_vec.push_back(atoi(begin));
                     m_mcgen_variation_include_only_weights[wt] = iow_vec;
                     log<LOG_INFO>(L"%1% || Parsed include_only_weights for systematic %2%: %3% entries") % __func__ % wt.c_str() % iow_vec.size();
+                }
+                if(restrict_str) {
+                    char *end;
+                    float rlo = std::strtof(restrict_str, &end);
+                    if(end == restrict_str)
+                        throw std::invalid_argument(std::string("restrict attribute for systematic '") + wt + "' must be two numbers, e.g. restrict=\"-1, 1\"");
+                    while(*end == ' ' || *end == ',') ++end;
+                    float rhi = std::strtof(end, nullptr);
+                    m_mcgen_variation_restrict[wt] = {rlo, rhi};
+                    log<LOG_INFO>(L"%1% || Parsed restrict=[%2%, %3%] for systematic %4%") % __func__ % rlo % rhi % wt.c_str();
                 }
                 if(scale) {
                     m_mcgen_variation_scale[wt] = std::strtof(scale, NULL);

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -503,6 +503,13 @@ namespace PROfit {
                         sv.back().include_only_weights = inconfig.m_mcgen_variation_include_only_weights.at(sys_name);
                         log<LOG_INFO>(L"%1% || Setting include_only_weights for systematic %2% (%3% entries)") % __func__ % sys_name.c_str() % sv.back().include_only_weights.size();
                     }
+                    // Check if restrict is set for this systematic
+                    if(inconfig.m_mcgen_variation_restrict.find(sys_name) != inconfig.m_mcgen_variation_restrict.end()) {
+                        sv.back().has_restrict = true;
+                        sv.back().restrict_lo = inconfig.m_mcgen_variation_restrict.at(sys_name).first;
+                        sv.back().restrict_hi = inconfig.m_mcgen_variation_restrict.at(sys_name).second;
+                        log<LOG_INFO>(L"%1% || Setting restrict=[%2%, %3%] for systematic %4%") % __func__ % sv.back().restrict_lo % sv.back().restrict_hi % sys_name.c_str();
+                    }
                 }
                 if(sys_mode == "flat"){
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a flat covariance systematic. Processing a such. ") % __func__ % sys_name.c_str();

--- a/src/PROfc.cxx
+++ b/src/PROfc.cxx
@@ -25,10 +25,13 @@ void fc_worker(fc_args args, MultiPROgressBar &progress) {
     }
     //upper lower bounds for splines
     for(size_t j = nphys; j < nparams; ++j) {
-        lb_osc(j) = args.systs.spline_lo[j-nphys];
-        ub_osc(j) = args.systs.spline_hi[j-nphys];
-        lb(j) = args.systs.spline_lo[j-nphys];
-        ub(j) = args.systs.spline_hi[j-nphys];
+        size_t si = j - nphys;
+        float lo = args.systs.spline_has_restrict[si] ? args.systs.spline_restrict_lo[si] : args.systs.spline_lo[si];
+        float hi = args.systs.spline_has_restrict[si] ? args.systs.spline_restrict_hi[si] : args.systs.spline_hi[si];
+        lb_osc(j) = lo;
+        ub_osc(j) = hi;
+        lb(j) = lo;
+        ub(j) = hi;
     }
     std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
     Eigen::VectorXf cached_seed_syst = Eigen::VectorXf::Zero(nparams);
@@ -39,10 +42,11 @@ void fc_worker(fc_args args, MultiPROgressBar &progress) {
         std::normal_distribution<float> d;
         Eigen::VectorXf throwC = Eigen::VectorXf::Constant(args.config.m_num_variable_bins_total_collapsed[args.config.i_prime], 0);
         for(size_t i = 0; i < args.systs.GetNSplines(); i++) {
+            float tlo = args.systs.spline_has_restrict[i] ? args.systs.spline_restrict_lo[i] : args.systs.spline_lo[i];
+            float thi = args.systs.spline_has_restrict[i] ? args.systs.spline_restrict_hi[i] : args.systs.spline_hi[i];
             do {
                 throws(i+nphys) = d(rng);
-            } while(throws(i+nphys) < args.systs.spline_lo[i]
-                    || throws(i+nphys) > args.systs.spline_hi[i]);
+            } while(throws(i+nphys) < tlo || throws(i+nphys) > thi);
         }
         for(size_t i = 0; i < args.config.m_num_variable_bins_total_collapsed[args.config.i_prime]; i++)
             throwC(i) = d(rng);

--- a/src/PROfitter.cxx
+++ b/src/PROfitter.cxx
@@ -479,8 +479,9 @@ int PROfitter::calcFreqSeedPoints(PROmetric &metric) {
             ub(i) = metric.GetModel().ub(i);
         }
         for(size_t i = nphys; i < nparams; ++i) {
-            lb(i) = metric.GetSysts().spline_lo[i-nphys];
-            ub(i) = metric.GetSysts().spline_hi[i-nphys];
+            size_t si = i - nphys;
+            lb(i) = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_lo[si] : metric.GetSysts().spline_lo[si];
+            ub(i) = metric.GetSysts().spline_has_restrict[si] ? metric.GetSysts().spline_restrict_hi[si] : metric.GetSysts().spline_hi[si];
         }
 
         //fix dm at minima

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -225,8 +225,9 @@ std::vector<profOut> PROfile::PROfilePointHelper(const PROsyst *systs, const PRO
         }
         //upper lower bounds for splines
         for(int j = nphys; j < nparams; ++j) {
-            lb(j) = systs->spline_lo[j-nphys];
-            ub(j) = systs->spline_hi[j-nphys];
+            size_t si = j - nphys;
+            lb(j) = systs->spline_has_restrict[si] ? systs->spline_restrict_lo[si] : systs->spline_lo[si];
+            ub(j) = systs->spline_has_restrict[si] ? systs->spline_restrict_hi[si] : systs->spline_hi[si];
         }
     } else {
         // Syst-only mode: create full-size bounds but fix physics params at seed values
@@ -241,8 +242,9 @@ std::vector<profOut> PROfile::PROfilePointHelper(const PROsyst *systs, const PRO
         }
         // Spline bounds as normal
         for(int j = nphys; j < nparams; ++j) {
-            lb(j) = systs->spline_lo[j-nphys];
-            ub(j) = systs->spline_hi[j-nphys];
+            size_t si = j - nphys;
+            lb(j) = systs->spline_has_restrict[si] ? systs->spline_restrict_lo[si] : systs->spline_lo[si];
+            ub(j) = systs->spline_has_restrict[si] ? systs->spline_restrict_hi[si] : systs->spline_hi[si];
         }
     }
 

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -871,7 +871,7 @@ PROfile::PROfile(const PROconfig &config, const PROsyst &systs, const PROmodel &
 
 }
 
-void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, [[maybe_unused]] PROmetric &metric, [[maybe_unused]] PROseed &proseed, std::string filename, bool with_osc, const Eigen::VectorXf& init_seed, const Eigen::VectorXf & true_params, bool mask_osc) {
+void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, [[maybe_unused]] PROmetric &metric, [[maybe_unused]] PROseed &proseed, std::string filename, bool with_osc, const Eigen::VectorXf& init_seed, const Eigen::VectorXf & true_params, const Eigen::MatrixXf& spline_covariance, bool mask_osc) {
 
     int nparams = systs.GetNSplines() + model.nparams*with_osc;
     int nBins = nparams;
@@ -1102,11 +1102,27 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
     prior_band->SetLineWidth(1);
     prior_band->Draw("same");
 
-    // Post-fit ±1σ bars: blue; half-width shrinks for many bins
+    // Post-fit ±1σ bars (blue): centered on the global best-fit, width from the MCMC
+    // posterior covariance diagonal (Gaussian approximation).  For oscillation physics
+    // parameters (which have no entry in spline_covariance), fall back to the profile interval.
     TGraphAsymmErrors todraw = onesig;
     for(int i = 0; i < nBins; ++i) {
-        todraw.SetPointError(i, bar_halfwidth, bar_halfwidth,
-                             todraw.GetErrorYlow(i), todraw.GetErrorYhigh(i));
+        int vec_idx = with_osc ? i : (i + (int)model.nparams);
+        float center = (vec_idx < (int)init_seed.size()) ? (float)init_seed[vec_idx] : bfvalues[i];
+        // syst_idx indexes into spline_covariance (syst-only, no physics params)
+        int syst_idx = with_osc ? (i - (int)model.nparams) : i;
+        bool is_syst = !with_osc || (i >= (int)model.nparams);
+        float err_lo, err_hi;
+        if(is_syst && syst_idx >= 0 && syst_idx < (int)spline_covariance.rows()) {
+            float sigma = std::sqrt(std::abs(spline_covariance(syst_idx, syst_idx)));
+            err_lo = sigma;
+            err_hi = sigma;
+        } else {
+            err_lo = todraw.GetErrorYlow(i);
+            err_hi = todraw.GetErrorYhigh(i);
+        }
+        todraw.SetPoint(i, todraw.GetPointX(i), center);
+        todraw.SetPointError(i, bar_halfwidth, bar_halfwidth, err_lo, err_hi);
     }
     if(mask_osc) {
         for(size_t i = 0; i < model.nparams; ++i) {
@@ -1226,7 +1242,7 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
     leg->SetBorderSize(1);
     leg->SetTextSize(std::max(0.022f, std::min(0.030f, axis_label_size * 0.85f)));
     leg->AddEntry(prior_band,   "Pre-fit #pm1#sigma (prior)", "f");
-    leg->AddEntry(&todraw,      "Post-fit #pm1#sigma",        "f");
+    leg->AddEntry(&todraw,      "Post-fit #pm1#sigma (MCMC)", "f");
     leg->AddEntry(&profile_pts, "Profile scan #pm1#sigma", "pe");
     TGraph *leg_global = new TGraph(1);
     leg_global->SetPoint(0, 0, 0);

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -871,7 +871,7 @@ PROfile::PROfile(const PROconfig &config, const PROsyst &systs, const PROmodel &
 
 }
 
-void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, [[maybe_unused]] PROmetric &metric, [[maybe_unused]] PROseed &proseed, std::string filename, bool with_osc, const Eigen::VectorXf& init_seed, const Eigen::VectorXf & true_params, const Eigen::MatrixXf& spline_covariance, bool mask_osc) {
+void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel &model, [[maybe_unused]] PROmetric &metric, [[maybe_unused]] PROseed &proseed, std::string filename, bool with_osc, const Eigen::VectorXf& init_seed, const Eigen::VectorXf & true_params, const Eigen::MatrixXf& spline_covariance, const Eigen::VectorXf& param_err_lo, const Eigen::VectorXf& param_err_hi, bool mask_osc) {
 
     int nparams = systs.GetNSplines() + model.nparams*with_osc;
     int nBins = nparams;
@@ -1102,21 +1102,19 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
     prior_band->SetLineWidth(1);
     prior_band->Draw("same");
 
-    // Post-fit ±1σ bars (blue): centered on the global best-fit, width from the MCMC
-    // posterior covariance diagonal (Gaussian approximation).  For oscillation physics
-    // parameters (which have no entry in spline_covariance), fall back to the profile interval.
+    // Post-fit ±1σ bars (blue): centered on the global best-fit, width from MCMC
+    // 16th/84th percentile quantiles.  For oscillation physics parameters (no entry
+    // in param_err_lo/hi), fall back to the profile interval.
     TGraphAsymmErrors todraw = onesig;
     for(int i = 0; i < nBins; ++i) {
         int vec_idx = with_osc ? i : (i + (int)model.nparams);
         float center = (vec_idx < (int)init_seed.size()) ? (float)init_seed[vec_idx] : bfvalues[i];
-        // syst_idx indexes into spline_covariance (syst-only, no physics params)
         int syst_idx = with_osc ? (i - (int)model.nparams) : i;
         bool is_syst = !with_osc || (i >= (int)model.nparams);
         float err_lo, err_hi;
-        if(is_syst && syst_idx >= 0 && syst_idx < (int)spline_covariance.rows()) {
-            float sigma = std::sqrt(std::abs(spline_covariance(syst_idx, syst_idx)));
-            err_lo = sigma;
-            err_hi = sigma;
+        if(is_syst && syst_idx >= 0 && syst_idx < param_err_lo.size() && syst_idx < param_err_hi.size()) {
+            err_lo = param_err_lo(syst_idx);
+            err_hi = param_err_hi(syst_idx);
         } else {
             err_lo = todraw.GetErrorYlow(i);
             err_hi = todraw.GetErrorYhigh(i);

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -76,6 +76,9 @@ namespace PROfit {
                 spline_names.pop_back();
                 spline_lo.pop_back();
                 spline_hi.pop_back();
+                spline_has_restrict.pop_back();
+                spline_restrict_lo.pop_back();
+                spline_restrict_hi.pop_back();
                 spline_binnings.pop_back();
 
                 // Store as covariance instead
@@ -164,6 +167,9 @@ namespace PROfit {
                         ret.splines.push_back(std::move(spline_copy));
                         ret.spline_hi.push_back(spline_hi[idx]);
                         ret.spline_lo.push_back(spline_lo[idx]);
+                        ret.spline_has_restrict.push_back(spline_has_restrict[idx]);
+                        ret.spline_restrict_lo.push_back(spline_restrict_lo[idx]);
+                        ret.spline_restrict_hi.push_back(spline_restrict_hi[idx]);
                         ret.spline_binnings.push_back(spline_binnings[idx]);
                         tmp_priors(ret.n_splines) = spline_priors(idx);
                         tmp_centers(ret.n_splines) = spline_centers(idx);
@@ -210,6 +216,9 @@ namespace PROfit {
                         ret.splines.push_back(std::move(spline_copy));
                         ret.spline_hi.push_back(spline_hi[idx]);
                         ret.spline_lo.push_back(spline_lo[idx]);
+                        ret.spline_has_restrict.push_back(spline_has_restrict[idx]);
+                        ret.spline_restrict_lo.push_back(spline_restrict_lo[idx]);
+                        ret.spline_restrict_hi.push_back(spline_restrict_hi[idx]);
                         ret.spline_binnings.push_back(spline_binnings[idx]);
                         tmp_priors(ret.n_splines) = spline_priors(idx);
                         tmp_centers(ret.n_splines) = spline_centers(idx);
@@ -632,6 +641,9 @@ namespace PROfit {
         const Spline& spline = splines[spline_num];
         if (bin < 0 || bin >= spline.bins) return -1;
 
+        if (spline_has_restrict[spline_num])
+            shift = std::clamp(shift, spline_restrict_lo[spline_num], spline_restrict_hi[spline_num]);
+
         // Find the right segment with egments are sorted by knob value
         int offset = bin * spline.segments_per_bin;
         const SplineSegment* segs = &spline.segments[offset];
@@ -782,6 +794,9 @@ namespace PROfit {
         spline_names.push_back(syst.systname);
         spline_lo.push_back(knobvals[0]);
         spline_hi.push_back(knobvals.back());
+        spline_has_restrict.push_back(syst.has_restrict);
+        spline_restrict_lo.push_back(syst.restrict_lo);
+        spline_restrict_hi.push_back(syst.restrict_hi);
         spline_binnings.push_back(syst.binning);
 
     }

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -641,9 +641,6 @@ namespace PROfit {
         const Spline& spline = splines[spline_num];
         if (bin < 0 || bin >= spline.bins) return -1;
 
-        if (spline_has_restrict[spline_num])
-            shift = std::clamp(shift, spline_restrict_lo[spline_num], spline_restrict_hi[spline_num]);
-
         // Find the right segment with egments are sorted by knob value
         int offset = bin * spline.segments_per_bin;
         const SplineSegment* segs = &spline.segments[offset];

--- a/xml/uboone_with_splines/uboone_spline_tutorial_numuCCNp0p_opendata_fast_nevis.xml
+++ b/xml/uboone_with_splines/uboone_spline_tutorial_numuCCNp0p_opendata_fast_nevis.xml
@@ -1,0 +1,284 @@
+<?xml version="1.0" ?>
+
+<mode name="nu" />
+
+<!-- This fast xml skips DetVar and only loads 10% of events in each prediction file -->
+
+<detector name="uBooNE" pot="4.031e19" />
+
+<channel name="numuCCNpFC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
+	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
+	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
+	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
+	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
+</channel>
+<channel name="numuCC0pFC" plotname="Reconstructed Neutrino Energy [MeV]">
+	<bins unit="Reconstructed Neutrino Energy [MeV]" min="0" max="2500" nbins="25"/>
+	<bins unit="True Neutrino Energy [MeV]" min="0" max="3000" nbins="20"/>
+	<bins unit="True L/E" min="0" max="3000" nbins="250" plot="false"/>
+	<subchannel name="nueCCoverlay" plotname="#nu_{e}CC overlay" color="#12fc50"/>
+	<subchannel name="ext" plotname="Ext" color="#3f8036"/>
+	<subchannel name="NCoverlay" plotname="NC overlay" color="#fc9312"/>
+	<subchannel name="dirt" plotname="Dirt" color="#895129"/>
+	<subchannel name="numuCCoverlay" plotname="#nu_{#mu}CC overlay" color="#21B1FF"/>
+</channel>
+
+<model tag="nullmodel">
+    <rule index="0" name="No Osc"/>
+</model>
+
+<!--Also available at /pnfs/uboone/persistent/users/uboonepro/surprise/spline/run4b_full_samples/checkout_run4b_nu_overlay_retuple_splines.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/PROfit_files/spline_weight_files/checkout_run4b_nu_overlay_retuple_splines.root" pot="6.7583e20" partial_load_frac="0.1">
+	<friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="wcpselection/T_BDTvars" />
+	<friend treename="spline_weights" />
+	<friend treename="nuselection/NeutrinoSelectionFilter" />
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_numuCCoverlay"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_nueCCoverlay"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_NCoverlay"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0) && (truth_isCC == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_numuCCoverlay"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 14) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_nueCCoverlay"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (abs(truth_nuPdg) == 12) && (truth_isCC == 1))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_NCoverlay"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0) && (truth_isCC == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+
+</MCFile>
+
+<!--Also available at /pnfs/uboone/persistent/users/uboonepro/surprise/spline/run4b_full_samples/checkout_run_4b_dirt_overlay_splines.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/PROfit_files/spline_weight_files/checkout_run_4b_dirt_overlay_splines.root" pot="2.7739e20" partial_load_frac="0.1">
+	<friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="wcpselection/T_BDTvars" />
+	<friend treename="spline_weights" />
+	<friend treename="nuselection/NeutrinoSelectionFilter" />
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_dirt"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_dirt"
+        	model_rule            = "1"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+			weight_2              = "(weight_cv * weight_spline * (weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0) + 1 * !((weight_cv * weight_spline < 30) * (weight_cv * weight_spline > 0)))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>truth_nuEnergy</variable>
+		<variable>1000.*(mcflux_dk2gen + mcflux_gen2vtx)/truth_nuEnergy</variable>
+	</branch>
+</MCFile>
+
+<!--Also available at /pnfs/uboone/persistent/users/uboonepro/surprise/run4b_full_samples/wc_processed/BNB/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root -->
+<MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/MCC9.10_Run4b_v10_04_07_09_Run4b_BNB_beam_off_surprise_reco2_hist.root" pot="3.874e20" partial_load_frac="0.1">
+	<friend treename="wcpselection/T_eval" />
+	<friend treename="wcpselection/T_PFeval" />
+	<friend treename="wcpselection/T_BDTvars" />
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_ext"
+			incl_systematics      = "false"
+        	model_rule            = "0"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_ext"
+			incl_systematics      = "false"
+        	model_rule            = "0"
+			weight_1              = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+</MCFile>
+
+
+<systematics>
+
+    <!-- MC Statistics -->
+	<systematic type="mcstat" plotname="MC Stats" tag="other">MCStat</systematic>
+
+    <!-- Cross Section Systematics, 55 total (currently 5 CCQE-related splines and one pion FSI spline as examples) -->
+
+	<systematic type="spline" binning="var0" plotname="MACCQE" tag="QE" force_0_cv="true" include_only_weights="1">MaCCQE_UBGenie</systematic>
+	<systematic type="spline" binning="var0" plotname="AxFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" include_only_weights="1">AxFFCCQEshape_UBGenie</systematic>
+	<systematic type="spline" binning="var0" plotname="VecFFCCQEshape" knobvals="0, 1" tag="QE" force_0_cv="true" include_only_weights="1">VecFFCCQEshape_UBGenie</systematic>
+	<systematic type="spline" binning="var0" plotname="RPA_CCQE" tag="QE" force_0_cv="true" include_only_weights="1">RPA_CCQE_UBGenie</systematic>
+	<systematic type="spline" binning="var0" plotname="CoulombCCQE" tag="QE" force_0_cv="true" include_only_weights="1">CoulombCCQE_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="NormCCMEC" knobvals="-2, -1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" include_only_weights="1">NormCCMEC_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NormNCMEC" knobvals="-1, 0, 1, 2, 3" tag="MEC" force_0_cv="true" include_only_weights="1">NormNCMEC_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="XSecShape_CCMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" include_only_weights="1">XSecShape_CCMEC_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="DecayAngMEC" knobvals="0, 1" tag="MEC" force_0_cv="true" include_only_weights="1">DecayAngMEC_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FracPN_CCMEC" tag="MEC" force_0_cv="true" include_only_weights="1">FracPN_CCMEC_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FracDelta_CCMEC" tag="MEC" force_0_cv="true" include_only_weights="1">FracDelta_CCMEC_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="MaCCRES" tag="RES" force_0_cv="true" include_only_weights="1">MaCCRES_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="MvCCRES" tag="RES" force_0_cv="true" include_only_weights="1">MvCCRES_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="MaNCRES" tag="RES" force_0_cv="true" include_only_weights="1">MaNCRES_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="MvNCRES" tag="RES" force_0_cv="true" include_only_weights="1">MvNCRES_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="RDecBR1eta" tag="RES" force_0_cv="true" include_only_weights="1">RDecBR1eta_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="Theta_Delta2Npi" knobvals="0, 1" tag="RES" force_0_cv="true" include_only_weights="1">Theta_Delta2Npi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="RDecBR1gamma" tag="RES" force_0_cv="true" include_only_weights="1">RDecBR1gamma_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="ThetaDelta2NRad" knobvals="0, 1" tag="RES" force_0_cv="true" include_only_weights="1">ThetaDelta2NRad_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="NormCCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" include_only_weights="1">NormCCCOH_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NormNCCOH" knobvals="-1, 0, 1, 2, 3" tag="COH" force_0_cv="true" include_only_weights="1">NormNCCOH_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="MaNCEL" tag="NC" force_0_cv="true" include_only_weights="1">MaNCEL_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="EtaNCEL" tag="NC" force_0_cv="true" include_only_weights="1">EtaNCEL_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="AGKYxF1pi" tag="Hadr." force_0_cv="true" include_only_weights="1">AGKYxF1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="AGKYpT1pi" tag="Hadr." force_0_cv="true" include_only_weights="1">AGKYpT1pi_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarnNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnNC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarnNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnNC2pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarpNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpNC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarpNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpNC2pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvnNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnNC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvnNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnNC2pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvpNC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpNC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvpNC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpNC2pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarnCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnCC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarnCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarnCC2pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarpCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpCC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvbarpCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvbarpCC2pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvnCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnCC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvnCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvnCC2pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvpCC1pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpCC1pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="NonRESBGvpCC2pi" tag="Non-RES" force_0_cv="true" include_only_weights="1">NonRESBGvpCC2pi_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="AhtBY" tag="Struct." force_0_cv="true" include_only_weights="1">AhtBY_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="BhtBY" tag="Struct." force_0_cv="true" include_only_weights="1">BhtBY_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="CV1uBY" tag="Struct." force_0_cv="true" include_only_weights="1">CV1uBY_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="CV2uBY" tag="Struct." force_0_cv="true" include_only_weights="1">CV2uBY_UBGenie</systematic>
+
+	<systematic type="spline" binning="var0" plotname="MFP_pi" tag="FSI" force_0_cv="true" include_only_weights="1">MFP_pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FrCEx_pi" tag="FSI" force_0_cv="true" include_only_weights="1">FrCEx_pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FrInel_pi" tag="FSI" force_0_cv="true" include_only_weights="1">FrInel_pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FrAbs_pi" tag="FSI" force_0_cv="true" include_only_weights="1">FrAbs_pi_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="MFP_N" tag="FSI" force_0_cv="true" include_only_weights="1">MFP_N_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FrCEx_N" tag="FSI" force_0_cv="true" include_only_weights="1">FrCEx_N_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FrInel_N" tag="FSI" force_0_cv="true" include_only_weights="1">FrInel_N_UBGenie</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="FrAbs_N" tag="FSI" force_0_cv="true" include_only_weights="1">FrAbs_N_UBGenie</systematic>
+
+	<systematic type="spline_to_covariance" binning="var0" plotname="xsr_scc_Fa3_SCC" tag="SCC" force_0_cv="true" include_only_weights="1">xsr_scc_Fa3_SCC</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="xsr_scc_Fv3_SCC" tag="SCC" force_0_cv="true" include_only_weights="1">xsr_scc_Fv3_SCC</systematic>
+
+
+	<!-- Flux Systematics, 11 total (currently 2 splines as examples) -->
+	<systematic type="spline" binning="var0" plotname="horncurrent" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">horncurrent_FluxUnisim</systematic>
+	<systematic type="spline" binning="var0" plotname="expskin" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">expskin_FluxUnisim</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="kminus" tag="Flux" force_0_cv="true" include_only_weights="1">kminus_PrimaryHadronNormalization</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="kplus" tag="Flux" force_0_cv="true" include_only_weights="1">kplus_PrimaryHadronFeynmanScaling</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="kzero" tag="Flux" force_0_cv="true" include_only_weights="1">kzero_PrimaryHadronSanfordWang</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="nucleoninexsec" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">nucleoninexsec_FluxUnisim</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="nucleonqexsec" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">nucleonqexsec_FluxUnisim</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="nucleontotxsec" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">nucleontotxsec_FluxUnisim</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="pioninexsec" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">pioninexsec_FluxUnisim</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="pionqexsec" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">pionqexsec_FluxUnisim</systematic>
+	<systematic type="spline_to_covariance" binning="var0" plotname="piontotxsec" knobvals="-1, 0, 1" restrict="-3, 3" tag="Flux" force_0_cv="true" include_only_weights="1">piontotxsec_FluxUnisim</systematic>
+	<systematic type="covariance" plotname="piplus_prod" tag="piprod">piplus_PrimaryHadronSWCentralSplineVariation</systematic>
+	<systematic type="covariance" plotname="piminus_prod" tag="piprod">piminus_PrimaryHadronSWCentralSplineVariation</systematic>
+
+
+	<!-- Re-interaction Systematics -->
+	<systematic type="covariance" tag="Reint" scale="0.001">weightsReint</systematic>
+
+	<!-- Other Systematics -->
+	<systematic type="norm" binning="reco" plotname="Targets_POT" tag="norm">nu_uBooNE:0.02</systematic>
+
+</systematics>
+
+<!--Also available at /pnfs/uboone/persistent/users/uboonepro/surprise/retuple/BNB/checkout_MCC9.10_Run4b_v10_04_07_20_BNB_beam_on_metapatch_retuple_retuple_hist_opendata_20700.root -->
+<data>
+  <MCFile treename="wcpselection/T_KINEvars" filename="/nevis/riverside/data/leehagaman/ngem/data_files/checkout_MCC9.10_Run4b_v10_04_07_11_BNB_beam_on_surprise_reco2_hist_opendata_20700.root" pot="4.031e19">
+    <friend treename="wcpselection/T_eval" />
+    <friend treename="wcpselection/T_BDTvars" />
+
+    <branch
+        	associated_subchannel = "nu_uBooNE_numuCCNpFC_data"
+        	model_rule            = "0"
+			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) > 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+	<branch
+        	associated_subchannel = "nu_uBooNE_numuCC0pFC_data"
+        	model_rule            = "0"
+			weight_1     = "((0 < kine_reco_Enu) && (match_isFC == 1) && (numu_score > 0.9) && (Sum$(abs(kine_particle_type)==2212 && kine_energy_particle>35) == 0))"
+		>
+		<variable>kine_reco_Enu</variable>
+		<variable>0</variable>
+		<variable>0</variable>
+	</branch>
+  </MCFile>
+</data>


### PR DESCRIPTION
Adding `restrict` option to adjust spline systematic limits. This will restrict the limits used by the optimizer, MCMC, and FC throws, but will not affect GetSplineShift on injected values. 

Example usage, telling PROfit to allow variations extrapolated from -3 to 3 even if only -1, 0, 1 knob values are supplied (extrapolating outside the simulated range):

```
<systematic type="spline" [...] knobvals="-1, 0, 1" restrict="-3, 3" [...] >
```

The default behavior (with no restrict option specified) is the same as it was previously: the optimizer, MCMC, and FC throws are restricted to be between the min and max knob values, except that MCMC has a hard-coded feature that changes a 0 to 1 range into a -1 to 1 range.

This also fixes the MCMC error band visualization in _1sigma_detailed plots, which was just matching the profile error bands before.