### PR TITLE
Update DetVar to work with ICARUS Run 2 Det Systs

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -486,6 +486,7 @@ int main(int argc, char* argv[])
                 PROconfig dvconfig = config.BuildDetVarConfig(idv);
                 NullModel dvmodel(dvprop);
                 Eigen::VectorXf dvparams = Eigen::VectorXf::Constant(dvmodel.nparams, 0);
+                PROspec cvSpec = FillSpectra(cvconfig, cvprop, emptySyst, cvmodel, cvparams, true, binningIndex);
                 PROspec varSpec = FillSpectra(dvconfig, dvprop, emptySyst, dvmodel, dvparams, true, binningIndex);
 
                 // Attempt to build matched specs using only common (run,subrun,event) events.
@@ -520,7 +521,8 @@ int main(int argc, char* argv[])
                     ss.p_multi_spec[0] = std::make_shared<PROspec>(matchedCvSpec);
                     ss.p_multi_spec[1] = std::make_shared<PROspec>(matchedVarSpec);
                     ss.SetHash(config.hash);
-                    systsstructs[binningIndex].push_back(std::move(ss));
+                    //systsstructs[binningIndex].push_back(std::move(ss));
+                    for(auto &ssv : systsstructs) ssv.push_back(ss);
                 }
                 log<LOG_INFO>(L"%1% || Added DetVar SystStruct '%2%' (section %3%, binning=%4%, mode=%5%)") % __func__ % varName.c_str() % isec % binningIndex % systType.c_str();
             }

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1568,7 +1568,7 @@ int main(int argc, char* argv[])
         for(size_t io = 0; io < config.m_num_variables; ++io) {
             other_hists.push_back(getCV1DHists(variable_cvs[io], config, binwidth_scale, io));
         }
