### PR TITLE
Feature/project sbn dev/markross null model fix

### DIFF
--- a/inc/PROfc.h
+++ b/inc/PROfc.h
@@ -54,7 +54,7 @@ namespace PROfit {
         const PROconfig config;          ///< Analysis configuration (copied per thread).
         const PROpeller prop;            ///< MC event store (copied per thread).
         const PROsyst systs;             ///< Systematic object (copied per thread).
-        std::string chi2;                ///< Name of the chi-squared type to use ("chi2", "CNP", or "poisson").
+        std::string chi2;                ///< Name of the chi-squared type to use ("PROchi", "PROCNP", or "Poisson").
         const Eigen::VectorXf phy_params;///< True physics parameter point at which the FC test is evaluated.
         const Eigen::MatrixXf L;         ///< Cholesky factor of the total covariance for correlated systematic throws.
         PROfitterConfig fitconfig;       ///< Fitter configuration.

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -75,6 +75,12 @@ public:
 
     std::vector<bool> is_log10; ///< True for each parameter stored in log10 space; false for linear.
 
+    /// Trivial models (e.g., NullModel) have no physics dependence: probabilities are identically 1.
+    /// When true, FillSpectra skips var_arrs / get_probs / GEMV and reads the spectrum directly from
+    /// H_combined. Also implies an empty `ivars` so events are binned per reco variable independently
+    /// (no cross-variable validity coupling through a placeholder physics-grid variable).
+    bool is_trivial = false;
+
     /**
      * @brief Build hists and H_combined from PROpeller event data.
      * @details Must be called after ivars and model_functions are set.  Iterates over all
@@ -197,10 +203,13 @@ public:
      */
     NullModel(const PROpeller &prop) {
         nparams = 0;
-        ivars = {1};
+        // Empty ivars: no placeholder physics-grid variable. Each reco variable is binned
+        // independently, so events out-of-range in one variable don't get dropped from another.
+        ivars = {};
+        is_trivial = true;
         model_functions.push_back([](const Eigen::VectorXf &, float){ return 1.0f; });
         prob_types = {0};
-       
+
         build_hists_and_combined(prop, /*filter_by_model_rule=*/false);
         is_log10.clear();
     }

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -231,8 +231,6 @@ public:
      *                      Must contain the key "L/E".
      */
     PROnumudis(const PROpeller &prop,const std::map<std::string,int> &parameter_map) {
-        prob_types = {0, 1};
-
         // model_functions is the non-unified version, these are optional
         // these get combined into one get_probs function in the constructor, but we can override this for faster computation
         model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0;});
@@ -257,7 +255,7 @@ public:
         default_val = Eigen::VectorXf(2);
         lb << -2, -std::numeric_limits<float>::infinity();
         ub << 2, 0;
-        default_val << -10, -10;
+        default_val << -2, -10;
 
     };
 
@@ -370,7 +368,7 @@ public:
         default_val = Eigen::VectorXf(2);
         lb << -2, -std::numeric_limits<float>::infinity();
         ub << 2, 0;
