### PR TITLE
Series of performance  tweaks in preparation for PROfit technical paper scaling studies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ else()
     FetchContent_Declare(
         lbfgspp
         GIT_REPOSITORY https://github.com/markrosslonergan/LBFGSpp
-        GIT_TAG        253e837bbff0460bddd84cd9883715c18aa19426
+        #        GIT_TAG        253e837bbff0460bddd84cd9883715c18aa19426
+        GIT_TAG        53c9c044c0d44f956b5dd2d90c6b598d2a17a8c9
         )
 endif()
 FetchContent_MakeAvailable(eigen)

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -859,6 +859,58 @@ int main(int argc, char* argv[])
         }
     }
 
+    // Empty-bin sanity check: build a default-CV spectrum and look for collapsed bins
+    // that would make stat-only / CNP statistics singular (CV<=0) or untrustworthy (CV<1).
+    {
+        const size_t io = config.i_prime;
+        Eigen::VectorXf cv_check_params =
+            Eigen::VectorXf::Zero(model->nparams + variable_systs[io].GetNSplines());
+        for(size_t i = 0; i < model->nparams; ++i)
+            cv_check_params(i) = model->default_val(i);
+
+        PROspec cv_check_spec = FillSpectra(config, prop, variable_systs[io], *model,
+                                            cv_check_params, !eventbyevent, io);
+        Eigen::VectorXf collapsed_cv = CollapseMatrix(config, cv_check_spec.Spec(), io);
+
+        int n_zero = 0, n_tiny = 0;
+        for(Eigen::Index b = 0; b < collapsed_cv.size(); ++b) {
+            if(collapsed_cv(b) <= 0.0f) {
+                log<LOG_ERROR>(L"%1% || Default-CV collapsed bin %2% has %3% expected events (<=0). Empty-bin would make CNP/stat covariance singular.") % __func__ % (long)b % collapsed_cv(b);
+                ++n_zero;
+            } else if(collapsed_cv(b) < 1.0f) {
+                log<LOG_WARNING>(L"%1% || Default-CV collapsed bin %2% has %3% expected events (<1). Low-stat region; results in this bin may be unreliable.") % __func__ % (long)b % collapsed_cv(b);
+                ++n_tiny;
+            }
+        }
+        if(n_zero > 0) {
+            if(!force) {
+                log<LOG_ERROR>(L"%1% || %2% collapsed CV bins are empty. Aborting. Re-run with --force to override (NOT recommended).") % __func__ % n_zero;
+                return 1;
+            }
+            log<LOG_WARNING>(L"%1% || %2% collapsed CV bins are empty but --force was set; proceeding at user's risk.") % __func__ % n_zero;
+        }
+        if(n_tiny > 0)
+            log<LOG_WARNING>(L"%1% || %2% collapsed CV bins have <1 expected event.") % __func__ % n_tiny;
+
+        if(use_real_data) {
+            int n_nan = 0, n_neg = 0;
+            const Eigen::VectorXf &dvec = data.Spec();
+            for(Eigen::Index b = 0; b < dvec.size(); ++b) {
+                if(std::isnan(dvec(b)) || std::isinf(dvec(b))) {
+                    log<LOG_ERROR>(L"%1% || Data bin %2% is NaN/inf.") % __func__ % (long)b;
+                    ++n_nan;
+                } else if(dvec(b) < 0.0f) {
+                    log<LOG_WARNING>(L"%1% || Data bin %2% is negative (%3%).") % __func__ % (long)b % dvec(b);
+                    ++n_neg;
+                }
+            }
+            if(n_nan > 0 && !force) {
+                log<LOG_ERROR>(L"%1% || %2% data bins are NaN/inf. Aborting. Re-run with --force to override.") % __func__ % n_nan;
+                return 1;
+            }
+        }
+    }
+
     //Pysics parameter input
     Eigen::VectorXf fakeDataParams = Eigen::VectorXf::Constant(model->nparams + variable_systs[config.i_prime].GetNSplines(), 0);
     Eigen::VectorXf CVParams = Eigen::VectorXf::Constant(model->nparams + variable_systs[config.i_prime].GetNSplines(), 0);

