### PR TITLE
Fix for multi-file branch activation

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -207,6 +207,9 @@ namespace PROfit{
         std::set<std::string> GetNeededBranchNames() const;
         // Adds branches referenced by a single TTreeFormula to an existing set.
         static void AddFormulaBranches(const TTreeFormula* f, std::set<std::string>& result);
+        // Extracts identifier tokens from a formula expression string, skipping
+        // known ROOT/C keywords that can never be branch names.
+        static void ExtractExprTokens(const std::string& expr, std::set<std::string>& result);
         virtual ~ROOTFormula() {}
 
       private:

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -2467,6 +2467,37 @@ void ROOTFormula::LoadEvent(unsigned eventno) {
     }
 }
 
+void ROOTFormula::ExtractExprTokens(const std::string& expr, std::set<std::string>& result) {
+    // Canonical skip-list: ROOT aggregate functions, C math functions, ROOT constants,
+    // and C++ keywords that can never be branch names.
+    static const std::set<std::string> kSkipTokens = {
+        "Sum", "Min", "Max", "Alt", "Count", "Iteration",
+        "MinIf", "MaxIf", "SumIf",
+        "abs", "fabs", "sqrt", "sin", "cos", "tan",
+        "asin", "acos", "atan", "atan2",
+        "sinh", "cosh", "tanh",
+        "exp", "log", "log10", "pow",
+        "ceil", "floor", "round", "fmod",
+        "TMath",
+        "kTRUE", "kFALSE",
+        "true", "false",
+        "int", "float", "double", "bool", "void",
+        "if", "else", "for", "while", "do", "return",
+    };
+    const char* p = expr.c_str();
+    while (*p) {
+        if (isalpha((unsigned char)*p) || *p == '_') {
+            const char* start = p;
+            while (isalnum((unsigned char)*p) || *p == '_') p++;
+            std::string token(start, p);
+            if (kSkipTokens.find(token) == kSkipTokens.end())
+                result.insert(std::move(token));
+        } else {
+            ++p;
+        }
+    }
+}
+
 void ROOTFormula::AddFormulaBranches(const TTreeFormula* f, std::set<std::string>& result) {
     if (!f) return;
 
@@ -2477,52 +2508,15 @@ void ROOTFormula::AddFormulaBranches(const TTreeFormula* f, std::set<std::string
         TBranch* br = leaf->GetBranch();
         if (br) {
             result.insert(std::string(br->GetName()));
-            // Also include top-level (mother) branch so split objects work
             TBranch* mother = br->GetMother();
             if (mother && mother != br) result.insert(std::string(mother->GetName()));
         }
     }
 
-    // Supplemental path: extract every C-identifier token from the formula expression
-    // string and add it to the candidate set.  This captures std::vector<T> branches
-    // (where GetLeaf() returns nullptr) and branches inside Sum$(), Min$(), Max$() whose
-    // sub-expressions are not reachable via the public TTreeFormula API.
-    // Known ROOT/C keywords that can never be branch names are filtered out so that
-    // SetBranchStatus does not emit spurious "not found" warnings for them.
-    static const std::set<std::string> kSkipTokens = {
-        // ROOT aggregate functions used before '$'
-        "Sum", "Min", "Max", "Alt", "Count", "Iteration",
-        "MinIf", "MaxIf", "SumIf",
-        // C standard math functions
-        "abs", "fabs", "sqrt", "sin", "cos", "tan",
-        "asin", "acos", "atan", "atan2",
-        "sinh", "cosh", "tanh",
-        "exp", "log", "log10", "pow",
-        "ceil", "floor", "round", "fmod",
-        // ROOT math namespace
-        "TMath",
-        // ROOT boolean constants
-        "kTRUE", "kFALSE",
-        // C++ keywords / built-in types
-        "true", "false",
-        "int", "float", "double", "bool", "void",
-        "if", "else", "for", "while", "do", "return",
-    };
+    // Supplemental path: token-extract the expression string to catch vector branches
+    // and Sum$()/Min$()/Max$() sub-expressions not reachable via GetLeaf().
     const char* title = f->GetTitle();
-    if (title) {
-        const char* p = title;
-        while (*p) {
-            if (isalpha(*p) || *p == '_') {
-                const char* start = p;
-                while (isalnum(*p) || *p == '_') p++;
-                std::string token(start, p);
-                if (kSkipTokens.find(token) == kSkipTokens.end())
-                    result.insert(std::move(token));
-            } else {
-                p++;
-            }
-        }
-    }
+    if (title) ExtractExprTokens(std::string(title), result);
 }
 
 std::set<std::string> ROOTFormula::GetNeededBranchNames() const {

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -239,12 +239,10 @@ namespace PROfit {
                 } // End friend initialization
             } // End chain filling
 