-/* TODO: DetVar Plotting
+        
         // DetVar plotting (uses combined DetVar propellers binary)
         if(config.m_has_detvar_section) {
             log<LOG_INFO>(L"%1% || Plotting detector variations...") % __func__;
@@ -1579,7 +1579,7 @@ int main(int argc, char* argv[])
             std::vector<std::string> detvar_names;
             std::vector<int> detvar_binning;
             // Matched pairs for _DetVarOverlapping PDF (var file index -> matched cv+var specs)
-            struct MatchedPair { PROspec cv; PROspec var; };
+            struct MatchedPair { PROspec cv; std::map<int, PROspec> vars; };
             std::map<size_t, MatchedPair> matched_pairs;
 
             if(!std::filesystem::exists(dvAllPropsBin)) {
@@ -1597,30 +1597,49 @@ int main(int argc, char* argv[])
                         plot_cv_idx_by_section[config.m_detvar_files[idv].section_index] = idv;
                 }
 
+                std::vector<size_t> skip;
                 for(size_t idv = 0; idv < config.GetNumDetVarFiles(); ++idv) {
+                    if(skip.size() && std::find(skip.begin(), skip.end(), idv) != skip.end()) continue;
                     const std::string& name = config.m_detvar_files[idv].name;
                     const std::string key = DetVarKey(config, idv);
                     if(plot_dvprops.count(key) == 0) {
                         log<LOG_ERROR>(L"%1% || DetVar entry '%2%' not found in combined binary. Run 'process' first.") % __func__ % name.c_str();
                         break;
                     }
-
-                    PROconfig dvconfig = config.BuildDetVarConfig(idv);
-                    PROpeller& dvprop = plot_dvprops.at(key);
-
-                    std::unique_ptr<PROmodel> dv_model = std::make_unique<NullModel>(dvprop);
-                    PROsyst dvsysts;
-                    Eigen::VectorXf dvparams = Eigen::VectorXf::Constant(dv_model->nparams, 0);
+                    std::map<int, size_t> syst_files;
+                    auto find_fn = [&name](const PROconfig::DetVarFile &dvf) { return dvf.name == name; };
+                    auto it = config.m_detvar_files.begin() + idv;
+                    while((it = std::find_if(it, config.m_detvar_files.end(), find_fn))
+                            != std::end(config.m_detvar_files)) {
+                        size_t i = std::distance(config.m_detvar_files.begin(), it);
+                        syst_files[it->knobval] = i;
+                        skip.push_back(i);
+                        it++;
+                    }
 
                     int binningIndex = config.m_mcgen_variation_binning_map.count(name) ? config.m_mcgen_variation_binning_map.at(name) : config.i_prime;
                     if(binningIndex < 0 || binningIndex >= (int)config.m_num_variables)
                         binningIndex = config.i_prime;
 
-                    // Always use full spec for _DetVarFull PDF
-                    PROspec full_spec = FillSpectra(dvconfig, dvprop, dvsysts, *dv_model, dvparams, !eventbyevent, binningIndex);
-                    detvar_specs.push_back(full_spec);
-                    detvar_names.push_back(name);
-                    detvar_binning.push_back(binningIndex);
+                    std::map<int, const PROpeller*> props;
+                    MatchedPair mp;
+                    for(auto &[kv, f] : syst_files) {
+                        PROconfig dvconfig = config.BuildDetVarConfig(f);
+                        const std::string key = DetVarKey(config, f);
+                        PROpeller& dvprop = plot_dvprops.at(key);
+
+                        std::unique_ptr<PROmodel> dv_model = std::make_unique<NullModel>(dvprop);
+                        PROsyst dvsysts;
+                        Eigen::VectorXf dvparams = Eigen::VectorXf::Constant(dv_model->nparams, 0);
+
+                        // Always use full spec for _DetVarFull PDF
+                        PROspec full_spec = FillSpectra(dvconfig, dvprop, dvsysts, *dv_model, dvparams, !eventbyevent, binningIndex);
+                        mp.vars[kv] = full_spec;
+                        props[kv] = &dvprop;
+                        detvar_specs.push_back(full_spec);
+                        detvar_names.push_back(name);
+                        detvar_binning.push_back(binningIndex);
+                    }
 
                     // For variation files, build matched pair for _DetVarOverlapping PDF
                     if(!config.m_detvar_files[idv].is_cv) {
@@ -1628,10 +1647,13 @@ int main(int argc, char* argv[])
                         auto cv_it = plot_cv_idx_by_section.find(sec);
                         if(cv_it != plot_cv_idx_by_section.end()) {
                             PROpeller& cvprop_plot = plot_dvprops.at(DetVarKey(config, cv_it->second));
-                            MatchedPair mp;
-                            if(BuildDetVarMatchedSpecs(cvprop_plot, dvprop, binningIndex,
+                            PROconfig cvconfig = config.BuildDetVarConfig(cv_it->second);
+                            std::unique_ptr<PROmodel> cv_model = std::make_unique<NullModel>(cvprop_plot);
+                            Eigen::VectorXf cvparams = Eigen::VectorXf::Constant(cv_model->nparams, 0);
+                            mp.cv = FillSpectra(cvconfig, cvprop_plot, PROsyst(), *cv_model, cvparams, !eventbyevent, binningIndex);
+                            if(BuildDetVarMatchedSpecs(cvprop_plot, props, binningIndex,
                                                        (int)config.m_num_variable_bins_total[binningIndex],
-                                                       mp.cv, mp.var)) {
+                                                       mp.cv, mp.vars)) {
                                 matched_pairs[idv] = std::move(mp);
                                 log<LOG_INFO>(L"%1% || DetVar plot '%2%': matched pair built for Overlapping PDF") % __func__ % name.c_str();
                             }
@@ -1773,10 +1795,12 @@ int main(int argc, char* argv[])
 
                                         const MatchedPair& mp = mp_it->second;
                                         std::map<std::string, std::unique_ptr<TH1D>> cv_hists_ov = getCV1DHists(mp.cv, config, binwidth_scale, detvar_binning[idv]);
-                                        std::map<std::string, std::unique_ptr<TH1D>> var_hists_ov = getCV1DHists(mp.var, config, binwidth_scale, detvar_binning[idv]);
+                                        std::map<int, std::map<std::string, std::unique_ptr<TH1D>>> var_hists_ov;
+                                        for(auto &[kv, vspec] : mp.vars)
+                                            var_hists_ov[kv] = getCV1DHists(vspec, config, binwidth_scale, detvar_binning[idv]);
 
                                         TH1D* cv_total_ov = nullptr;
-                                        TH1D* var_total_ov = nullptr;
+                                        std::map<int, TH1D*> var_total_ov;
                                         for(size_t sc = 0; sc < config.m_num_subchannels[ic]; sc++) {
                                             const std::string& subchannel_name = config.m_fullnames[ov_global_subchannel_index + sc];
                                             auto cv_hit = cv_hists_ov.find(subchannel_name);
@@ -1784,47 +1808,59 @@ int main(int argc, char* argv[])
                                                 if(!cv_total_ov) cv_total_ov = (TH1D*)cv_hit->second->Clone("cv_matched_ov_total");
                                                 else cv_total_ov->Add(&*(cv_hit->second));
                                             }
-                                            auto var_hit = var_hists_ov.find(subchannel_name);
-                                            if(var_hit != var_hists_ov.end()) {
-                                                if(!var_total_ov) var_total_ov = (TH1D*)var_hit->second->Clone("var_matched_ov_total");
-                                                else var_total_ov->Add(&*(var_hit->second));
+                                            for(auto &[kv, specs] : var_hists_ov) {
+                                                auto var_hit = specs.find(subchannel_name);
+                                                if(var_hit != specs.end()) {
+                                                    if(var_total_ov.count(kv) == 0) 
+                                                        var_total_ov[kv] 
+                                                            = (TH1D*)var_hit->second->Clone("var_matched_ov_total");
+                                                    else 
+                                                        var_total_ov[kv]->Add(&*(var_hit->second));
+                                                }
                                             }
                                         }
 
-                                        if(cv_total_ov && var_total_ov) {
+                                        if(cv_total_ov && var_total_ov.size()) {
                                             cv_total_ov->SetLineColor(kBlack);
                                             cv_total_ov->SetLineWidth(3);
                                             cv_total_ov->SetFillColor(kWhite);
                                             cv_total_ov->SetFillStyle(0);
-                                            var_total_ov->SetLineColor(kRed);
-                                            var_total_ov->SetLineWidth(2);
-                                            var_total_ov->SetFillColor(kWhite);
-                                            var_total_ov->SetFillStyle(0);
+                                            std::vector<double> maxs;
+                                            for(auto &[kv, h] : var_total_ov) {
+                                                h->SetLineWidth(2);
+                                                h->SetFillColor(kWhite);
+                                                h->SetFillStyle(0);
+                                                maxs.push_back(h->GetMaximum());
+                                            }
 
-                                            float ymax_ov = std::max(cv_total_ov->GetMaximum(), var_total_ov->GetMaximum());
+                                            float ymax_ov = std::max(cv_total_ov->GetMaximum(), *std::max_element(maxs.begin(), maxs.end()));
                                             cv_total_ov->SetMaximum(ymax_ov * 1.15);
                                             std::string ov_title = config.m_mode_names[im] + " " + config.m_detector_names[id] + " " + config.m_channel_names[ic] + " " + detvar_names[idv] + " (Matched)";
                                             cv_total_ov->SetTitle(ov_title.c_str());
                                             if(binwidth_scale) cv_total_ov->GetYaxis()->SetTitle("Events/GeV");
                                             else cv_total_ov->GetYaxis()->SetTitle("Events");
 
-                                            cv_total_ov->Draw("hist");
-                                            var_total_ov->Draw("hist same");
-
                                             std::unique_ptr<TLegend> ov_leg = std::make_unique<TLegend>(0.55, 0.75, 0.89, 0.89);
                                             ov_leg->SetFillStyle(0);
                                             ov_leg->SetLineWidth(0);
+
+                                            gStyle->SetPalette(kCandy);
+                                            cv_total_ov->Draw("hist");
                                             ov_leg->AddEntry(cv_total_ov, "Matched CV", "l");
-                                            ov_leg->AddEntry(var_total_ov, detvar_names[idv].c_str(), "l");
+                                            for(auto &[kv, h] : var_total_ov) {
+                                                h->Draw("hist same plc");
+                                                ov_leg->AddEntry(h, (detvar_names[idv]+" "+std::to_string(kv)).c_str(), "l");
+                                            }
+
                                             ov_leg->Draw("same");
 
                                             ov_canvas.Print(ov_pdf.c_str(), "pdf");
 
                                             delete cv_total_ov;
-                                            delete var_total_ov;
+                                            //delete var_total_ov;
                                         } else {
                                             if(cv_total_ov) delete cv_total_ov;
-                                            if(var_total_ov) delete var_total_ov;
+                                            //if(var_total_ov) delete var_total_ov;
                                         }
                                     }
                                     ov_global_subchannel_index += config.m_num_subchannels[ic];
@@ -1833,11 +1869,12 @@ int main(int argc, char* argv[])
                         }
                         ov_canvas.Print((ov_pdf + "]").c_str(), "pdf");
                         log<LOG_INFO>(L"%1% || DetVar overlapping plots saved to %2%") % __func__ % ov_pdf.c_str();
+                        set_matrix_palette();
                     }
                 }
             }
         }
-*/
+
         TCanvas c;
         if(fake_data_osc_params.size()) {
 

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -50,7 +50,7 @@ using namespace PROfit;
 // Unique key for DetVar propeller maps (names can be reused across sections).
 static std::string DetVarKey(const PROconfig& config, size_t file_index) {
     const auto& dv = config.m_detvar_files[file_index];
-    return "sec" + std::to_string(dv.section_index) + "::" + dv.name;
+    return "sec" + std::to_string(dv.section_index) + "::" + dv.name + "." + std::to_string(dv.knobval);
 }
 
 // Build a collision-free composite key for event i_event from its matching_var_values.
@@ -67,12 +67,18 @@ static std::vector<int> DetVarMatchingKey(const PROpeller& prop, size_t i_event)
 // in both propellers. var_idx selects which variable's bin indices to use.
 // Returns false (leaving out_cv/out_var unchanged) if either propeller lacks matching vars.
 static bool BuildDetVarMatchedSpecs(
-        const PROpeller& cvprop, const PROpeller& varprop,
+        const PROpeller& cvprop, const std::map<int, const PROpeller*> &varprop,
         int var_idx, int spec_size,
-        PROspec& out_cv, PROspec& out_var) {
+        PROspec& out_cv, std::map<int, PROspec> &out_var, bool renorm = true) {
 
-    if(!cvprop.has_matching_vars || !varprop.has_matching_vars) return false;
-    if(cvprop.matching_var_values.size() != varprop.matching_var_values.size()) return false;
+    if(!cvprop.has_matching_vars || 
+            !std::all_of(varprop.begin(), varprop.end(), [](const auto &p){ return p.second->has_matching_vars;})) 
+        return false;
+    if(!std::all_of(varprop.begin(), varprop.end(), 
+                [&cvprop](const auto &p){ 
+                    return cvprop.matching_var_values.size() == p.second->matching_var_values.size(); 
+                }))
+        return false;
 
     // Step 1: build lookup key -> list of event indices for CV.
     // Use std::map with vector<int> keys for guaranteed collision-free RSE matching.
@@ -82,12 +88,20 @@ static bool BuildDetVarMatchedSpecs(
 
     // Step 2: find the set of keys present in both CV and variation;
     // track unique var keys to compute CV-only / var-only / overlapping counts.
-    std::set<std::vector<int>> var_key_set;
+    std::map<int, std::set<std::vector<int>>> var_key_set;
     std::set<std::vector<int>> common_keys;
-    for(size_t j = 0; j < varprop.NEvent(); ++j) {
-        auto k = DetVarMatchingKey(varprop, j);
-        var_key_set.insert(k);
-        if(cv_key_map.count(k)) common_keys.insert(k);
+    for(const auto &[kv, prop] : varprop) {
+        for(size_t j = 0; j < prop->NEvent(); ++j) {
+            auto k = DetVarMatchingKey(*prop, j);
+            var_key_set[kv].insert(k);
+        }
+    }
+    for(const auto &cv_key : cv_key_map) {
+        if(std::all_of(var_key_set.begin(), var_key_set.end(),
+                    [&cv_key](const auto &s) {
+                        return s.second.count(cv_key.first) > 0;
+                    }))
+            common_keys.insert(cv_key.first);
     }
 
     const size_t n_cv_only      = cv_key_map.size() - common_keys.size();
@@ -109,26 +123,35 @@ static bool BuildDetVarMatchedSpecs(
     }
 
     // Step 4: fill matched var spec
-    PROspec matched_var(spec_size);
-    size_t n_var_prop_matched = 0;
-    for(size_t j = 0; j < varprop.NEvent(); ++j) {
-        if(!common_keys.count(DetVarMatchingKey(varprop, j))) continue;
-        ++n_var_prop_matched;
-        int bin = varprop.variable_bin_indices[var_idx][j];
-        if(bin >= 0) matched_var.QuickFill(bin, varprop.added_weights[j]);
+    const float cv_matched_total = matched_cv.Spec().sum();
+    std::map<int, PROspec> matched_var;
+    Eigen::VectorXf n_var_prop_matched = Eigen::VectorXf::Zero(varprop.size());
+    Eigen::VectorXf n_var_evt = Eigen::VectorXf::Zero(varprop.size());
+    size_t prop_i = 0;
+    for(const auto &[kv, prop] : varprop) {
+        matched_var[kv] = PROspec(spec_size);
+        n_var_evt(prop_i) = prop->NEvent();
+        for(size_t j = 0; j < prop->NEvent(); ++j) {
+            if(!common_keys.count(DetVarMatchingKey(*prop, j))) continue;
+            n_var_prop_matched(prop_i) += 1;
+            int bin = prop->variable_bin_indices[var_idx][j];
+            if(bin >= 0) matched_var[kv].QuickFill(bin, prop->added_weights[j]);
+        }
+        if(renorm){
+            // Renormalize matched_var to the matched_cv total so the comparison is purely
+            // shape/efficiency: removes the effect of different statistics between CV and var files.
+            const float var_matched_total = matched_var[kv].Spec().sum();
+            if(var_matched_total > 0.0f && cv_matched_total > 0.0f) {
+                const float renorm = cv_matched_total / var_matched_total;
+                matched_var[kv] = PROspec(matched_var[kv].Spec() * renorm, matched_var[kv].Error() * renorm);
+                log<LOG_INFO>(L"DetVar matching: renorm factor (CV_matched/var_matched) = %1%") % renorm;
+            }
+        }
+        prop_i++;
     }
     log<LOG_INFO>(L"DetVar matching: matched propeller events CV: %1%, var: %2% (total propeller events CV: %3%, var: %4%)")
-        % n_cv_prop_matched % n_var_prop_matched % cvprop.NEvent() % varprop.NEvent();
+        % n_cv_prop_matched % n_var_prop_matched % cvprop.NEvent() % n_var_evt;
 
-    // Renormalize matched_var to the matched_cv total so the comparison is purely
-    // shape/efficiency: removes the effect of different statistics between CV and var files.
-    const float cv_matched_total = matched_cv.Spec().sum();
-    const float var_matched_total = matched_var.Spec().sum();
-    if(var_matched_total > 0.0f && cv_matched_total > 0.0f) {
-        const float renorm = cv_matched_total / var_matched_total;
-        matched_var = PROspec(matched_var.Spec() * renorm, matched_var.Error() * renorm);
-        log<LOG_INFO>(L"DetVar matching: renorm factor (CV_matched/var_matched) = %1%") % renorm;
-    }
 
     out_cv  = std::move(matched_cv);
     out_var = std::move(matched_var);
@@ -467,59 +490,83 @@ int main(int argc, char* argv[])
                 cv_binning = config.i_prime;
             PROspec cvSpec = FillSpectra(cvconfig, cvprop, emptySyst, cvmodel, cvparams, true, cv_binning);
 
+            std::vector<size_t> skip;
             for(size_t idv = 0; idv < config.m_detvar_files.size(); ++idv) {
+                if(skip.size() && std::find(skip.begin(), skip.end(), idv) != skip.end()) continue;
                 if(config.m_detvar_files[idv].section_index != isec) continue;
                 if(config.m_detvar_files[idv].is_cv) continue;
 
                 const std::string& varName = config.m_detvar_files[idv].name;
+                bool renorm = config.m_detvar_files[idv].renorm;
 
                 if(config.m_mcgen_variation_type_map.count(varName) == 0) {
                     log<LOG_INFO>(L"%1% || Skipping DetVar '%2%' — no matching entry in <systematics> section.") % __func__ % varName.c_str();
                     continue;
                 }
+                std::map<int, size_t> syst_files;
+                auto find_fn = [&varName](const PROconfig::DetVarFile &dvf) { return dvf.name == varName; };
+                auto it = config.m_detvar_files.begin() + idv;
+                while((it = std::find_if(it, config.m_detvar_files.end(), find_fn))
+                        != std::end(config.m_detvar_files)) {
+                    size_t i = std::distance(config.m_detvar_files.begin(), it);
+                    syst_files[it->knobval] = i;
+                    skip.push_back(i);
+                    it++;
+                }
+
                 const std::string& systType = config.m_mcgen_variation_type_map.at(varName);
                 int binningIndex = config.m_mcgen_variation_binning_map.count(varName) ? config.m_mcgen_variation_binning_map.at(varName) : config.i_prime;
                 if(binningIndex < 0 || binningIndex >= (int)config.m_num_variables)
                     binningIndex = config.i_prime;
 
-                PROpeller& dvprop = dvprops.at(DetVarKey(config, idv));
-                PROconfig dvconfig = config.BuildDetVarConfig(idv);
-                NullModel dvmodel(dvprop);
-                Eigen::VectorXf dvparams = Eigen::VectorXf::Constant(dvmodel.nparams, 0);
                 PROspec cvSpec = FillSpectra(cvconfig, cvprop, emptySyst, cvmodel, cvparams, true, binningIndex);
-                PROspec varSpec = FillSpectra(dvconfig, dvprop, emptySyst, dvmodel, dvparams, true, binningIndex);
+                std::map<int, PROspec> specs;
+                std::map<int, const PROpeller*> props;
+                for(const auto &[k, i] : syst_files) {
+                    PROpeller& dvprop = dvprops.at(DetVarKey(config, i));
+                    PROconfig dvconfig = config.BuildDetVarConfig(i);
+                    NullModel dvmodel(dvprop);
+                    Eigen::VectorXf dvparams = Eigen::VectorXf::Constant(dvmodel.nparams, 0);
+                    specs[k] = FillSpectra(dvconfig, dvprop, emptySyst, dvmodel, dvparams, true, binningIndex);
+                    props[k] = &dvprop;
+                }
 
                 // Attempt to build matched specs using only common (run,subrun,event) events.
                 // If both propellers have matching vars stored, replace cvSpec/varSpec for this pair.
                 PROspec matchedCvSpec = cvSpec;
-                PROspec matchedVarSpec = varSpec;
                 const bool matched = BuildDetVarMatchedSpecs(
-                    cvprop, dvprop, binningIndex, (int)config.m_num_variable_bins_total[binningIndex],
-                    matchedCvSpec, matchedVarSpec);
+                    cvprop, props, binningIndex, (int)config.m_num_variable_bins_total[binningIndex],
+                    matchedCvSpec, specs, renorm);
                 if(matched) {
                     log<LOG_INFO>(L"%1% || DetVar '%2%': using event-matched spectra for spline building") % __func__ % varName.c_str();
                 } else {
                     log<LOG_INFO>(L"%1% || DetVar '%2%': no matching vars stored, using full spectra") % __func__ % varName.c_str();
                 }
-
-                // Zero out variation bins where CV is 0 to avoid division-by-zero.
+                
                 {
-                    Eigen::VectorXf varVec = matchedVarSpec.Spec();
-                    const Eigen::VectorXf& cvVec = matchedCvSpec.Spec();
-                    for(int ib = 0; ib < cvVec.size(); ++ib) {
-                        if(cvVec(ib) == 0.0f) varVec(ib) = 0.0f;
+                    // Zero out bins where CV is 0 to avoid division by zero when constructing splines
+                    Eigen::ArrayXf mask = (matchedCvSpec.Spec().array() != 0.0f).cast<float>();
+                    for(auto &[_, spec] : specs) {
+                        spec.Spec() = spec.Spec().array() * mask;
+                        spec.Error() = spec.Error().array() * mask;
                     }
-                    matchedVarSpec = PROspec(varVec, Eigen::VectorXf::Zero(varVec.size()));
                 }
 
+
                 {
-                    SystStruct ss(varName, 2, systType, "1",
-                                  {0.0f, 1.0f}, {0.0f, 1.0f}, 0);
+                    std::vector<eweight_type> knobvals;
+                    std::transform(specs.begin(), specs.end(), std::back_inserter(knobvals),
+                            [](const auto &p){ return p.first; });
+                    std::sort(knobvals.begin(), knobvals.end());
+                    SystStruct ss(varName, specs.size(), systType, "1",
+                                  knobvals, knobvals, 0);
                     ss.binning = binningIndex;
                     ss.CreateSpecs(matchedCvSpec.Spec().size());
                     ss.p_cv = std::make_shared<PROspec>(matchedCvSpec);
-                    ss.p_multi_spec[0] = std::make_shared<PROspec>(matchedCvSpec);
-                    ss.p_multi_spec[1] = std::make_shared<PROspec>(matchedVarSpec);
+                    for(const auto &[kv, spec] : specs) {
+                        size_t idx = std::distance(knobvals.begin(), std::find(knobvals.begin(), knobvals.end(), kv));
+                        ss.p_multi_spec[idx] = std::make_shared<PROspec>(specs[kv]);
+                    }
                     ss.SetHash(config.hash);
                     //systsstructs[binningIndex].push_back(std::move(ss));
                     for(auto &ssv : systsstructs) ssv.push_back(ss);
@@ -1521,7 +1568,7 @@ int main(int argc, char* argv[])
         for(size_t io = 0; io < config.m_num_variables; ++io) {
             other_hists.push_back(getCV1DHists(variable_cvs[io], config, binwidth_scale, io));
         }
-
+/* TODO: DetVar Plotting
         // DetVar plotting (uses combined DetVar propellers binary)
         if(config.m_has_detvar_section) {
             log<LOG_INFO>(L"%1% || Plotting detector variations...") % __func__;
@@ -1790,7 +1837,7 @@ int main(int argc, char* argv[])
                 }
             }
         }
-
+*/
         TCanvas c;
         if(fake_data_osc_params.size()) {
 

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -69,7 +69,7 @@ static std::vector<int> DetVarMatchingKey(const PROpeller& prop, size_t i_event)
 static bool BuildDetVarMatchedSpecs(
         const PROpeller& cvprop, const std::map<int, const PROpeller*> &varprop,
         int var_idx, int spec_size,
-        PROspec& out_cv, std::map<int, PROspec> &out_var, bool renorm = true) {
+        PROspec& out_cv, std::map<int, PROspec> &out_var) {
 
     if(!cvprop.has_matching_vars || 
             !std::all_of(varprop.begin(), varprop.end(), [](const auto &p){ return p.second->has_matching_vars;})) 
@@ -123,7 +123,6 @@ static bool BuildDetVarMatchedSpecs(
     }
 
     // Step 4: fill matched var spec
-    const float cv_matched_total = matched_cv.Spec().sum();
     std::map<int, PROspec> matched_var;
     Eigen::VectorXf n_var_prop_matched = Eigen::VectorXf::Zero(varprop.size());
     Eigen::VectorXf n_var_evt = Eigen::VectorXf::Zero(varprop.size());
@@ -136,16 +135,6 @@ static bool BuildDetVarMatchedSpecs(
             n_var_prop_matched(prop_i) += 1;
             int bin = prop->variable_bin_indices[var_idx][j];
             if(bin >= 0) matched_var[kv].QuickFill(bin, prop->added_weights[j]);
-        }
-        if(renorm){
-            // Renormalize matched_var to the matched_cv total so the comparison is purely
-            // shape/efficiency: removes the effect of different statistics between CV and var files.
-            const float var_matched_total = matched_var[kv].Spec().sum();
-            if(var_matched_total > 0.0f && cv_matched_total > 0.0f) {
-                const float renorm = cv_matched_total / var_matched_total;
-                matched_var[kv] = PROspec(matched_var[kv].Spec() * renorm, matched_var[kv].Error() * renorm);
-                log<LOG_INFO>(L"DetVar matching: renorm factor (CV_matched/var_matched) = %1%") % renorm;
-            }
         }
         prop_i++;
     }
@@ -497,7 +486,6 @@ int main(int argc, char* argv[])
                 if(config.m_detvar_files[idv].is_cv) continue;
 
                 const std::string& varName = config.m_detvar_files[idv].name;
-                bool renorm = config.m_detvar_files[idv].renorm;
 
                 if(config.m_mcgen_variation_type_map.count(varName) == 0) {
                     log<LOG_INFO>(L"%1% || Skipping DetVar '%2%' — no matching entry in <systematics> section.") % __func__ % varName.c_str();
@@ -536,7 +524,7 @@ int main(int argc, char* argv[])
                 PROspec matchedCvSpec = cvSpec;
                 const bool matched = BuildDetVarMatchedSpecs(
                     cvprop, props, binningIndex, (int)config.m_num_variable_bins_total[binningIndex],
-                    matchedCvSpec, specs, renorm);
+                    matchedCvSpec, specs);
                 if(matched) {
                     log<LOG_INFO>(L"%1% || DetVar '%2%': using event-matched spectra for spline building") % __func__ % varName.c_str();
                 } else {
@@ -568,7 +556,6 @@ int main(int argc, char* argv[])
                         ss.p_multi_spec[idx] = std::make_shared<PROspec>(specs[kv]);
                     }
                     ss.SetHash(config.hash);
-                    //systsstructs[binningIndex].push_back(std::move(ss));
                     for(auto &ssv : systsstructs) ssv.push_back(ss);
                 }
                 log<LOG_INFO>(L"%1% || Added DetVar SystStruct '%2%' (section %3%, binning=%4%, mode=%5%)") % __func__ % varName.c_str() % isec % binningIndex % systType.c_str();

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -529,8 +529,9 @@ namespace PROfit{
                 std::string name;  // "cv" / "cv_N" or variation name like "Recomb2"
                 float pot;
                 float partial_load_frac = 1.0f;
-                bool is_cv;
+                bool is_cv, renorm;
                 size_t section_index;  // which DetVarSection this file belongs to
+                int knobval;
             };
 
             bool m_has_detvar_section = false;

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -525,6 +525,7 @@ namespace PROfit{
             //---- Detector Variation (DetVar) support ----
             struct DetVarFile {
                 std::string filename;
+                std::string treename;
                 std::string name;  // "cv" / "cv_N" or variation name like "Recomb2"
                 float pot;
                 float partial_load_frac = 1.0f;

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -529,7 +529,7 @@ namespace PROfit{
                 std::string name;  // "cv" / "cv_N" or variation name like "Recomb2"
                 float pot;
                 float partial_load_frac = 1.0f;
-                bool is_cv, renorm;
+                bool is_cv;
                 size_t section_index;  // which DetVarSection this file belongs to
                 int knobval;
             };

--- a/inc/PROspec.h
+++ b/inc/PROspec.h
@@ -247,6 +247,14 @@ namespace PROfit{
                 }
 
             /**
+             * @brief Return a (non-const) reference to the underlying spectrum vector.
+             * @return (Non-const) Reference to the Eigen::VectorXf of bin contents.
+             */
+            inline Eigen::VectorXf& Spec() {
+                return spec;
+            }
+
+            /**
              * @brief Return a const reference to the underlying error vector.
              * @return Const reference to the Eigen::VectorXf of per-bin errors.
              */
@@ -255,6 +263,13 @@ namespace PROfit{
                     return error;
                 }
 
+            /**
+             * @brief Return a (non-const) reference to the underlying error vector.
+             * @return (Non-const) Reference to the Eigen::VectorXf of per-bin errors.
+             */
+            inline Eigen::VectorXf& Error() {
+                return error;
+            }
 
             /**
              * @brief Check whether two PROspec objects have the same number of bins.

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -995,6 +995,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
             cv_file.name = (section_idx == 0) ? "cv" : ("cv_" + std::to_string(section_idx));
             cv_file.pot = strtod(cv_pot_str, &end);
             cv_file.is_cv = true;
+            cv_file.renorm = false;
             cv_file.section_index = section_idx;
             { const char* frac = pCV->Attribute("partial_load_frac");
               cv_file.partial_load_frac = frac ? (float)strtod(frac, nullptr) : 1.0f; }
@@ -1020,12 +1021,16 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     log<LOG_ERROR>(L"%1% || ERROR: Require a treename in either the DetVarSection or variation elements.") % __func__;
                     exit(EXIT_FAILURE);
                 }
+                const char *renorm = pVar->Attribute("renorm");
+                const char *knobval = pVar->Attribute("knobval");
                 DetVarFile var_file;
                 var_file.filename = dv_filename;
                 var_file.treename = dv_treename;
                 var_file.name = var_name;
                 var_file.pot = strtod(var_pot_str, &end);
                 var_file.is_cv = false;
+                var_file.knobval = knobval ? strtod(knobval, &end) : 1;
+                var_file.renorm = !renorm || (strcmp(renorm, "0") && strcmp(renorm, "false") && strcmp(renorm, "no"));
                 var_file.section_index = section_idx;
                 { const char* frac = pVar->Attribute("partial_load_frac");
                   var_file.partial_load_frac = frac ? (float)strtod(frac, nullptr) : 1.0f; }

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -995,7 +995,6 @@ int PROconfig::LoadFromXML(const std::string &filename){
             cv_file.name = (section_idx == 0) ? "cv" : ("cv_" + std::to_string(section_idx));
             cv_file.pot = strtod(cv_pot_str, &end);
             cv_file.is_cv = true;
-            cv_file.renorm = false;
             cv_file.section_index = section_idx;
             { const char* frac = pCV->Attribute("partial_load_frac");
               cv_file.partial_load_frac = frac ? (float)strtod(frac, nullptr) : 1.0f; }
@@ -1021,7 +1020,6 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     log<LOG_ERROR>(L"%1% || ERROR: Require a treename in either the DetVarSection or variation elements.") % __func__;
                     exit(EXIT_FAILURE);
                 }
-                const char *renorm = pVar->Attribute("renorm");
                 const char *knobval = pVar->Attribute("knobval");
                 DetVarFile var_file;
                 var_file.filename = dv_filename;
@@ -1030,7 +1028,6 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 var_file.pot = strtod(var_pot_str, &end);
                 var_file.is_cv = false;
                 var_file.knobval = knobval ? strtod(knobval, &end) : 1;
-                var_file.renorm = !renorm || (strcmp(renorm, "0") && strcmp(renorm, "false") && strcmp(renorm, "no"));
                 var_file.section_index = section_idx;
                 { const char* frac = pVar->Attribute("partial_load_frac");
                   var_file.partial_load_frac = frac ? (float)strtod(frac, nullptr) : 1.0f; }

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -920,10 +920,9 @@ int PROconfig::LoadFromXML(const std::string &filename){
             log<LOG_INFO>(L"%1% || Parsing <DetVarSection> index %2%") % __func__ % section_idx;
 
             const char* dv_treename = pDetVar->Attribute("treename");
-            if(!dv_treename) {
-                log<LOG_ERROR>(L"%1% || ERROR: <DetVarSection> must have a treename attribute") % __func__;
-                exit(EXIT_FAILURE);
-            }
+            bool have_tree = dv_treename;
+            const char* dv_filename = pDetVar->Attribute("filename");
+            bool have_file = dv_filename;
 
             const char* dv_scale_str = pDetVar->Attribute("scale");
             std::string dv_scale = dv_scale_str ? dv_scale_str : "1.0";
@@ -975,14 +974,24 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 log<LOG_ERROR>(L"%1% || ERROR: <DetVarSection> must have a <cv> element") % __func__;
                 exit(EXIT_FAILURE);
             }
-            const char* cv_filename = pCV->Attribute("filename");
+            if(!have_file) dv_filename = pCV->Attribute("filename");
+            if(!dv_filename) {
+                log<LOG_ERROR>(L"%1% || ERROR: Require filename attribute in either DetVarSection or cv.") % __func__;
+                exit(EXIT_FAILURE);
+            }
             const char* cv_pot_str = pCV->Attribute("pot");
-            if(!cv_filename || !cv_pot_str) {
-                log<LOG_ERROR>(L"%1% || ERROR: <cv> must have filename and pot attributes") % __func__;
+            if(!cv_pot_str) {
+                log<LOG_ERROR>(L"%1% || ERROR: <cv> must have pot attribute") % __func__;
+                exit(EXIT_FAILURE);
+            }
+            if(!have_tree) dv_treename = pCV->Attribute("treename");
+            if(!dv_treename) {
+                log<LOG_ERROR>(L"%1% || ERROR: Require a treename in either the DetVarSection or cv elements.") % __func__;
                 exit(EXIT_FAILURE);
             }
             DetVarFile cv_file;
-            cv_file.filename = cv_filename;
+            cv_file.filename = dv_filename;
+            cv_file.treename = dv_treename;
             cv_file.name = (section_idx == 0) ? "cv" : ("cv_" + std::to_string(section_idx));
             cv_file.pot = strtod(cv_pot_str, &end);
             cv_file.is_cv = true;
@@ -990,20 +999,30 @@ int PROconfig::LoadFromXML(const std::string &filename){
             { const char* frac = pCV->Attribute("partial_load_frac");
               cv_file.partial_load_frac = frac ? (float)strtod(frac, nullptr) : 1.0f; }
             m_detvar_files.push_back(cv_file);
-            log<LOG_INFO>(L"%1% || DetVar CV file (section %2%): %3%, POT: %4%") % __func__ % section_idx % cv_filename % cv_file.pot;
+            log<LOG_INFO>(L"%1% || DetVar CV file (section %2%): %3%, POT: %4%") % __func__ % section_idx % dv_filename % cv_file.pot;
 
             // Parse variation files
             tinyxml2::XMLElement *pVar = pDetVar->FirstChildElement("variation");
             while(pVar) {
-                const char* var_filename = pVar->Attribute("filename");
+                if(!have_file) dv_filename = pVar->Attribute("filename");
+                if(!dv_filename) {
+                    log<LOG_ERROR>(L"%1% || ERROR: Require filename attribute in either DetVarSection or variation.") % __func__;
+                    exit(EXIT_FAILURE);
+                }
                 const char* var_name = pVar->Attribute("name");
                 const char* var_pot_str = pVar->Attribute("pot");
-                if(!var_filename || !var_name || !var_pot_str) {
-                    log<LOG_ERROR>(L"%1% || ERROR: <variation> must have filename, name, and pot attributes") % __func__;
+                if(!var_name || !var_pot_str) {
+                    log<LOG_ERROR>(L"%1% || ERROR: <variation> must have name and pot attributes") % __func__;
+                    exit(EXIT_FAILURE);
+                }
+                if(!have_tree) dv_treename = pVar->Attribute("treename");
+                if(!dv_treename) {
+                    log<LOG_ERROR>(L"%1% || ERROR: Require a treename in either the DetVarSection or variation elements.") % __func__;
                     exit(EXIT_FAILURE);
                 }
                 DetVarFile var_file;
-                var_file.filename = var_filename;
+                var_file.filename = dv_filename;
+                var_file.treename = dv_treename;
                 var_file.name = var_name;
                 var_file.pot = strtod(var_pot_str, &end);
                 var_file.is_cv = false;
@@ -1012,7 +1031,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                   var_file.partial_load_frac = frac ? (float)strtod(frac, nullptr) : 1.0f; }
                 m_detvar_files.push_back(var_file);
                 m_detvar_variation_names.insert(var_name);
-                log<LOG_INFO>(L"%1% || DetVar variation '%2%' file (section %3%): %4%, POT: %5%") % __func__ % var_name % section_idx % var_filename % var_file.pot;
+                log<LOG_INFO>(L"%1% || DetVar variation '%2%' file (section %3%): %4%, POT: %5%") % __func__ % var_name % section_idx % dv_filename % var_file.pot;
 
                 pVar = pVar->NextSiblingElement("variation");
             }
@@ -1083,7 +1102,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 }
 
                 // MCFile template with placeholders
-                dvXml << "<MCFile treename=\"" << dv_treename << "\" filename=\"__DETVAR_FILENAME__\" scale=\"" << dv_scale << "\" pot=\"__DETVAR_POT__\" partial_load_frac=\"__DETVAR_PARTIAL_LOAD_FRAC__\">\n";
+                dvXml << "<MCFile treename=\"__DETVAR_TREENAME__\" filename=\"__DETVAR_FILENAME__\" scale=\"" << dv_scale << "\" pot=\"__DETVAR_POT__\" partial_load_frac=\"__DETVAR_PARTIAL_LOAD_FRAC__\">\n";
 
                 // Serialize friend trees from this DetVarSection
                 tinyxml2::XMLElement *pDVFriend = pDetVar->FirstChildElement("friend");
@@ -2354,6 +2373,12 @@ PROconfig PROconfig::BuildDetVarConfig(size_t file_index) const {
         auto pos = xml_str.find(fn_placeholder);
         if(pos != std::string::npos) {
             xml_str.replace(pos, fn_placeholder.size(), dvfile.filename);
+        }
+
+        std::string tr_placeholder = "__DETVAR_TREENAME__";
+        pos = xml_str.find(tr_placeholder);
+        if(pos != std::string::npos) {
+            xml_str.replace(pos, tr_placeholder.size(), dvfile.treename);
         }
 
         std::string pot_placeholder = "__DETVAR_POT__";


### PR DESCRIPTION
- [x] Per var treename
  + `treename` and `filename` attributes can now be specified in either the `<DetVarSection>` or `<variation>`
  + If specified in both, the `<DetVarSection>` value will be preferred. This can be changed though.
- [x] Variable other than i_prime (CV uses i_prime if no matching vars?)
  + Fix bug where det systs were not being filled into every vars syststruct object
  + Fix bug where CV always used i_prime binning even if systematic should use another binning
    * The variation used the systematic binning, so if the systematic used something other than i_prime the variation and CV would have different binnings and taking a ratio would fail
- [x] Two sided vars
  + Add `knobval="X"` attribute to `<variation>` elements (if not given assume `+1`)
  + 2 variation referring to the same systematic should have the same `name` attribute
  + Rework det syst code in bin/PROfit.cxx to work with multiple `DetVarFile` objects if multiple objects have the same name
  + Why are det systs renormalizing to the CV normalization by default? Do we want det systs to be shape only? That's not how ICARUS det systs worked, so I added the ability to turn that off.
    * ~Default is still shape only det systs though.~
    * ~Use `renorm="false"`, `renorm="no"`, or `renorm="0"` to turn off (anything else is treated as true)~
    * Removed. In the future we will enable shape only systematics in `<systematic>`/`<allowlist>`
  + Added non-const versions of `PROspec::Spec()` and `PROspec::Error()` so they can be used to modify spectrum in place.
- [x] Fix DetVar Plotting

~- [ ] Extrapolate out to +/-3 (no mirroring for one sided vars)~ (Use #397)

Basically ready to go for now. Should test with MicroBooNE to made sure I didn't break anything.