--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -59,6 +59,20 @@ namespace PROfit{
 
             bool correlated_systematics;      ///< If true, use correlated (off-diagonal) pull covariance.
             Eigen::MatrixXf prior_covariance; ///< Prior covariance matrix for nuisance parameters.
+            Eigen::MatrixXf prior_covariance_inv; ///< Inverse of prior_covariance, computed once in the ctor.
+
+            // Cache for CollapseMatrix(FillSpectra(noshiftvec_for_phys)). The noshiftvec
+            // CV depends only on the physics parameters (splines are zeroed out). Cache
+            // is invalidated by reset() and override_systs().
+            Eigen::VectorXf cnp_cached_phys;       ///< Last physics subvector used to fill cnp_cached_collapsed_cv.
+            Eigen::VectorXf cnp_cached_collapsed_cv; ///< Cached collapsed noshift CV spectrum.
+            bool cnp_cv_cache_valid = false;       ///< True iff cnp_cached_collapsed_cv matches cnp_cached_phys.
+
+            /// Returns CollapseMatrix(FillSpectra(noshiftvec built from `phys`)). Hits the
+            /// cache when `phys` matches the last cached call; otherwise recomputes.
+            Eigen::VectorXf cachedNoshiftCollapsedCV(const Eigen::VectorXf &phys, Eigen::Index param_size);
+
+            FillSpectraCache fs_cache;             ///< Per-thread split-half cache for FillSpectra.
 
         public:
 
@@ -89,11 +103,15 @@ namespace PROfit{
                 physics_param_fixed.clear();
                 last_value = 0;
                 last_param = Eigen::VectorXf::Constant(last_param.size(), 0);
+                cnp_cv_cache_valid = false;
+                fs_cache.invalidate();
             }
 
             /** @brief Replace the internal systematic pointer with @p new_syst. */
             void override_systs(const PROsyst &new_syst) {
                 syst = &new_syst;
+                cnp_cv_cache_valid = false;
+                fs_cache.invalidate();
             }
 
             /**

--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -67,7 +67,7 @@ namespace PROfit{
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd);
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient);
 
             /** @brief Return a heap-allocated copy of this PROCNP. */
             PROmetric *Clone() const {

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -27,6 +27,46 @@
 namespace PROfit{
 
     /**
+     * @brief Single-slot cache for the binned FillSpectra path, splitting the work into
+     *        independently keyed physics and systematic halves.
+     * @details The binned FillSpectra factors as `final_spec = systw .* result` where
+     *   - `result` (physics half) depends only on @p phys, @p inmodel, @p inprop, and @p var_index;
+     *   - `systw`  (syst half)    depends only on @p shifts, @p insyst, @p inprop, and @p var_index.
+     *
+     * On each call the cached overload compares the new phys/shifts subvectors against the cached
+     * keys and recomputes only the half that changed. The cache is invalidated when the model or
+     * syst pointer or var_index changes (via `invalidate()` or context check). The cache is NOT
+     * thread-safe; each thread should hold its own (PROfile/PROsurf already Clone() metrics per
+     * thread, so per-metric caches are naturally per-thread).
+     *
+     * @note Only the binned FillSpectra path is cached. The unbinned (event-by-event) path
+     *       invalidates the cache and falls back to the non-cached overload.
+     */
+    struct FillSpectraCache {
+        Eigen::VectorXf last_phys;            ///< Cached physics subvector for last_result.
+        Eigen::VectorXf last_shifts;          ///< Cached spline subvector for last_systw.
+        Eigen::VectorXf last_result;          ///< Cached H_combined * probs (or trivial-model result).
+        Eigen::VectorXf last_systw;           ///< Cached per-bin systematic-weight vector.
+        int last_var_index = -1;              ///< var_index for which the cache is valid.
+        const PROsyst *last_syst_ptr = nullptr;
+        const PROmodel *last_model_ptr = nullptr;
+
+        /// Mark cache contents stale; next call recomputes both halves.
+        void invalidate() {
+            last_var_index = -1;
+            last_syst_ptr = nullptr;
+            last_model_ptr = nullptr;
+        }
+    };
+
+    /**
+     * @brief Cached overload of the binned FillSpectra. See FillSpectraCache.
+     * @param cache  Single-slot cache; reuses physics or systematic half whose subvector matches.
+     * @return Same value as the non-cached FillSpectra; cache is updated as a side effect.
+     */
+    PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, FillSpectraCache &cache, bool binned = true, size_t var_index = 0);
+
+    /**
      * @brief Master spectrum-filling function combining oscillation weights and systematic spline weights.
      * @details Iterates over MC events (or uses pre-binned histograms when @p binned is true),
      * computes oscillation probabilities via @p inmodel, applies spline shifts from @p insyst,

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -47,6 +47,16 @@ namespace PROfit{
         Eigen::VectorXf last_shifts;          ///< Cached spline subvector for last_systw.
         Eigen::VectorXf last_result;          ///< Cached H_combined * probs (or trivial-model result).
         Eigen::VectorXf last_systw;           ///< Cached per-bin systematic-weight vector.
+
+        /// Per-spline factors at the cached "central" point, shape (nbins_var, nsplines).
+        /// central_factors(k, i) = spline i's multiplicative contribution to systw at bin k.
+        /// systw_central(k) = product over i of central_factors(k, i). Used by the Tier 1.3
+        /// incremental update path (single-spline-shift gradient calls) so we can divide
+        /// out the old contribution and multiply in the new one without rerunning the full
+        /// spline loop. Empty/zero-sized when the cache has not yet been populated by a
+        /// full recompute.
+        Eigen::MatrixXf central_factors;
+
         int last_var_index = -1;              ///< var_index for which the cache is valid.
         const PROsyst *last_syst_ptr = nullptr;
         const PROmodel *last_model_ptr = nullptr;

--- a/inc/PROchi.h
+++ b/inc/PROchi.h
@@ -25,6 +25,7 @@
 #include "PROpeller.h"
 #include "PROmodel.h"
 #include "PROmetric.h"
+#include "PROcess.h"
 
 namespace PROfit{
 
@@ -62,7 +63,16 @@ namespace PROfit{
 
             bool correlated_systematics;         ///< If true, use the correlated (off-diagonal) covariance for pull terms.
             Eigen::MatrixXf prior_covariance;    ///< Prior covariance matrix for nuisance parameters (used when correlated).
+            Eigen::MatrixXf prior_covariance_inv; ///< Inverse of prior_covariance, computed once in the ctor.
             Eigen::MatrixXf collapsed_stat_covariance; ///< Statistical covariance in the collapsed bin space.
+
+            // Cached non-empty-bin slicing for default mode. In shape_only mode
+            // normdata depends on `result` so these are rebuilt per call instead.
+            std::vector<Eigen::Index> nec_indices;          ///< Indices of bins with positive data; empty if cache invalid.
+            Eigen::MatrixXf nec_reduced_stat_cov;           ///< Reduced collapsed_stat_covariance for nec_indices (default mode only).
+            bool nec_valid = false;                         ///< True iff !shape_only and cache populated in the ctor.
+
+            FillSpectraCache fs_cache;                      ///< Per-thread split-half cache for FillSpectra.
 
 
             /*Function: Constructor bringing all objects together*/
@@ -78,6 +88,7 @@ namespace PROfit{
                 physics_param_fixed.clear();
                 last_value = 0;
                 last_param = Eigen::VectorXf::Constant(last_param.size(), 0);
+                fs_cache.invalidate();
             }
 
             /** @brief Return a heap-allocated copy of this PROchi. */
@@ -99,6 +110,7 @@ namespace PROfit{
             /** @brief Replace the internal systematic pointer with @p new_syst. */
             virtual void override_systs(const PROsyst &new_syst) {
                 syst = &new_syst;
+                fs_cache.invalidate();
             }
 
             /**

--- a/inc/PROchi.h
+++ b/inc/PROchi.h
@@ -71,7 +71,7 @@ namespace PROfit{
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd);
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient);
 
             /** @brief Reset cached state and clear any fixed-parameter list. */
             virtual void reset() {

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -380,7 +380,10 @@ namespace PROfit{
 
             std::vector<std::vector<std::pair<float,float>>> m_variable_bin_to_edges;
 
-            std::vector<Eigen::MatrixXf> variable_collapsing_matrices; 
+            std::vector<Eigen::MatrixXf> variable_collapsing_matrices;
+            // Sparse companions to variable_collapsing_matrices (one nonzero per row).
+            // Used by CollapseMatrix in the chi^2 inner loop; built once in construct_variable_collapsing_matrices.
+            std::vector<Eigen::SparseMatrix<float>> variable_collapsing_matrices_sparse;
             std::vector<Eigen::VectorXf> collapsed_bin_widths;
 
             //This section entirely for montecarlo generation of a covariance matrix or PROspec 
@@ -460,10 +463,14 @@ namespace PROfit{
              * Note: To collapse a full matrix M, please do T.transpose() * M * T
              * 	     To collapse a full vector V, please do T.transpose() * V
              */
-            inline 
-                Eigen::MatrixXf GetCollapsingMatrix() const {return variable_collapsing_matrices[i_prime]; }
             inline
-                Eigen::MatrixXf GetCollapsingMatrix(int other_index) const {return variable_collapsing_matrices[other_index]; }
+                const Eigen::MatrixXf& GetCollapsingMatrix() const {return variable_collapsing_matrices[i_prime]; }
+            inline
+                const Eigen::MatrixXf& GetCollapsingMatrix(int other_index) const {return variable_collapsing_matrices[other_index]; }
+            inline
+                const Eigen::SparseMatrix<float>& GetCollapsingMatrixSparse() const {return variable_collapsing_matrices_sparse[i_prime]; }
+            inline
+                const Eigen::SparseMatrix<float>& GetCollapsingMatrixSparse(int other_index) const {return variable_collapsing_matrices_sparse[other_index]; }
 
             /* Function: Calculate how big each mode block and decector block are, for any given number of channels/subchannels, before and after the collapse
              * Note: only consider mode/detector/channel/subchannels that are actually used 

--- a/inc/PROmetric.h
+++ b/inc/PROmetric.h
@@ -51,12 +51,12 @@ namespace PROfit {
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient) = 0;
             /**
              * @brief Evaluate the chi-squared, optionally skipping gradient computation.
-             * @param param    Current parameter vector.
-             * @param gradient Output gradient vector; may not be filled if @p nograd is true.
-             * @param nograd   If true, skip gradient computation for speed.
+             * @param param       Current parameter vector.
+             * @param gradient    Output gradient vector; only filled when @p rungradient is true.
+             * @param rungradient If true, compute the gradient; if false, skip it for speed.
              * @return Chi-squared value.
              */
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd) = 0;
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient) = 0;
             /** @brief Reset any cached state (e.g. last parameter vector and value). */
             virtual void reset() = 0;
             /** @brief Return a heap-allocated deep copy of this PROmetric. */

--- a/inc/PROpoisson.h
+++ b/inc/PROpoisson.h
@@ -26,6 +26,7 @@
 #include "PROpeller.h"
 #include "PROmodel.h"
 #include "PROmetric.h"
+#include "PROcess.h"
 
 namespace PROfit{
 
@@ -61,6 +62,9 @@ namespace PROfit{
 
             bool correlated_systematics;      ///< If true, use correlated pull covariance.
             Eigen::MatrixXf prior_covariance; ///< Prior covariance matrix for nuisance parameters.
+            Eigen::MatrixXf prior_covariance_inv; ///< Inverse of prior_covariance, computed once in the ctor.
+
+            FillSpectraCache fs_cache;        ///< Per-thread split-half cache for FillSpectra.
 
 
             /*Function: Constructor bringing all objects together*/
@@ -76,6 +80,7 @@ namespace PROfit{
                 physics_param_fixed.clear();
                 last_value = 0;
                 last_param = Eigen::VectorXf::Constant(last_param.size(), 0);
+                fs_cache.invalidate();
             }
 
             /** @brief Return a heap-allocated copy of this PROpoisson. */
@@ -96,6 +101,7 @@ namespace PROfit{
             /** @brief Replace the internal systematic pointer with @p new_syst. */
             virtual void override_systs(const PROsyst &new_syst) {
                 syst = &new_syst;
+                fs_cache.invalidate();
             }
 
             /**

--- a/inc/PROpoisson.h
+++ b/inc/PROpoisson.h
@@ -69,7 +69,7 @@ namespace PROfit{
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd);
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient);
 
             /** @brief Reset cached state and clear any fixed-parameter list. */
             virtual void reset() {

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -39,6 +39,7 @@ PROCNP::PROCNP(const std::string tag, const PROconfig &conin, const PROpeller &p
             prior_covariance(iB, iA) = std::get<2>(t);
         }
         prior_covariance = systin->spline_priors.asDiagonal() * prior_covariance * systin->spline_priors.asDiagonal();
+        prior_covariance_inv = prior_covariance.inverse();
     }
 }
 
@@ -48,7 +49,18 @@ float PROCNP::Pull(const Eigen::VectorXf &systs) {
     if (!correlated_systematics) {
         return (centered.array().square() / syst->spline_priors.array().square()).sum();
     }
-    return centered.dot(prior_covariance.inverse() * centered);
+    return centered.dot(prior_covariance_inv * centered);
+}
+
+Eigen::VectorXf PROCNP::cachedNoshiftCollapsedCV(const Eigen::VectorXf &phys, Eigen::Index param_size) {
+    if(cnp_cv_cache_valid && cnp_cached_phys.size() == phys.size() && cnp_cached_phys == phys)
+        return cnp_cached_collapsed_cv;
+    Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param_size);
+    noshiftvec.head(model.nparams) = phys;
+    cnp_cached_collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec());
+    cnp_cached_phys = phys;
+    cnp_cv_cache_valid = true;
+    return cnp_cached_collapsed_cv;
 }
 
 void PROCNP::fixSpline(int fix, float valin){
@@ -78,14 +90,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
     Eigen::VectorXf subvector2 = param.segment(model.nparams, syst->GetNSplines());
     //log<LOG_DEBUG>(L"%1% || Created spline subvector with size %2%") % __func__ % subvector2.size();
-    Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-    noshiftvec.head(model.nparams) = subvector1;
 
-    PROspec result = FillSpectra(config, peller, *syst, model, param, strat == BinnedChi2);
+    PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2, config.i_prime);
 
 
     Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
-    Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec());
+    Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(subvector1, param.size());
     Eigen::MatrixXf collapsed_stat_covariance = Eigen::MatrixXf::Zero(data.Spec().size(), data.Spec().size());
     Eigen::VectorXf normdata = shape_only 
         ? data.Normalize(config,result)
@@ -162,14 +172,11 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
-                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                 Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
                 if(i < model.nparams) {
-                    Eigen::VectorXf subvector1 = param_plus.segment(0, model.nparams);
-                    Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-                    noshiftvec.head(model.nparams) = subvector1;
-                    Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec(),config.i_prime);
+                    Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(param_plus.segment(0, model.nparams), param.size());
                     for(long j = 0; j < data.Spec().size(); ++j)
                         new_collapsed_stat_covariance(j,j) = normdata(j) == 0 ? collapsed_cv(j)/2 :
                             3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
@@ -207,14 +214,11 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
                     chi2_plus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
                     if(i < model.nparams) {
-                        Eigen::VectorXf subvector1 = param_plus.segment(0, model.nparams);
-                        Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-                        noshiftvec.head(model.nparams) = subvector1;
-                        Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec(),config.i_prime);
+                        Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(param_plus.segment(0, model.nparams), param.size());
                         for(long j = 0; j < data.Spec().size(); ++j)
                             new_collapsed_stat_covariance(j,j) = normdata(j) == 0 ? collapsed_cv(j)/2 :
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
@@ -236,14 +240,11 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
                     chi2_minus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
                     if(i < model.nparams) {
-                        Eigen::VectorXf subvector1 = param_minus.segment(0, model.nparams);
-                        Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-                        noshiftvec.head(model.nparams) = subvector1;
-                        Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec(),config.i_prime);
+                        Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(param_minus.segment(0, model.nparams), param.size());
                         for(long j = 0; j < data.Spec().size(); ++j)
                             new_collapsed_stat_covariance(j,j) = normdata(j) == 0 ? collapsed_cv(j)/2 :
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -94,10 +94,9 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         collapsed_stat_covariance(i,i) = data.Spec()(i) == 0 ? collapsed_cv(i)/2 :
             3 / (1.0 / normdata(i) + 2.0 / collapsed_cv(i));
 
-    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
-    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
     inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
 
     Eigen::VectorXf delta = CollapseMatrix(config, result.Spec()) - normdata;
@@ -176,8 +175,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                             3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
                 }
 
-                Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                 Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
 
@@ -222,8 +220,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
                     }
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
 
@@ -252,8 +249,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
                     }
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
 