-            for (size_t fid = 0; fid < (size_t)num_files; fid++) {
-                if (inconfig.m_mcgen_numfriends[fid] > 0) {
-                    for (size_t k = 0; k < friendChains[fid].size(); k++) {
-                        log<LOG_DEBUG>(L"%1% || Adding friend chain %2% to main chain %3%") % __func__ % k % fid;
-                        chains[fid]->AddFriend(friendChains[fid][k]);
-                    }
+            if (inconfig.m_mcgen_numfriends[fid] > 0) {
+                for (size_t k = 0; k < friendChains[fid].size(); k++) {
+                    log<LOG_DEBUG>(L"%1% || Adding friend chain %2% to main chain %3%") % __func__ % k % fid;
+                    chains[fid]->AddFriend(friendChains[fid][k]);
                 }
             }
 
@@ -696,33 +694,42 @@ namespace PROfit {
                 log<LOG_DEBUG>(L"%1% || Subchannel: %2% maps to index: %3%") % __func__ % subchannel_name.c_str() % subchannel_index[ib];
             }
 
+
             // Prune unused branches: disable everything, then re-enable only what our
             // formulas and eventweight maps actually need.  This prevents loading large
             // unused friend-tree columns on each GetEntry.
+            //
+            // NOTE: We extract branch names from the formula expression strings directly
+            // rather than via TTreeFormula::GetNcodes()/GetLeaf(), because the TTreeFormula
+            // objects created in the first file-setup loop may have stale internal state
+            // (ROOT can close/remap files when processing multiple TChains, invalidating
+            // leaf pointers stored inside those objects).
             {
                 std::set<std::string> needed;
 
-                // Branches referenced by variable and weight formulas
+                // Extract branch-name tokens from all formula expression strings.
+                // Uses ROOTFormula::ExtractExprTokens (the canonical skip-list lives there)
+                // rather than probing TTreeFormula objects, which may have stale internal
+                // state from ROOT closing/remapping files across multiple TChains.
+                log<LOG_DEBUG>(L"%1% || Branch pruning fid=%2%: extracting tokens from formula strings") % __func__ % fid;
                 for(int ib = 0; ib < num_branch; ib++) {
-                    for(const auto& rf : branches[ib]->branch_variable_formulas)
-                        for(const auto& n : rf->GetNeededBranchNames()) needed.insert(n);
-                    for(const auto& rf : branches[ib]->branch_weight_formulas)
-                        for(const auto& n : rf->GetNeededBranchNames()) needed.insert(n);
+                    for(const auto& expr : branches[ib]->variable_names)
+                        ROOTFormula::ExtractExprTokens(expr, needed);
+                    for(const auto& wname : inconfig.m_mcgen_weight_names[fid][ib])
+                        ROOTFormula::ExtractExprTokens(wname, needed);
                 }
-
-                // Branches referenced by systematic weight formulas
-                for(const auto& f : sys_weight_formula)
-                    ROOTFormula::AddFormulaBranches(f.get(), needed);
-
-                // Branches referenced by matching-variable formulas
-                for(const auto& f : matching_var_formulas)
-                    ROOTFormula::AddFormulaBranches(f.get(), needed);
+                for(const auto& sv : syst_vector)
+                    for(const auto& s : sv)
+                        if(s.HasWeightFormula())
+                            ROOTFormula::ExtractExprTokens(s.GetWeightFormula(), needed);
+                for(const auto& vname : inconfig.m_detvar_matching_vars)
+                    ROOTFormula::ExtractExprTokens(vname, needed);
 
                 // Branches bound via SetBranchAddress (eventweight maps)
                 for(const auto& [name, _] : f_event_weights[fid][0]) needed.insert(name);
                 for(const auto& [name, _] : f_knob_vals[fid][0])     needed.insert(name);
 
-                // Disable all, then re-enable needed set
+                log<LOG_DEBUG>(L"%1% || Branch pruning fid=%2%: needed set has %3% entries, calling SetBranchStatus(*,0)") % __func__ % fid % needed.size();
                 chains[fid]->SetBranchStatus("*", 0);
                 for(const auto& name : needed) {
                     UInt_t found = 0;
@@ -733,13 +740,6 @@ namespace PROfit {
 
             chains[fid]->SetCacheSize(100000000); // 100 MB read-ahead cache
             chains[fid]->AddBranchToCache("*", kTRUE); // cache all active branches
-            TObjArray* tbranches = chains[fid]->GetListOfBranches();
-            for (int i = 0; i < tbranches->GetEntries(); i++) {
-                TBranch* branch = (TBranch*)tbranches->At(i);
-                const char* branchName = branch->GetName();
-                bool isActive = chains[fid]->GetBranchStatus(branchName);
-                log<LOG_DEBUG>(L"%1% || BRANCH %2% is %3%") % __func__ % branchName % (isActive ? "active" : "inactive");
-            }
 
             // loop over all entries
             size_t to_print = nevents > 5 ? nevents / 5 : 1;
@@ -1028,14 +1028,22 @@ namespace PROfit {
 
             // Prune unused branches: disable everything, then re-enable only what our
             // formulas actually need.
+            //
+            // NOTE: extract tokens from formula strings directly rather than via
+            // TTreeFormula::GetNcodes()/GetLeaf(), because TTreeFormula objects created
+            // during the first fid loop may have stale internal state (ROOT can
+            // close/remap files when processing multiple TChains, invalidating leaf
+            // pointers stored inside those objects).
             {
                 std::set<std::string> needed;
+                log<LOG_DEBUG>(L"%1% || Branch pruning fid=%2%: extracting tokens from formula strings") % __func__ % fid;
                 for(int ib = 0; ib < num_branch; ib++) {
-                    for(const auto& rf : branches[ib]->branch_variable_formulas)
-                        for(const auto& n : rf->GetNeededBranchNames()) needed.insert(n);
-                    for(const auto& rf : branches[ib]->branch_weight_formulas)
-                        for(const auto& n : rf->GetNeededBranchNames()) needed.insert(n);
+                    for(const auto& expr : branches[ib]->variable_names)
+                        ROOTFormula::ExtractExprTokens(expr, needed);
+                    for(const auto& wname : inconfig.m_mcgen_weight_names[fid][ib])
+                        ROOTFormula::ExtractExprTokens(wname, needed);
                 }
+                log<LOG_DEBUG>(L"%1% || Branch pruning fid=%2%: needed set has %3% entries, calling SetBranchStatus(*,0)") % __func__ % fid % needed.size();
                 chains[fid]->SetBranchStatus("*", 0);
                 for(const auto& name : needed) {
                     UInt_t found = 0;


### PR DESCRIPTION
Fix for the branch activation speedup in [PR 386](https://github.com/markrosslonergan/Elephant_Vanishes/pull/386), since Nate found that this was not working properly with a file list input. 

The core issue was `chains[fid]->AddFriend` being called more than once per file. When fixing that I simplified things so that the branch activations just use the strings `variable_names` and avoid the more complex handling of `branch_variable_formulas` (this was already used as a fallback for some cases where the TTreeFormula manipulations didn't give all the necessary variables).