-        default_val << -10, -10;
+        default_val << -2, -10;
     };
 
     /**
@@ -465,7 +463,7 @@ public:
         lb << -2, -10; //-std::numeric_limits<float>::infinity();
         ub << 2, 0;
         //default_val << -std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity();
-        default_val << -10, -10; //std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity();
+        default_val << -2, -10; //std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity();
     
         log<LOG_INFO>(L"%1% || setting up a model nueapp, with  %2% params.")     % __func__ % nparams;
         for(size_t i=0; i< nparams;i++){
@@ -578,7 +576,7 @@ public:
         default_val = Eigen::VectorXf(2);
         lb << -2, -std::numeric_limits<float>::infinity();
         ub << 2, 0;
-        default_val << -10, -10;
+        default_val << -2, -10;
 
     };
 
@@ -859,7 +857,7 @@ public:
             probs(i, 1) = 1.0f - 4.0f*Um4sq*(1.0f-Um4sq)*sinterm*sinterm;
 
             // P_mue
-            probs(i, 2) = 4.0f*Ue4sq*Ue4sq*sinterm*sinterm;
+            probs(i, 2) = 4.0f*Ue4sq*Um4sq*sinterm*sinterm;
 
             // P_ee
             probs(i, 3) = 1.0f - 4.0f*Ue4sq*(1.0f-Ue4sq)*sinterm*sinterm;
@@ -1394,9 +1392,9 @@ public:
  * @brief 3+1 model variant 3C: parameterised by sin^2(2*theta_mue) and an asymmetry angle xi.
  * @details Variant C uses the appearance amplitude sin^2(2*theta_mue) directly together with a
  * hyperbolic asymmetry parameter xi that sets the relative size of the nu_e and nu_mu mixing elements:
- *   U_mu4 = exp(-xi) * sqrt(sin^2(2*theta_mue)) / 2
- *   U_e4  = exp(+xi) * sqrt(sin^2(2*theta_mue)) / 2
- * A unitarity constraint |U_e4| * cosh(xi) < 1 is enforced via model_constraint.
+ *   |U_mu4|^2 = exp(-xi) * sqrt(sin^2(2*theta_mue)) / 2
+ *   |U_e4|^2  = exp(+xi) * sqrt(sin^2(2*theta_mue)) / 2
+ * A unitarity constraint sqrt(sin^2(2*theta_mue)) * cosh(xi) < 1 is enforced via model_constraint.
  * dmsq and sinsq2thmue are in log10 space; xi is linear.
  */
 class PRO3p1_3C : public PROmodel {
@@ -1576,7 +1574,6 @@ public:
         // 3+1+decay to invisible particles, example from IceCube: https://arxiv.org/pdf/2204.00612
         // (invisible means no active or sterile-oscillating-to-active neutrinos after the decay)
 
-        prob_types = {0, 1, 2, 3};
         // model_functions is the non-unified version, these are optional
         // these get combined into one get_probs function in the constructor, but we can override this for faster computation
         model_functions.push_back([this]([[maybe_unused]] const Eigen::VectorXf &v, float) {(void)this; return 1.0; });
@@ -2123,7 +2120,8 @@ public:
         lb << 6e-5f, -3e-3f, 0.2f, 0.01f, 0.3f, -M_PI;
         ub << 9e-5f, 3e-3f, 0.4f, 0.04f, 0.7f, M_PI;
         default_val = Eigen::VectorXf(6);
-        default_val << 1e-5, 1e-3, 0, 0, 0, 0;
+        // Defaults set to midpoint of [lb, ub] for each parameter so the fitter starts in-range.
+        default_val << 7.5e-5f, 1e-3f, 0.3f, 0.025f, 0.5f, 0.0f;
     }
 
     /// @brief nu_e → nu_e survival probability via NuFastLBL. @param params Physics vector (6 params). @param le L/E [km/GeV]. @return P(nu_e→nu_e).

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -98,30 +98,37 @@ namespace PROfit {
 
             //log<LOG_INFO>(L"%1% || Starting le_arr building %2%") % __func__ % var_index;
             //auto start_le = std::chrono::high_resolution_clock::now();
-            
-            // Build var_arrs: one entry per ivar, each of length n_phys_bins (flat grid).
-            // For 1-var: var_arrs[0] = midbin values of that var (n_phys_bins = n_ivar_bins).
-            // For N-var: row-major product grid — var_arrs[k][flat] = midbin of ivar[k] at flat index.
-            const size_t N_ivars = inmodel.ivars.size();
-            std::vector<size_t> ivar_sizes(N_ivars);
-            for(size_t k = 0; k < N_ivars; ++k)
-                ivar_sizes[k] = inprop.variable_midbin[inmodel.ivars[k]].size();
 
-            std::vector<std::vector<float>> var_arrs(N_ivars, std::vector<float>(inmodel.n_phys_bins));
-            for(long int flat = 0; flat < inmodel.n_phys_bins; ++flat) {
-                long int rem = flat;
-                for(int k = (int)N_ivars - 1; k >= 0; --k) {
-                    var_arrs[k][flat] = inprop.variable_midbin[inmodel.ivars[k]][rem % ivar_sizes[k]];
-                    rem /= (long int)ivar_sizes[k];
+            Eigen::VectorXf result;
+            if(inmodel.is_trivial) {
+                // Trivial model: probs ≡ 1. H_combined[var_index] has shape (n_reco, 1) and column 0
+                // already contains the per-reco-bin event-weight sum, with no physics-grid coupling.
+                result = inmodel.H_combined[var_index].col(0);
+            } else {
+                // Build var_arrs: one entry per ivar, each of length n_phys_bins (flat grid).
+                // For 1-var: var_arrs[0] = midbin values of that var (n_phys_bins = n_ivar_bins).
+                // For N-var: row-major product grid — var_arrs[k][flat] = midbin of ivar[k] at flat index.
+                const size_t N_ivars = inmodel.ivars.size();
+                std::vector<size_t> ivar_sizes(N_ivars);
+                for(size_t k = 0; k < N_ivars; ++k)
+                    ivar_sizes[k] = inprop.variable_midbin[inmodel.ivars[k]].size();
+
+                std::vector<std::vector<float>> var_arrs(N_ivars, std::vector<float>(inmodel.n_phys_bins));
+                for(long int flat = 0; flat < inmodel.n_phys_bins; ++flat) {
+                    long int rem = flat;
+                    for(int k = (int)N_ivars - 1; k >= 0; --k) {
+                        var_arrs[k][flat] = inprop.variable_midbin[inmodel.ivars[k]][rem % ivar_sizes[k]];
+                        rem /= (long int)ivar_sizes[k];
+                    }
                 }
+
+                auto probs = inmodel.get_probs(phys, var_arrs);
+
+                // Single GEMV: H_combined[var_index] has shape (n_reco, n_phys*J).
+                // probs is (n_phys, J) in column-major, so probs.data() = [col0 | col1 | ...] = probs_flat.
+                Eigen::Map<const Eigen::VectorXf> probs_flat(probs.data(), probs.size());
+                result = inmodel.H_combined[var_index] * probs_flat;
             }
-
-            auto probs = inmodel.get_probs(phys, var_arrs);
-
-            // Single GEMV: H_combined[var_index] has shape (n_reco, n_phys*J).
-            // probs is (n_phys, J) in column-major, so probs.data() = [col0 | col1 | ...] = probs_flat.
-            Eigen::Map<const Eigen::VectorXf> probs_flat(probs.data(), probs.size());
-            Eigen::VectorXf result = inmodel.H_combined[var_index] * probs_flat;
 
             // Apply systematic weights and create spectrum
             Eigen::VectorXf final_spec = systw.cwiseProduct(result);
@@ -131,16 +138,20 @@ namespace PROfit {
         } else {
 
             // Unbinned path: per-event var values, one vector per ivar.
-            std::vector<std::vector<float>> var_arrs(inmodel.ivars.size(), std::vector<float>(inprop.NEvent()));
-            for(size_t k = 0; k < inmodel.ivars.size(); ++k)
-                for(size_t i = 0; i < inprop.NEvent(); ++i)
-                    var_arrs[k][i] = inprop.VariableValue(inmodel.ivars[k], i);
+            // For trivial models (empty ivars), skip var_arrs / get_probs entirely and use oscw = 1.
+            Eigen::MatrixXf probs;
+            if(!inmodel.is_trivial) {
+                std::vector<std::vector<float>> var_arrs(inmodel.ivars.size(), std::vector<float>(inprop.NEvent()));
+                for(size_t k = 0; k < inmodel.ivars.size(); ++k)
+                    for(size_t i = 0; i < inprop.NEvent(); ++i)
+                        var_arrs[k][i] = inprop.VariableValue(inmodel.ivars[k], i);
 
-            auto probs = inmodel.get_probs(phys, var_arrs);
+                probs = inmodel.get_probs(phys, var_arrs);
+            }
 
             for(size_t i = 0; i < inprop.NEvent(); ++i) {
-                float oscw = probs(i, inprop.model_rule[i]);
-                float add_w = inprop.added_weights[i]; 
+                float oscw = inmodel.is_trivial ? 1.0f : probs(i, inprop.model_rule[i]);
+                float add_w = inprop.added_weights[i];
                 const int reco_bin = inprop.VariableBinIndex(var_index, i);
 
                 float systw = 1;

--- a/src/PROfc.cxx
+++ b/src/PROfc.cxx
@@ -6,7 +6,6 @@ void fc_worker(fc_args args, MultiPROgressBar &progress) {
     log<LOG_INFO>(L"%1% || FC for point %2%") % __func__ % args.phy_params;
     std::mt19937 rng{args.seed};
     std::unique_ptr<PROmodel> model = get_model_from_string(args.config, args.prop);
-    std::unique_ptr<PROmodel> null_model = std::make_unique<NullModel>(args.prop);
 
     PROchi::EvalStrategy strat = args.binned ? PROchi::BinnedChi2 : PROchi::EventByEvent;
     Eigen::VectorXf throws = Eigen::VectorXf::Constant(model->nparams + args.systs.GetNSplines(), 0);


### PR DESCRIPTION
NullModel cross-variable coupling: Added is_trivial flag and short-circuited FillSpectra so NullModel no longer drops events from one reco variable when they fall outside another's range.
PRO3p1 P_mue bug: Fixed PRO3p1::get_probsappearance term from 4·Ue4²·Ue4²·sin² to the correct 4·Ue4²·Um4²·sin².
Out-of-bounds defaults: Clamped default_val into [lb, ub] for PROnumudis / PROnumudisTEST / PROnueapp / PROnuedis (dmsq) and PROLBL (4 of 6 PMNS params).
PRO3p1_3C docstring: Corrected U_mu4 / U_e4 to |U_mu4|² / |U_e4|² (and updated the unitarity-constraint expression accordingly) to match the code's actual convention.