@@ -312,8 +308,7 @@ float PROCNP::getSingleChannelChi(size_t global_channel_index, const PROspec &cv
     //only calculate a syst covariance if we have any covariance parameters as defined in the xml
     if(syst->GetNCovar()){
         // Calculate Full Syst Covariance matrix
-        Eigen::MatrixXf diag =  cv.Spec().array().matrix().asDiagonal(); 
-        Eigen::MatrixXf full_covariance =  diag*(syst->fractional_covariance)*diag;
+        Eigen::MatrixXf full_covariance = cv.Spec().asDiagonal() * (syst->fractional_covariance) * cv.Spec().asDiagonal();
 
         // Collapse Covariance and Spectra 
         Eigen::MatrixXf collapsed_full_covariance =  CollapseMatrix(config,full_covariance);
@@ -368,10 +363,9 @@ void PROCNP::print(const Eigen::VectorXf &param){
     }
 
     log<LOG_INFO>(L"%1% || Collapsed stat Covariance is : \n %2%") % __func__ % collapsed_stat_covariance;
-    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
-    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
     inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
 
     // Calculate Chi^2  value
@@ -438,14 +432,13 @@ void PROCNP::print(const Eigen::VectorXf &param){
             }
         }
 
-        Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-        Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+        Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
-        Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+        Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
         inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
 
         // Calculate Chi^2  value
-        Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec(); 
+        Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec();
 
         float pull = Pull(subvector2);
         float value_grad = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -42,6 +42,91 @@ namespace PROfit {
     }
 
 
+    PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, FillSpectraCache &cache, bool binned, size_t var_index) {
+        // Unbinned path can't be cleanly split phys/syst (per-event Fill mixes them).
+        // Fall back, invalidate cache.
+        if(!binned) {
+            cache.invalidate();
+            return FillSpectra(inconfig, inprop, insyst, inmodel, params, binned, var_index);
+        }
+
+        Eigen::VectorXf phys = params.segment(0, inmodel.nparams);
+        Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
+
+        const bool ctx_changed = (cache.last_var_index != (int)var_index ||
+                                  cache.last_syst_ptr != &insyst ||
+                                  cache.last_model_ptr != &inmodel);
+
+        // ---- Systematic-weights half (depends only on shifts) ----
+        const bool shifts_changed = ctx_changed ||
+                                    cache.last_shifts.size() != shifts.size() ||
+                                    cache.last_shifts != shifts;
+        if(shifts_changed) {
+            const size_t nbins_var = inconfig.m_num_variable_bins_total[var_index];
+            Eigen::VectorXf systw = Eigen::VectorXf::Constant(nbins_var, 1);
+            for(int i = 0; i < (int)insyst.GetNSplines(); ++i) {
+                size_t binning = insyst.spline_binnings[i];
+                if(binning == var_index) {
+                    for(size_t k = 0; k < nbins_var; ++k)
+                        systw(k) *= insyst.GetSplineShift(i, shifts(i), k);
+                } else {
+                    const size_t nbins_binning = inconfig.m_num_variable_bins_total[binning];
+                    Eigen::VectorXf spline_shifts(nbins_binning);
+                    for(size_t j = 0; j < nbins_binning; ++j)
+                        spline_shifts(j) = insyst.GetSplineShift(i, shifts(i), j);
+                    const auto &hist = inprop.variable_hist_storage(binning, var_index);
+                    Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts;
+                    Eigen::VectorXf unweighted_sum = hist.colwise().sum().transpose();
+                    for(size_t k = 0; k < nbins_var; ++k)
+                        if(unweighted_sum(k) > 0)
+                            systw(k) *= weighted_sum(k) / unweighted_sum(k);
+                }
+            }
+            cache.last_systw = std::move(systw);
+            cache.last_shifts = shifts;
+        }
+
+        // ---- Physics-result half (depends only on phys) ----
+        const bool phys_changed = ctx_changed ||
+                                  cache.last_phys.size() != phys.size() ||
+                                  cache.last_phys != phys;
+        if(phys_changed) {
+            Eigen::VectorXf result;
+            if(inmodel.is_trivial) {
+                result = inmodel.H_combined[var_index].col(0);
+            } else {
+                const size_t N_ivars = inmodel.ivars.size();
+                std::vector<size_t> ivar_sizes(N_ivars);
+                for(size_t k = 0; k < N_ivars; ++k)
+                    ivar_sizes[k] = inprop.variable_midbin[inmodel.ivars[k]].size();
+
+                std::vector<std::vector<float>> var_arrs(N_ivars, std::vector<float>(inmodel.n_phys_bins));
+                for(long int flat = 0; flat < inmodel.n_phys_bins; ++flat) {
+                    long int rem = flat;
+                    for(int k = (int)N_ivars - 1; k >= 0; --k) {
+                        var_arrs[k][flat] = inprop.variable_midbin[inmodel.ivars[k]][rem % ivar_sizes[k]];
+                        rem /= (long int)ivar_sizes[k];
+                    }
+                }
+
+                auto probs = inmodel.get_probs(phys, var_arrs);
+                Eigen::Map<const Eigen::VectorXf> probs_flat(probs.data(), probs.size());
+                result = inmodel.H_combined[var_index] * probs_flat;
+            }
+            cache.last_result = std::move(result);
+            cache.last_phys = phys;
+        }
+
+        cache.last_var_index = (int)var_index;
+        cache.last_syst_ptr = &insyst;
+        cache.last_model_ptr = &inmodel;
+
+        Eigen::VectorXf final_spec  = cache.last_systw.cwiseProduct(cache.last_result);
+        Eigen::VectorXf final_error = final_spec.array().abs().sqrt();
+        return PROspec(final_spec, final_error);
+    }
+
+
     PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned, size_t var_index){
         PROspec myspectrum(inconfig.m_num_variable_bins_total[var_index]);
         Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -58,32 +58,117 @@ namespace PROfit {
                                   cache.last_model_ptr != &inmodel);
 
         // ---- Systematic-weights half (depends only on shifts) ----
-        const bool shifts_changed = ctx_changed ||
-                                    cache.last_shifts.size() != shifts.size() ||
-                                    cache.last_shifts != shifts;
-        if(shifts_changed) {
-            const size_t nbins_var = inconfig.m_num_variable_bins_total[var_index];
+        // Three branches for the systw vector:
+        //   * full_systw_hit    : shifts identical to cached -> reuse cache.last_systw.
+        //   * try_incremental   : shifts differs in EXACTLY one spline-range element
+        //                          -> Tier 1.3: divide out old factor, multiply in new
+        //                          factor for that one spline. Cache stays pinned to
+        //                          its "central" state (no write-back).
+        //   * full recompute    : everything else (size mismatch, ctx change, multi-diff,
+        //                          or incremental gave a divide-by-near-zero on some bin).
+        //                          Re-runs the full loop AND populates central_factors.
+        const size_t       nbins_var      = inconfig.m_num_variable_bins_total[var_index];
+        const Eigen::Index nsplines_e     = (Eigen::Index)insyst.GetNSplines();
+        const bool         size_match     = (cache.last_shifts.size() == shifts.size());
+        const bool         factors_valid  = (cache.central_factors.cols() == nsplines_e &&
+                                             cache.central_factors.rows() == (Eigen::Index)nbins_var);
+        const bool         diff_check_ok  = !ctx_changed && size_match && factors_valid;
+
+        int diff_count = 0;
+        int diff_idx   = -1;
+        if(diff_check_ok) {
+            for(Eigen::Index i = 0; i < shifts.size(); ++i) {
+                if(cache.last_shifts(i) != shifts(i)) {
+                    diff_idx = (int)i;
+                    if(++diff_count > 1) break;
+                }
+            }
+        }
+        const bool full_systw_hit  = diff_check_ok && (diff_count == 0);
+        const bool try_incremental = diff_check_ok && (diff_count == 1)
+                                                   && (diff_idx >= 0)
+                                                   && (diff_idx < (int)insyst.GetNSplines());
+
+        Eigen::VectorXf       systw_local;            // populated only on the incremental path
+        const Eigen::VectorXf *systw_to_use = nullptr; // points to whichever vector we'll combine
+
+        if(full_systw_hit) {
+            systw_to_use = &cache.last_systw;
+        } else if(try_incremental) {
+            const size_t j       = (size_t)diff_idx;
+            const size_t binning = insyst.spline_binnings[j];
+
+            Eigen::VectorXf new_factor_j(nbins_var);
+            if(binning == var_index) {
+                for(size_t k = 0; k < nbins_var; ++k)
+                    new_factor_j(k) = insyst.GetSplineShift((int)j, shifts(j), (int)k);
+            } else {
+                const size_t nbins_binning = inconfig.m_num_variable_bins_total[binning];
+                Eigen::VectorXf spline_shifts_one(nbins_binning);
+                for(size_t b = 0; b < nbins_binning; ++b)
+                    spline_shifts_one(b) = insyst.GetSplineShift((int)j, shifts(j), (int)b);
+                const auto &hist = inprop.variable_hist_storage(binning, var_index);
+                Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts_one;
+                Eigen::VectorXf unweighted_sum = hist.colwise().sum().transpose();
+                for(size_t k = 0; k < nbins_var; ++k)
+                    new_factor_j(k) = (unweighted_sum(k) > 0) ? weighted_sum(k) / unweighted_sum(k)
+                                                              : 1.0f;
+            }
+
+            // Apply division+multiplication into a fresh local systw without touching cache.
+            // If any cached factor for spline j is too small, fall back to full recompute.
+            constexpr float kTiny = 1e-30f;
+            systw_local.resize(nbins_var);
+            bool ok = true;
+            for(size_t k = 0; k < nbins_var; ++k) {
+                const float old_f = cache.central_factors(k, (Eigen::Index)j);
+                if(std::abs(old_f) < kTiny) { ok = false; break; }
+                systw_local(k) = cache.last_systw(k) / old_f * new_factor_j(k);
+            }
+
+            if(ok) {
+                systw_to_use = &systw_local;
+                // CRITICAL: do NOT update cache.last_shifts, cache.last_systw, or
+                // cache.central_factors. Cache stays pinned to the central point so
+                // subsequent single-shift gradient calls also hit the incremental path.
+            }
+            // else fall through to full recompute below
+        }
+
+        if(systw_to_use == nullptr) {
+            // Full recompute: rebuild systw AND populate per-spline factors. The
+            // existing math is preserved bit-for-bit; we just stash each spline's
+            // contribution as we go.
             Eigen::VectorXf systw = Eigen::VectorXf::Constant(nbins_var, 1);
+            Eigen::MatrixXf factors(nbins_var, insyst.GetNSplines());
             for(int i = 0; i < (int)insyst.GetNSplines(); ++i) {
                 size_t binning = insyst.spline_binnings[i];
                 if(binning == var_index) {
-                    for(size_t k = 0; k < nbins_var; ++k)
-                        systw(k) *= insyst.GetSplineShift(i, shifts(i), k);
+                    for(size_t k = 0; k < nbins_var; ++k) {
+                        const float f = insyst.GetSplineShift(i, shifts(i), (int)k);
+                        factors(k, i) = f;
+                        systw(k) *= f;
+                    }
                 } else {
                     const size_t nbins_binning = inconfig.m_num_variable_bins_total[binning];
-                    Eigen::VectorXf spline_shifts(nbins_binning);
-                    for(size_t j = 0; j < nbins_binning; ++j)
-                        spline_shifts(j) = insyst.GetSplineShift(i, shifts(i), j);
+                    Eigen::VectorXf spline_shifts_loc(nbins_binning);
+                    for(size_t b = 0; b < nbins_binning; ++b)
+                        spline_shifts_loc(b) = insyst.GetSplineShift(i, shifts(i), (int)b);
                     const auto &hist = inprop.variable_hist_storage(binning, var_index);
-                    Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts;
+                    Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts_loc;
                     Eigen::VectorXf unweighted_sum = hist.colwise().sum().transpose();
-                    for(size_t k = 0; k < nbins_var; ++k)
-                        if(unweighted_sum(k) > 0)
-                            systw(k) *= weighted_sum(k) / unweighted_sum(k);
+                    for(size_t k = 0; k < nbins_var; ++k) {
+                        const float f = (unweighted_sum(k) > 0) ? weighted_sum(k) / unweighted_sum(k)
+                                                                : 1.0f;
+                        factors(k, i) = f;
+                        systw(k) *= f;
+                    }
                 }
             }
-            cache.last_systw = std::move(systw);
-            cache.last_shifts = shifts;
+            cache.last_systw      = std::move(systw);
+            cache.last_shifts     = shifts;
+            cache.central_factors = std::move(factors);
+            systw_to_use          = &cache.last_systw;
         }
 
         // ---- Physics-result half (depends only on phys) ----
@@ -121,7 +206,9 @@ namespace PROfit {
         cache.last_syst_ptr = &insyst;
         cache.last_model_ptr = &inmodel;
 
-        Eigen::VectorXf final_spec  = cache.last_systw.cwiseProduct(cache.last_result);
+        // systw_to_use points to either cache.last_systw (full hit / full recompute) or
+        // to the local perturbed vector built by the Tier 1.3 incremental path.
+        Eigen::VectorXf final_spec  = systw_to_use->cwiseProduct(cache.last_result);
         Eigen::VectorXf final_error = final_spec.array().abs().sqrt();
         return PROspec(final_spec, final_error);
     }

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -87,10 +87,9 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
     Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
 
-    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
-   
-    Eigen::VectorXf normdata = shape_only 
+    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
+
+    Eigen::VectorXf normdata = shape_only
         ? data.Normalize(config,result)
         : data.Spec();
 
@@ -193,8 +192,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 // Calculate chi2_plus or chi2_minus, depending on boundary
                 PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
-                Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                 
                 // Reduce matrices using non_empty_indices
@@ -239,8 +237,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     
                     // Reduce matrices using non_empty_indices
@@ -269,8 +266,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     
                     // Reduce matrices using non_empty_indices
@@ -327,8 +323,7 @@ float PROchi::getSingleChannelChi(size_t global_channel_index, const PROspec & c
     //only calculate a syst covariance if we have any covariance parameters as defined in the xml
     if(syst->GetNCovar()){
         // Calculate Full Syst Covariance matrix
-        Eigen::MatrixXf diag =  cv.Spec().array().matrix().asDiagonal(); 
-        Eigen::MatrixXf full_covariance =  diag*(syst->fractional_covariance)*diag;
+        Eigen::MatrixXf full_covariance = cv.Spec().asDiagonal() * (syst->fractional_covariance) * cv.Spec().asDiagonal();
 
         // Collapse Covariance and Spectra 
         Eigen::MatrixXf collapsed_full_covariance =  CollapseMatrix(config,full_covariance);

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -126,32 +126,27 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
             log<LOG_ERROR>(L"%1% || ERROR: All data bins are empty!") % __func__;
             throw std::runtime_error("All data bins are empty in PROchi.");
         }
-        const size_t s = nei_local.size();
-        rstat_local.resize(s, s);
-        for(size_t i = 0; i < s; ++i)
-            for(size_t j = 0; j < s; ++j)
-                rstat_local(i, j) = collapsed_stat_covariance(nei_local[i], nei_local[j]);
+        const Eigen::Map<const Eigen::Matrix<Eigen::Index, Eigen::Dynamic, 1>>
+            idx_local(nei_local.data(), (Eigen::Index)nei_local.size());
+        rstat_local = Eigen::MatrixXf(normdata(idx_local).asDiagonal());
     }
     const std::vector<Eigen::Index> &non_empty_indices = nec_valid ? nec_indices : nei_local;
     const Eigen::MatrixXf &reduced_collapsed_stat_covariance = nec_valid ? nec_reduced_stat_cov : rstat_local;
     const size_t reduced_size = non_empty_indices.size();
 
+    // Eigen 3.4 indexing handle for all the per-call reductions below (and in the
+    // gradient blocks further down). Lightweight reference, no allocation.
+    const Eigen::Map<const Eigen::Matrix<Eigen::Index, Eigen::Dynamic, 1>>
+        idx(non_empty_indices.data(), (Eigen::Index)reduced_size);
+
     // Per-call: reduced_collapsed_full_covariance depends on `result` via collapsed_full_covariance.
-    Eigen::MatrixXf reduced_collapsed_full_covariance(reduced_size, reduced_size);
-    for (size_t i = 0; i < reduced_size; ++i) {
-        for (size_t j = 0; j < reduced_size; ++j) {
-            reduced_collapsed_full_covariance(i, j) = collapsed_full_covariance(non_empty_indices[i], non_empty_indices[j]);
-        }
-    }
+    Eigen::MatrixXf reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
 
     inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + reduced_collapsed_full_covariance).inverse();
 
     // Create reduced delta vector
     Eigen::VectorXf collapsed_mc_spec = CollapseMatrix(config, result.Spec());
-    Eigen::VectorXf delta(reduced_size);
-    for (size_t i = 0; i < reduced_size; ++i) {
-        delta(i) = collapsed_mc_spec(non_empty_indices[i]) - normdata(non_empty_indices[i]);
-    }
+    Eigen::VectorXf delta = collapsed_mc_spec(idx) - normdata(idx);
     
     float pull = Pull(subvector2);
     float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
@@ -218,21 +213,12 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                 Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                
-                // Reduce matrices using non_empty_indices
-                Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
-                for (size_t ii = 0; ii < reduced_size; ++ii) {
-                    for (size_t jj = 0; jj < reduced_size; ++jj) {
-                        grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
-                    }
-                }
+
+                Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
                 Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
                 Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
-                Eigen::VectorXf delta(reduced_size);
-                for (size_t ii = 0; ii < reduced_size; ++ii) {
-                    delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
-                }
+                Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                 Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                 float pull = Pull(subvector2);
                 chi2_oneside = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
@@ -263,21 +249,12 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    
-                    // Reduce matrices using non_empty_indices
-                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        for (size_t jj = 0; jj < reduced_size; ++jj) {
-                            grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
-                        }
-                    }
+
+                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
                     Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
-                    Eigen::VectorXf delta(reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
-                    }
+                    Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                     Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
                     chi2_plus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
@@ -292,21 +269,12 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    
-                    // Reduce matrices using non_empty_indices
-                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        for (size_t jj = 0; jj < reduced_size; ++jj) {
-                            grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
-                        }
-                    }
+
+                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
                     Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
-                    Eigen::VectorXf delta(reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
-                    }
+                    Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                     Eigen::VectorXf subvector2 = param_minus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
                     chi2_minus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -37,14 +37,32 @@ PROchi::PROchi(const std::string tag, const PROconfig &conin, const PROpeller &p
           prior_covariance(iB, iA) = std::get<2>(t);
         }
         prior_covariance = systin->spline_priors.asDiagonal() * prior_covariance * systin->spline_priors.asDiagonal();
+        prior_covariance_inv = prior_covariance.inverse();
     }
-    
+
     // GP: What do you do if the MC has 0 events in a bin?
     //     Proposed solution (hack?) here. Set the error to 1. This will return
     //     the correct answer if there are no data events in the bin. It is a bit
     //     iffier if there are data events in the bin, we may want to implement some
     //     error handling there.
     collapsed_stat_covariance = data.Spec().array().cwiseMax(1).matrix().asDiagonal();
+
+    // Default-mode cache: in non-shape_only mode normdata == data.Spec() is constant
+    // across all operator() invocations, so non_empty_indices and the reduced stat
+    // covariance are constant. Build them once here and reuse them.
+    if(!shape_only) {
+        const Eigen::VectorXf &nd = data.Spec();
+        for(Eigen::Index i = 0; i < nd.size(); ++i)
+            if(nd(i) > 0) nec_indices.push_back(i);
+        if(!nec_indices.empty()) {
+            Eigen::VectorXf reduced_diag(nec_indices.size());
+            for(size_t k = 0; k < nec_indices.size(); ++k)
+                reduced_diag(k) = nd(nec_indices[k]);
+            nec_reduced_stat_cov = Eigen::MatrixXf(reduced_diag.asDiagonal());
+            nec_valid = true;
+        }
+        // If empty, leave nec_valid=false; operator() will throw on first call.
+    }
 }
 
 float PROchi::Pull(const Eigen::VectorXf &systs) {
@@ -54,8 +72,8 @@ float PROchi::Pull(const Eigen::VectorXf &systs) {
         return (centered.array().square() / syst->spline_priors.array().square()).sum();
     }
 
-    // Otherwise dot onto covariance
-    return centered.dot(prior_covariance.inverse() * centered);
+    // Otherwise dot onto covariance (prior_covariance_inv was computed in the ctor).
+    return centered.dot(prior_covariance_inv * centered);
 }
 
 void PROchi::fixSpline(int fix, float valin){
@@ -83,7 +101,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
     // Get Spectra from FillSpectra
     Eigen::VectorXf subvector2 = param.segment(nparams - nsyst, nsyst);
     
-    PROspec result = FillSpectra(config, peller, *syst, model, param, strat == BinnedChi2, config.i_prime);
+    PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2, config.i_prime);
 
     Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
 
@@ -93,30 +111,36 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         ? data.Normalize(config,result)
         : data.Spec();
 
-    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
     collapsed_stat_covariance = (normdata).matrix().asDiagonal();
 
-    // remove rows and columns corresponding to empty data bin indices here, avoiding any nan chi2 calculations for bins with no data events
-    std::vector<Eigen::Index> non_empty_indices;
-    for (Eigen::Index i = 0; i < normdata.size(); ++i) {
-        if (normdata(i) > 0) {
-            non_empty_indices.push_back(i);
+    // non_empty_indices and reduced_collapsed_stat_covariance are constant in default
+    // (non-shape_only) mode and were precomputed in the ctor; in shape_only mode
+    // normdata depends on `result` so we must rebuild them per call.
+    std::vector<Eigen::Index> nei_local;
+    Eigen::MatrixXf rstat_local;
+    if(!nec_valid) {
+        for(Eigen::Index i = 0; i < normdata.size(); ++i)
+            if(normdata(i) > 0) nei_local.push_back(i);
+        if(nei_local.empty()) {
+            log<LOG_ERROR>(L"%1% || ERROR: All data bins are empty!") % __func__;
+            throw std::runtime_error("All data bins are empty in PROchi.");
         }
+        const size_t s = nei_local.size();
+        rstat_local.resize(s, s);
+        for(size_t i = 0; i < s; ++i)
+            for(size_t j = 0; j < s; ++j)
+                rstat_local(i, j) = collapsed_stat_covariance(nei_local[i], nei_local[j]);
     }
-    
-    size_t reduced_size = non_empty_indices.size();
-    if (reduced_size == 0) {
-        log<LOG_ERROR>(L"%1% || ERROR: All data bins are empty!") % __func__;
-        throw std::runtime_error("All data bins are empty in PROchi.");
-    }
-    
-    // Create reduced covariance matrices by removing empty bin rows/columns
+    const std::vector<Eigen::Index> &non_empty_indices = nec_valid ? nec_indices : nei_local;
+    const Eigen::MatrixXf &reduced_collapsed_stat_covariance = nec_valid ? nec_reduced_stat_cov : rstat_local;
+    const size_t reduced_size = non_empty_indices.size();
+
+    // Per-call: reduced_collapsed_full_covariance depends on `result` via collapsed_full_covariance.
     Eigen::MatrixXf reduced_collapsed_full_covariance(reduced_size, reduced_size);
-    Eigen::MatrixXf reduced_collapsed_stat_covariance(reduced_size, reduced_size);
     for (size_t i = 0; i < reduced_size; ++i) {
         for (size_t j = 0; j < reduced_size; ++j) {
             reduced_collapsed_full_covariance(i, j) = collapsed_full_covariance(non_empty_indices[i], non_empty_indices[j]);
-            reduced_collapsed_stat_covariance(i, j) = collapsed_stat_covariance(non_empty_indices[i], non_empty_indices[j]);
         }
     }
 
@@ -190,7 +214,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
-                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                 Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
@@ -235,7 +259,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (plus) violates unitarity. Setting chi2_plus to large value.") % __func__;
                     chi2_plus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
@@ -264,7 +288,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (minus) violates unitarity. Setting chi2_minus to large value.") % __func__;
                     chi2_minus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -2233,6 +2233,14 @@ void PROconfig::construct_variable_collapsing_matrices(){
         }
 
     }
+
+    // Build sparse companions. Each row of T has exactly one 1.0, so nnz = m_num_variable_bins_total[io].
+    variable_collapsing_matrices_sparse.clear();
+    variable_collapsing_matrices_sparse.reserve(m_num_variables);
+    for(size_t io = 0; io < m_num_variables; ++io) {
+        variable_collapsing_matrices_sparse.emplace_back(variable_collapsing_matrices[io].sparseView());
+        variable_collapsing_matrices_sparse.back().makeCompressed();
+    }
     return;
 }
 

--- a/src/PROpoisson.cxx
+++ b/src/PROpoisson.cxx
@@ -41,6 +41,7 @@ PROpoisson::PROpoisson(const std::string tag, const PROconfig &conin, const PROp
           prior_covariance(iB, iA) = std::get<2>(t);
         }
         prior_covariance = systin->spline_priors.asDiagonal() * prior_covariance * systin->spline_priors.asDiagonal();
+        prior_covariance_inv = prior_covariance.inverse();
     }
 }
 
@@ -51,7 +52,7 @@ float PROpoisson::Pull(const Eigen::VectorXf &systs) {
         return (centered.array().square() / syst->spline_priors.array().square()).sum();
     }
 
-    return centered.dot(prior_covariance.inverse() * centered);
+    return centered.dot(prior_covariance_inv * centered);
 }
 
 void PROpoisson::fixSpline(int fix, float valin){
@@ -78,9 +79,9 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
     }
     Eigen::VectorXf subvector2 = param.segment(nparams - nsyst, nsyst);
     
-    PROspec result = FillSpectra(config, peller, *syst, model, param, strat == BinnedChi2);
+    PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2);
 
-    const Eigen::VectorXf vdata = shape_only 
+    const Eigen::VectorXf vdata = shape_only
         ? data.Normalize(config,result)
         : data.Spec();
     const Eigen::VectorXf vmc = CollapseMatrix(config, result.Spec());
@@ -111,7 +112,7 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
                     continue;
                 }
             }
-            PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, strat != EventByEvent);
+            PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, fs_cache, strat != EventByEvent);
 
             const Eigen::VectorXf vdata = shape_only 
                 ? data.Normalize(config,result)

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -914,10 +914,9 @@ namespace PROfit {
     }
 
     Eigen::MatrixXf PROsyst::DecomposeFractionalCovariance(const PROconfig &config, const Eigen::VectorXf &cv_vec) const {
-        if(cv_vec.size() == last_decomp_spec.size() && cv_vec == last_decomp_spec) 
+        if(cv_vec.size() == last_decomp_spec.size() && cv_vec == last_decomp_spec)
           return last_decomp_mat;
-        Eigen::MatrixXf diag = cv_vec.asDiagonal();
-        Eigen::MatrixXf full_cov = diag * fractional_covariance * diag;
+        Eigen::MatrixXf full_cov = cv_vec.asDiagonal() * fractional_covariance * cv_vec.asDiagonal();
         Eigen::MatrixXf coll = other_index < 0 ? CollapseMatrix(config, full_cov) : CollapseMatrix(config, full_cov, other_index);
         /*Eigen::LDLT<Eigen::MatrixXf> ldlt(coll);
           Eigen::MatrixXf L = ldlt.matrixL(); 

--- a/src/PROtocall.cxx
+++ b/src/PROtocall.cxx
@@ -38,53 +38,45 @@ namespace PROfit{
     }
 
     Eigen::MatrixXf CollapseMatrix(const PROconfig &inconfig, const Eigen::MatrixXf& full_matrix){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix();
-        int num_bin_before_collapse = variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse();
+        const Eigen::Index num_bin_before_collapse = T.rows();
         if(full_matrix.rows() != num_bin_before_collapse || full_matrix.cols() != num_bin_before_collapse){
             log<LOG_ERROR>(L"%1% || Matrix dimension doesn't match expected size. Provided matrix: %2% x %3%. Expected matrix size: %4% x %5%") % __func__ % full_matrix.rows() % full_matrix.cols() % num_bin_before_collapse% num_bin_before_collapse;
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-
-        //log<LOG_DEBUG>(L"%1% || CT  %2% x %3%. Full matrix: %4% x %5% ") % __func__ % variable_collapsing_matrices[config.i_prime].transpose().rows() %  variable_collapsing_matrices[config.i_prime].transpose().cols() % full_matrix.rows() % full_matrix.cols();
-        Eigen::MatrixXf result_matrix   = variable_collapsing_matrix.transpose()*full_matrix*variable_collapsing_matrix;
-        return result_matrix;
+        return Eigen::MatrixXf(T.transpose() * full_matrix * T);
     }
 
     Eigen::VectorXf CollapseMatrix(const PROconfig &inconfig, const Eigen::VectorXf& full_vector){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix();
-        if(full_vector.size() != variable_collapsing_matrix.rows()){
-            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse();
+        if(full_vector.size() != T.rows()){
+            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % T.rows();
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-        Eigen::VectorXf result_vector = variable_collapsing_matrix.transpose() * full_vector;
-        return result_vector;
+        return Eigen::VectorXf(T.transpose() * full_vector);
     }
 
     Eigen::MatrixXf CollapseMatrix(const PROconfig &inconfig, const Eigen::MatrixXf& full_matrix, int other_index){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix(other_index);
-        int num_bin_before_collapse = variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse(other_index);
+        const Eigen::Index num_bin_before_collapse = T.rows();
         if(full_matrix.rows() != num_bin_before_collapse || full_matrix.cols() != num_bin_before_collapse){
             log<LOG_ERROR>(L"%1% || Matrix dimension doesn't match expected size. Provided matrix: %2% x %3%. Expected matrix size: %4% x %5%") % __func__ % full_matrix.rows() % full_matrix.cols() % num_bin_before_collapse% num_bin_before_collapse;
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-
-        //log<LOG_DEBUG>(L"%1% || CT  %2% x %3%. Full matrix: %4% x %5% ") % __func__ % variable_collapsing_matrix.transpose().rows() %  variable_collapsing_matrices[config.i_prime].transpose().cols() % full_matrix.rows() % full_matrix.cols();
-        Eigen::MatrixXf result_matrix   = variable_collapsing_matrix.transpose()*full_matrix*variable_collapsing_matrix;
-        return result_matrix;
+        return Eigen::MatrixXf(T.transpose() * full_matrix * T);
     }
 
     Eigen::VectorXf CollapseMatrix(const PROconfig &inconfig, const Eigen::VectorXf& full_vector, int other_index){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix(other_index);
-        if(full_vector.size() != variable_collapsing_matrix.rows()){
-            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse(other_index);
+        if(full_vector.size() != T.rows()){
+            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % T.rows();
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-        Eigen::VectorXf result_vector = variable_collapsing_matrix.transpose() * full_vector;
-        return result_vector;
+        return Eigen::VectorXf(T.transpose() * full_vector);
     }
     void PrintVariableInfo(const PROconfig &inconfig){
 


### PR DESCRIPTION
Series of performance  tweaks in preparation for PROfit technical paper scaling studies.

Overall approx x3-x4 speed up on 40x40 surface, bit less for profile (x2-x3) . Not yet optimized for FC which I believe could have seperate says to improve.

1. Collapsing matrix made sparse, as well as better handling of Eigen::MatrixF creation
2. FillSpectra Caching: Split Physics and Spline's, if one hasn't changed then load from cache. For splines, this is also true PER spline, so in gradient calculation saves time
3. Cached prior inverse covariance matrix, so dont waste time re-inverting
4. Eigen::MatixF  diag was creating non-sparse NxN many times inside Chi^2 calc , just to access diagonals and not off diagonals. Optimized. asDiagonal()
5. Updated LBFGSB version. Some line search updates, and error handling is streamlines for our approach
6. Minor CMakeLists compile options tweaks for Eigen. Didn't do much (compile — -O3 -DNDEBUG -march=x86-64-v3 -DEIGEN_DONT_PARALLELIZE)


Simple numudis only test, surface ngrid = 35. 
Speedup column is **cumulative wall-time vs `base`** (so always ≥ 1.00× for forward progress).

| Mode | Base | Final | **Wall speedup** | User speedup |
|---|---:|---:|---:|---:|
| global  | 16.01 s | 9.09 s   | **1.76×** | 1.77× |
| profile | 183.95 s | 47.19 s | **3.90×** | 4.29× |
| surface | 248.79 s | 64.98 s | **3.83×** | 4.03× |



