### PR TITLE
MCMC and Chi2 tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ else()
     FetchContent_Declare(
         lbfgspp
         GIT_REPOSITORY https://github.com/markrosslonergan/LBFGSpp
-        GIT_TAG        253e837bbff0460bddd84cd9883715c18aa19426
+        #        GIT_TAG        253e837bbff0460bddd84cd9883715c18aa19426
+        GIT_TAG        53c9c044c0d44f956b5dd2d90c6b598d2a17a8c9
         )
 endif()
 FetchContent_MakeAvailable(eigen)

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1222,7 +1222,7 @@ int main(int argc, char* argv[])
             //c1.Print("phys_cov.pdf");
         }
         log<LOG_INFO>(L"%1% || MCMC acceptance is  %2%. ") % __func__% ((double)mh.naccept /fitConfig.MCMCiter);
-        mh.plot_autocorrelation(final_output_tag+"_PROfile_corrmat_mcmc_autocorraltion.pdf", param_names);
+        mh.plot_autocorrelation(final_output_tag+"_PROfile_corrmat_mcmc_autocorrelation.pdf", param_names);
 
         std::string hname = "#chi^{2}/ndf = " + to_string(best_chi2) + "/" + to_string(config.m_num_variable_bins_total_collapsed[config.i_prime]);
         PROspec cv = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), CVParams , true,config.i_prime);
@@ -2659,7 +2659,7 @@ int main(int argc, char* argv[])
         }
         log<LOG_INFO>(L"%1% || MCMC acceptance is  %2%. ") % __func__% ((double)mh.naccept /fitConfig.MCMCiter);
 
-        mh.plot_autocorrelation(final_output_tag+"_PROglobal_corrmat_mcmc_autocorraltion.pdf", param_names);
+        mh.plot_autocorrelation(final_output_tag+"_PROglobal_corrmat_mcmc_autocorrelation.pdf", param_names);
 
         std::string hname = "#chi^{2}/ndf = " + to_string(best_chi2) + "/" + to_string(config.m_num_variable_bins_total_collapsed[config.i_prime]);
         PROspec cv = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), CVParams , true,config.i_prime);
@@ -2793,7 +2793,7 @@ int main(int argc, char* argv[])
                     tree.Fill();
                 }
                 tree.Write();
-                met.plot_autocorrelation((final_output_tag+"_PROMCMC_autocorraltion_chain"+std::to_string(chain_counter)+".pdf").c_str(), param_names);
+                met.plot_autocorrelation((final_output_tag+"_PROMCMC_autocorrelation_chain"+std::to_string(chain_counter)+".pdf").c_str(), param_names);
             }
         }
         //TCanvas c;

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -162,6 +162,40 @@ bool LOGGING_TO_FILE = false;
 
 void mcmc_worker(std::vector<Metropolis<simple_target, adaptive_proposal>> &mets, Eigen::VectorXf initial, PROmetric *metric, uint32_t seed, size_t nchains, size_t burnin, size_t steps);
 
+// Walks the collapsed reco bins and logs any with prediction < threshold,
+// printing the channel, bin index/edges, prediction, and data count side-by-side.
+static void logLowPredictionBins(const PROconfig &config, const Eigen::VectorXf &pred_collapsed, const Eigen::VectorXf &data_collapsed, float threshold = 1.0f, size_t var_index = 0) {
+    log<LOG_INFO>(L"%1% || ----- Low-prediction reco bins (pred < %2%) -----") % __func__ % threshold;
+    log<LOG_INFO>(L"%1% || %2$-30s  %3$-12s  %4$-18s  %5$-12s  %6$-12s")
+        % __func__ % "channel" % "bin_in_chan" % "edges [MeV]" % "pred" % "data";
+    size_t flat = 0;
+    size_t n_low = 0;
+    size_t global_channel_index = 0;
+    for(size_t mode = 0; mode < config.m_num_modes; ++mode) {
+        for(size_t det = 0; det < config.m_num_detectors; ++det) {
+            for(size_t channel = 0; channel < config.m_num_channels; ++channel) {
+                std::vector<float> edges = config.GetChannelVariableBins(global_channel_index, var_index).Edges();
+                const std::string &cname = config.m_channel_names[channel];
+                for(size_t b = 0; b + 1 < edges.size(); ++b, ++flat) {
+                    if(flat >= (size_t)pred_collapsed.size()) break;
+                    float p = pred_collapsed(flat);
+                    float d = data_collapsed(flat);
+                    if(p < threshold) {
+                        ++n_low;
+                        char edge_str[32];
+                        std::snprintf(edge_str, sizeof(edge_str), "[%.0f, %.0f)", edges[b], edges[b+1]);
+                        log<LOG_INFO>(L"%1% || %2$-30s  %3$-12zu  %4$-18s  %5$-12.4f  %6$-12.2f")
+                            % __func__ % cname.c_str() % b % edge_str % p % d;
+                    }
+                }
+                ++global_channel_index;
+            }
+        }
+    }
+    log<LOG_INFO>(L"%1% || %2% / %3% reco bins have prediction < %4%.")
+        % __func__ % n_low % (size_t)pred_collapsed.size() % threshold;
+}
+
 int main(int argc, char* argv[])
 {
     gStyle->SetOptStat(0);
@@ -1101,6 +1135,12 @@ int main(int argc, char* argv[])
         }
         log<LOG_INFO>(L"%1% || ################################################") % __func__;
 
+        {
+            Eigen::VectorXf bf_spec_full = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), best_fit, true, config.i_prime).Spec();
+            Eigen::VectorXf bf_spec_coll = CollapseMatrix(config, bf_spec_full);
+            logLowPredictionBins(config, bf_spec_coll, data.Spec(), 1.0f, config.i_prime);
+        }
+
         log<LOG_INFO>(L"%1% || Starting a metropolis hastings chain to estimate the covariance matrix around the above best fit. Run and Burn is (%2%,%3%);") % __func__%fitConfig.MCMCiter % fitConfig.MCMCburn;
         std::vector<int> fixed;
         for(size_t i = 0; i< global_fixed.size();i++){
@@ -1114,9 +1154,11 @@ int main(int argc, char* argv[])
         size_t count = 0;
         const auto action = [&](const Eigen::VectorXf &value) {
             covmat += (value-best_fit) * (value-best_fit).transpose();
-            count += 1; 
+            count += 1;
         };
-        mh.run(fitConfig.MCMCburn,fitConfig.MCMCiter, action);
+        std::optional<PROgressBar> mh_pbar;
+        if(progress_bar) mh_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit");
+        mh.run(fitConfig.MCMCburn,fitConfig.MCMCiter, action, mh_pbar ? &*mh_pbar : nullptr);
 
         covmat /= count;
         Eigen::VectorXf inv_best_fit = best_fit.array().abs().max(1e-10f).inverse();
@@ -1207,18 +1249,19 @@ int main(int argc, char* argv[])
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
         Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
-        //log<LOG_INFO>(L"%1% ||ARSOut %2% ") % __func__ % cv.Spec();
-        //log<LOG_INFO>(L"%1% || address %2%") % __func__ % &cv;
 
+        std::optional<PROgressBar> errband_pre_pbar;
+        if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
         PROerrorbar  err_band =
             MCMC_prefit_errors
-            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime)
+            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        //Metropolis mh_post(simple_target{*metric}, simple_proposal(*metric, dseed(PROseed::global_rng), 0.2, fixed_pars), best_fit, dseed(PROseed::global_rng));
         Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
-        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, post_param_lo, post_param_hi, binwidth_scale,config.i_prime);
+        std::optional<PROgressBar> errband_post_pbar;
+        if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
+        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, post_param_lo, post_param_hi, binwidth_scale,config.i_prime, errband_post_pbar ? &*errband_post_pbar : nullptr);
 
         std::vector<TPaveText> texts;
         TPaveText chi2text(0.55, 0.50, 0.85, 0.58, "NDC");
@@ -2533,6 +2576,12 @@ int main(int argc, char* argv[])
         }
         log<LOG_INFO>(L"%1% || ################################################") % __func__;
 
+        {
+            Eigen::VectorXf bf_spec_full = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), best_fit, true, config.i_prime).Spec();
+            Eigen::VectorXf bf_spec_coll = CollapseMatrix(config, bf_spec_full);
+            logLowPredictionBins(config, bf_spec_coll, data.Spec(), 1.0f, config.i_prime);
+        }
+
         log<LOG_INFO>(L"%1% || Starting a metropolis hastings chain to estimate the covariance matrix aroud the above best fit. Run and Burn is (%2%,%3%);") % __func__%fitConfig.MCMCiter % fitConfig.MCMCburn;
         std::vector<int> fixed;
         for(size_t i = 0; i< global_fixed.size();i++){
@@ -2545,9 +2594,11 @@ int main(int argc, char* argv[])
         size_t count = 0;
         const auto action = [&](const Eigen::VectorXf &value) {
             covmat += (value-best_fit) * (value-best_fit).transpose();
-            count += 1; 
+            count += 1;
         };
-        mh.run(fitConfig.MCMCburn,fitConfig.MCMCiter, action);
+        std::optional<PROgressBar> mh_pbar;
+        if(progress_bar) mh_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit");
+        mh.run(fitConfig.MCMCburn,fitConfig.MCMCiter, action, mh_pbar ? &*mh_pbar : nullptr);
 
         covmat /= count;
         Eigen::VectorXf inv_best_fit = best_fit.array().abs().max(1e-10f).inverse();
@@ -2637,14 +2688,18 @@ int main(int argc, char* argv[])
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
         Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
+        std::optional<PROgressBar> errband_pre_pbar;
+        if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
         PROerrorbar  err_band =
             MCMC_prefit_errors
-            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime)
+            ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
         Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
-        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, post_param_lo, post_param_hi, binwidth_scale,config.i_prime);
+        std::optional<PROgressBar> errband_post_pbar;
+        if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
+        PROerrorbar post_err_band = getMCMCErrorBand(mh_post, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, posteriors, spline_covariance, post_param_lo, post_param_hi, binwidth_scale,config.i_prime, errband_post_pbar ? &*errband_post_pbar : nullptr);
 
         std::vector<TPaveText> texts;
         TPaveText chi2text(0.55, 0.50, 0.85, 0.58, "NDC");
@@ -2796,6 +2851,173 @@ int main(int argc, char* argv[])
                 log<LOG_INFO>(L"%1% || Test %2% bin %3%: %4%") % __func__ % (test + 1) % b % spec.Spec()(b);
             }
             log<LOG_INFO>(L"%1% || Test %2% Total: %3%") % __func__ % (test + 1) % spec.Spec().sum();
+        }
+
+        // ---- chi2 algorithm comparison: 4 paths exercising covariance-build and inverse-vs-solve ----
+        log<LOG_INFO>(L"%1% || ===== chi2 algorithm comparison =====") % __func__;
+        const PROsyst &cmp_syst = metric->GetSysts();
+        const Eigen::MatrixXf &cmp_fcov = cmp_syst.fractional_covariance;
+        const Eigen::VectorXf cmp_data = data.Spec();
+
+        std::vector<Eigen::Index> cmp_nonempty;
+        for(Eigen::Index i = 0; i < cmp_data.size(); ++i)
+            if(cmp_data(i) > 0) cmp_nonempty.push_back(i);
+        const size_t cmp_red = cmp_nonempty.size();
+        if(cmp_red == 0) {
+            log<LOG_ERROR>(L"%1% || All data bins empty, skipping chi2 comparison.") % __func__;
+        } else {
+            const size_t cmp_N = 200;
+            std::vector<Eigen::VectorXf> cmp_params;
+            cmp_params.reserve(cmp_N);
+            std::mt19937 cmp_rng(67890);
+            std::normal_distribution<float> cmp_d(0.0f, 1.0f);
+            for(size_t k = 0; k < cmp_N; ++k) {
+                Eigen::VectorXf p = Eigen::VectorXf::Zero(N_phys_params + n_splines);
+                for(size_t i = 0; i < N_phys_params; ++i) p(i) = CVParams(i);
+                for(size_t i = 0; i < n_splines; ++i) p(N_phys_params + i) = cmp_d(cmp_rng);
+                cmp_params.push_back(p);
+            }
+
+            std::vector<float> chi2_old(cmp_N), chi2_mid(cmp_N), chi2_new(cmp_N), chi2_alt(cmp_N);
+            Eigen::MatrixXf cmp_red_stat(cmp_red, cmp_red);
+
+            // OLD: dense diag*F*diag + .inverse()
+            auto cmp_t0 = std::chrono::high_resolution_clock::now();
+            for(size_t k = 0; k < cmp_N; ++k) {
+                PROspec r = FillSpectra(config, prop, cmp_syst, metric->GetModel(), cmp_params[k], true, config.i_prime);
+                Eigen::MatrixXf diag = r.Spec().array().matrix().asDiagonal();
+                Eigen::MatrixXf full_cov = diag * cmp_fcov * diag;
+                Eigen::MatrixXf coll = CollapseMatrix(config, full_cov);
+                Eigen::MatrixXf stat = cmp_data.matrix().asDiagonal();
+                Eigen::MatrixXf red_full(cmp_red, cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    for(size_t j = 0; j < cmp_red; ++j) {
+                        red_full(i,j) = coll(cmp_nonempty[i], cmp_nonempty[j]);
+                        cmp_red_stat(i,j) = stat(cmp_nonempty[i], cmp_nonempty[j]);
+                    }
+                Eigen::MatrixXf inv = (cmp_red_stat + red_full).inverse();
+                Eigen::VectorXf coll_mc = CollapseMatrix(config, r.Spec());
+                Eigen::VectorXf delta(cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    delta(i) = coll_mc(cmp_nonempty[i]) - cmp_data(cmp_nonempty[i]);
+                chi2_old[k] = (delta.transpose() * inv * delta)(0,0);
+            }
+            auto cmp_t1 = std::chrono::high_resolution_clock::now();
+
+            // INTERMEDIATE: cwiseProduct (fast covariance build) + .inverse() (slow inversion)
+            for(size_t k = 0; k < cmp_N; ++k) {
+                PROspec r = FillSpectra(config, prop, cmp_syst, metric->GetModel(), cmp_params[k], true, config.i_prime);
+                const Eigen::VectorXf &s = r.Spec();
+                Eigen::MatrixXf full_cov = (s * s.transpose()).cwiseProduct(cmp_fcov);
+                Eigen::MatrixXf coll = CollapseMatrix(config, full_cov);
+                Eigen::MatrixXf red_full(cmp_red, cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    for(size_t j = 0; j < cmp_red; ++j) {
+                        red_full(i,j) = coll(cmp_nonempty[i], cmp_nonempty[j]);
+                        cmp_red_stat(i,j) = (i == j) ? cmp_data(cmp_nonempty[i]) : 0.0f;
+                    }
+                Eigen::MatrixXf inv = (cmp_red_stat + red_full).inverse();
+                Eigen::VectorXf coll_mc = CollapseMatrix(config, r.Spec());
+                Eigen::VectorXf delta(cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    delta(i) = coll_mc(cmp_nonempty[i]) - cmp_data(cmp_nonempty[i]);
+                chi2_mid[k] = (delta.transpose() * inv * delta)(0,0);
+            }
+            auto cmp_t2 = std::chrono::high_resolution_clock::now();
+
+            // NEW: cwiseProduct + .llt().solve()
+            for(size_t k = 0; k < cmp_N; ++k) {
+                PROspec r = FillSpectra(config, prop, cmp_syst, metric->GetModel(), cmp_params[k], true, config.i_prime);
+                const Eigen::VectorXf &s = r.Spec();
+                Eigen::MatrixXf full_cov = (s * s.transpose()).cwiseProduct(cmp_fcov);
+                Eigen::MatrixXf coll = CollapseMatrix(config, full_cov);
+                Eigen::MatrixXf red_full(cmp_red, cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    for(size_t j = 0; j < cmp_red; ++j) {
+                        red_full(i,j) = coll(cmp_nonempty[i], cmp_nonempty[j]);
+                        cmp_red_stat(i,j) = (i == j) ? cmp_data(cmp_nonempty[i]) : 0.0f;
+                    }
+                Eigen::MatrixXf M = cmp_red_stat + red_full;
+                Eigen::VectorXf coll_mc = CollapseMatrix(config, r.Spec());
+                Eigen::VectorXf delta(cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    delta(i) = coll_mc(cmp_nonempty[i]) - cmp_data(cmp_nonempty[i]);
+                chi2_new[k] = delta.dot(M.llt().solve(delta));
+            }
+            auto cmp_t3 = std::chrono::high_resolution_clock::now();
+
+            // ALT: inline asDiagonal()*F*asDiagonal() (no materialization) + .llt().solve() (matches upstream's covariance build)
+            for(size_t k = 0; k < cmp_N; ++k) {
+                PROspec r = FillSpectra(config, prop, cmp_syst, metric->GetModel(), cmp_params[k], true, config.i_prime);
+                Eigen::MatrixXf full_cov = r.Spec().asDiagonal() * cmp_fcov * r.Spec().asDiagonal();
+                Eigen::MatrixXf coll = CollapseMatrix(config, full_cov);
+                Eigen::MatrixXf red_full(cmp_red, cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    for(size_t j = 0; j < cmp_red; ++j) {
+                        red_full(i,j) = coll(cmp_nonempty[i], cmp_nonempty[j]);
+                        cmp_red_stat(i,j) = (i == j) ? cmp_data(cmp_nonempty[i]) : 0.0f;
+                    }
+                Eigen::MatrixXf M = cmp_red_stat + red_full;
+                Eigen::VectorXf coll_mc = CollapseMatrix(config, r.Spec());
+                Eigen::VectorXf delta(cmp_red);
+                for(size_t i = 0; i < cmp_red; ++i)
+                    delta(i) = coll_mc(cmp_nonempty[i]) - cmp_data(cmp_nonempty[i]);
+                chi2_alt[k] = delta.dot(M.llt().solve(delta));
+            }
+            auto cmp_t4 = std::chrono::high_resolution_clock::now();
+
+            double cmp_old_s = std::chrono::duration<double>(cmp_t1 - cmp_t0).count();
+            double cmp_mid_s = std::chrono::duration<double>(cmp_t2 - cmp_t1).count();
+            double cmp_new_s = std::chrono::duration<double>(cmp_t3 - cmp_t2).count();
+            double cmp_alt_s = std::chrono::duration<double>(cmp_t4 - cmp_t3).count();
+
+            auto worst_diff = [&](const std::vector<float> &ref, const std::vector<float> &test) {
+                double max_abs = 0, max_rel = 0;
+                size_t max_rel_k = 0;
+                for(size_t k = 0; k < cmp_N; ++k) {
+                    double a = std::abs(double(test[k]) - double(ref[k]));
+                    double denom = std::max(std::abs(double(ref[k])), 1e-30);
+                    double r = a / denom;
+                    if(a > max_abs) max_abs = a;
+                    if(r > max_rel) { max_rel = r; max_rel_k = k; }
+                }
+                return std::make_tuple(max_abs, max_rel, max_rel_k);
+            };
+            auto [mid_abs, mid_rel, mid_k] = worst_diff(chi2_old, chi2_mid);
+            auto [new_abs, new_rel, new_k] = worst_diff(chi2_old, chi2_new);
+            auto [alt_abs, alt_rel, alt_k] = worst_diff(chi2_old, chi2_alt);
+
+            log<LOG_INFO>(L"%1% || ----- chi2 algorithm comparison: 4 paths, identical parameter sets -----") % __func__;
+            log<LOG_INFO>(L"%1% || N = %2% chi2 evaluations per path; reduced bin count = %3% (after dropping empty-data bins)") % __func__ % cmp_N % cmp_red;
+            log<LOG_INFO>(L"%1% ||") % __func__;
+            log<LOG_INFO>(L"%1% || Path 1 (OLD)         : full_cov = diag(spec) * F * diag(spec)        [dense diag materialized -> O(N^3) matmuls]") % __func__;
+            log<LOG_INFO>(L"%1% ||                        chi2     = delta^T * (M).inverse() * delta    [O(N^3) inverse + 2 matvec]") % __func__;
+            log<LOG_INFO>(L"%1% || Path 2 (INTERMEDIATE): full_cov = (spec * spec^T).cwiseProduct(F)    [O(N^2): outer product + Hadamard]") % __func__;
+            log<LOG_INFO>(L"%1% ||                        chi2     = delta^T * (M).inverse() * delta    [same inverse step as OLD]") % __func__;
+            log<LOG_INFO>(L"%1% || Path 3 (NEW)         : full_cov = (spec * spec^T).cwiseProduct(F)    [same as INTERMEDIATE]") % __func__;
+            log<LOG_INFO>(L"%1% ||                        chi2     = delta . M.llt().solve(delta)       [Cholesky solve, no explicit inverse]") % __func__;
+            log<LOG_INFO>(L"%1% || Path 4 (ALT)         : full_cov = spec.asDiagonal()*F*spec.asDiagonal() [Eigen DiagonalWrapper, matches upstream build]") % __func__;
+            log<LOG_INFO>(L"%1% ||                        chi2     = delta . M.llt().solve(delta)       [same solve as NEW]") % __func__;
+            log<LOG_INFO>(L"%1% ||") % __func__;
+            log<LOG_INFO>(L"%1% || Path 1 (OLD)         : %2% s total, %3% ms/call (baseline)")
+                % __func__ % cmp_old_s % (cmp_old_s / cmp_N * 1e3);
+            log<LOG_INFO>(L"%1% || Path 2 (INTERMEDIATE): %2% s total, %3% ms/call (%4%x vs OLD)  -> isolates the covariance-build speedup")
+                % __func__ % cmp_mid_s % (cmp_mid_s / cmp_N * 1e3) % (cmp_old_s / std::max(cmp_mid_s, 1e-12));
+            log<LOG_INFO>(L"%1% || Path 3 (NEW)         : %2% s total, %3% ms/call (%4%x vs OLD)  -> cwiseProduct build + Cholesky solve")
+                % __func__ % cmp_new_s % (cmp_new_s / cmp_N * 1e3) % (cmp_old_s / std::max(cmp_new_s, 1e-12));
+            log<LOG_INFO>(L"%1% || Path 4 (ALT)         : %2% s total, %3% ms/call (%4%x vs OLD)  -> asDiagonal build + Cholesky solve (= current code)")
+                % __func__ % cmp_alt_s % (cmp_alt_s / cmp_N * 1e3) % (cmp_old_s / std::max(cmp_alt_s, 1e-12));
+            log<LOG_INFO>(L"%1% ||") % __func__;
+            log<LOG_INFO>(L"%1% || NEW vs ALT covariance-build comparison: %2%x (>1 means ALT/asDiagonal is faster)")
+                % __func__ % (cmp_new_s / std::max(cmp_alt_s, 1e-12));
+            log<LOG_INFO>(L"%1% ||") % __func__;
+            log<LOG_INFO>(L"%1% || Numerical agreement (chi2 differences from OLD path):") % __func__;
+            log<LOG_INFO>(L"%1% || INTERMEDIATE vs OLD: worst abs diff %2%, worst rel diff %3% (at k=%4%, old=%5%, mid=%6%)")
+                % __func__ % mid_abs % mid_rel % mid_k % chi2_old[mid_k] % chi2_mid[mid_k];
+            log<LOG_INFO>(L"%1% || NEW          vs OLD: worst abs diff %2%, worst rel diff %3% (at k=%4%, old=%5%, new=%6%)")
+                % __func__ % new_abs % new_rel % new_k % chi2_old[new_k] % chi2_new[new_k];
+            log<LOG_INFO>(L"%1% || ALT          vs OLD: worst abs diff %2%, worst rel diff %3% (at k=%4%, old=%5%, alt=%6%)")
+                % __func__ % alt_abs % alt_rel % alt_k % chi2_old[alt_k] % chi2_alt[alt_k];
         }
 
     }

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -859,6 +859,58 @@ int main(int argc, char* argv[])
         }
     }
 
+    // Empty-bin sanity check: build a default-CV spectrum and look for collapsed bins
+    // that would make stat-only / CNP statistics singular (CV<=0) or untrustworthy (CV<1).
+    {
+        const size_t io = config.i_prime;
+        Eigen::VectorXf cv_check_params =
+            Eigen::VectorXf::Zero(model->nparams + variable_systs[io].GetNSplines());
+        for(size_t i = 0; i < model->nparams; ++i)
+            cv_check_params(i) = model->default_val(i);
+
+        PROspec cv_check_spec = FillSpectra(config, prop, variable_systs[io], *model,
+                                            cv_check_params, !eventbyevent, io);
+        Eigen::VectorXf collapsed_cv = CollapseMatrix(config, cv_check_spec.Spec(), io);
+
+        int n_zero = 0, n_tiny = 0;
+        for(Eigen::Index b = 0; b < collapsed_cv.size(); ++b) {
+            if(collapsed_cv(b) <= 0.0f) {
+                log<LOG_ERROR>(L"%1% || Default-CV collapsed bin %2% has %3% expected events (<=0). Empty-bin would make CNP/stat covariance singular.") % __func__ % (long)b % collapsed_cv(b);
+                ++n_zero;
+            } else if(collapsed_cv(b) < 1.0f) {
+                log<LOG_WARNING>(L"%1% || Default-CV collapsed bin %2% has %3% expected events (<1). Low-stat region; results in this bin may be unreliable.") % __func__ % (long)b % collapsed_cv(b);
+                ++n_tiny;
+            }
+        }
+        if(n_zero > 0) {
+            if(!force) {
+                log<LOG_ERROR>(L"%1% || %2% collapsed CV bins are empty. Aborting. Re-run with --force to override (NOT recommended).") % __func__ % n_zero;
+                return 1;
+            }
+            log<LOG_WARNING>(L"%1% || %2% collapsed CV bins are empty but --force was set; proceeding at user's risk.") % __func__ % n_zero;
+        }
+        if(n_tiny > 0)
+            log<LOG_WARNING>(L"%1% || %2% collapsed CV bins have <1 expected event.") % __func__ % n_tiny;
+
+        if(use_real_data) {
+            int n_nan = 0, n_neg = 0;
+            const Eigen::VectorXf &dvec = data.Spec();
+            for(Eigen::Index b = 0; b < dvec.size(); ++b) {
+                if(std::isnan(dvec(b)) || std::isinf(dvec(b))) {
+                    log<LOG_ERROR>(L"%1% || Data bin %2% is NaN/inf.") % __func__ % (long)b;
+                    ++n_nan;
+                } else if(dvec(b) < 0.0f) {
+                    log<LOG_WARNING>(L"%1% || Data bin %2% is negative (%3%).") % __func__ % (long)b % dvec(b);
+                    ++n_neg;
+                }
+            }
+            if(n_nan > 0 && !force) {
+                log<LOG_ERROR>(L"%1% || %2% data bins are NaN/inf. Aborting. Re-run with --force to override.") % __func__ % n_nan;
+                return 1;
+            }
+        }
+    }
+
     //Pysics parameter input
     Eigen::VectorXf fakeDataParams = Eigen::VectorXf::Constant(model->nparams + variable_systs[config.i_prime].GetNSplines(), 0);
     Eigen::VectorXf CVParams = Eigen::VectorXf::Constant(model->nparams + variable_systs[config.i_prime].GetNSplines(), 0);

--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -59,6 +59,20 @@ namespace PROfit{
 
             bool correlated_systematics;      ///< If true, use correlated (off-diagonal) pull covariance.
             Eigen::MatrixXf prior_covariance; ///< Prior covariance matrix for nuisance parameters.
+            Eigen::MatrixXf prior_covariance_inv; ///< Inverse of prior_covariance, computed once in the ctor.
+
+            // Cache for CollapseMatrix(FillSpectra(noshiftvec_for_phys)). The noshiftvec
+            // CV depends only on the physics parameters (splines are zeroed out). Cache
+            // is invalidated by reset() and override_systs().
+            Eigen::VectorXf cnp_cached_phys;       ///< Last physics subvector used to fill cnp_cached_collapsed_cv.
+            Eigen::VectorXf cnp_cached_collapsed_cv; ///< Cached collapsed noshift CV spectrum.
+            bool cnp_cv_cache_valid = false;       ///< True iff cnp_cached_collapsed_cv matches cnp_cached_phys.
+
+            /// Returns CollapseMatrix(FillSpectra(noshiftvec built from `phys`)). Hits the
+            /// cache when `phys` matches the last cached call; otherwise recomputes.
+            Eigen::VectorXf cachedNoshiftCollapsedCV(const Eigen::VectorXf &phys, Eigen::Index param_size);
+
+            FillSpectraCache fs_cache;             ///< Per-thread split-half cache for FillSpectra.
 
         public:
 
@@ -89,11 +103,15 @@ namespace PROfit{
                 physics_param_fixed.clear();
                 last_value = 0;
                 last_param = Eigen::VectorXf::Constant(last_param.size(), 0);
+                cnp_cv_cache_valid = false;
+                fs_cache.invalidate();
             }
 
             /** @brief Replace the internal systematic pointer with @p new_syst. */
             void override_systs(const PROsyst &new_syst) {
                 syst = &new_syst;
+                cnp_cv_cache_valid = false;
+                fs_cache.invalidate();
             }
 
             /**

--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -67,7 +67,7 @@ namespace PROfit{
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd);
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient);
 
             /** @brief Return a heap-allocated copy of this PROCNP. */
             PROmetric *Clone() const {

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -2,6 +2,7 @@
 #define PROMCMC_H
 
 #include "PROmetric.h"
+#include "PROgress.h"
 #include <Eigen/Eigen>
 
 #include <algorithm>
@@ -58,19 +59,26 @@ namespace PROfit {
                     return false;
                 }
 
-                void run(size_t burnin, size_t steps, std::optional<std::function<void(const Eigen::VectorXf&)>> action = {}) {
+                void run(size_t burnin, size_t steps, std::optional<std::function<void(const Eigen::VectorXf&)>> action = {}, PROgressBar *pbar = nullptr) {
+                    const size_t pbar_stride = std::max<size_t>(1, (burnin + steps) / 10000);
                     for(size_t i = 0; i < burnin; i++) {
                         if constexpr(Proposal_FN::has_tune) {
                             proposal.tune(step());
                         } else {
                             step();
                         }
+                        if(pbar && (i + 1) % pbar_stride == 0) pbar->set_progress(i + 1);
                     }
-                    proposal.tune_mode = false; 
+                    proposal.tune_mode = false;
                     for(size_t i = 0; i < steps; i++) {
                         step();
                         if(save_chain) chain.push_back(current);
                         if(action) (*action)(current);
+                        if(pbar && (i + 1) % pbar_stride == 0) pbar->set_progress(burnin + i + 1);
+                    }
+                    if(pbar) {
+                        pbar->finish();
+                        std::cerr << std::endl;
                     }
                 }
 
@@ -351,8 +359,8 @@ namespace PROfit {
         // Adaptive scaling state
         std::vector<bool> accept_history;
         size_t adapt_window = 1000;  // window size for adaptation
-        float target_accept = 0.234; 
-        float adapt_factor = 1.02;   
+        float target_accept = 0.234;
+        float adapt_factor = 1.1;
 
 
         Eigen::MatrixXf sub_L;

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -60,7 +60,7 @@ namespace PROfit {
                 }
 
                 void run(size_t burnin, size_t steps, std::optional<std::function<void(const Eigen::VectorXf&)>> action = {}, PROgressBar *pbar = nullptr) {
-                    const size_t pbar_stride = std::max<size_t>(1, (burnin + steps) / 10000);
+                    const size_t pbar_stride = std::max<size_t>(1, (burnin + steps) / 1000);
                     for(size_t i = 0; i < burnin; i++) {
                         if constexpr(Proposal_FN::has_tune) {
                             proposal.tune(step());

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -27,6 +27,46 @@
 namespace PROfit{
 
     /**
+     * @brief Single-slot cache for the binned FillSpectra path, splitting the work into
+     *        independently keyed physics and systematic halves.
+     * @details The binned FillSpectra factors as `final_spec = systw .* result` where
+     *   - `result` (physics half) depends only on @p phys, @p inmodel, @p inprop, and @p var_index;
+     *   - `systw`  (syst half)    depends only on @p shifts, @p insyst, @p inprop, and @p var_index.
+     *
+     * On each call the cached overload compares the new phys/shifts subvectors against the cached
+     * keys and recomputes only the half that changed. The cache is invalidated when the model or
+     * syst pointer or var_index changes (via `invalidate()` or context check). The cache is NOT
+     * thread-safe; each thread should hold its own (PROfile/PROsurf already Clone() metrics per
+     * thread, so per-metric caches are naturally per-thread).
+     *
+     * @note Only the binned FillSpectra path is cached. The unbinned (event-by-event) path
+     *       invalidates the cache and falls back to the non-cached overload.
+     */
+    struct FillSpectraCache {
+        Eigen::VectorXf last_phys;            ///< Cached physics subvector for last_result.
+        Eigen::VectorXf last_shifts;          ///< Cached spline subvector for last_systw.
+        Eigen::VectorXf last_result;          ///< Cached H_combined * probs (or trivial-model result).
+        Eigen::VectorXf last_systw;           ///< Cached per-bin systematic-weight vector.
+        int last_var_index = -1;              ///< var_index for which the cache is valid.
+        const PROsyst *last_syst_ptr = nullptr;
+        const PROmodel *last_model_ptr = nullptr;
+
+        /// Mark cache contents stale; next call recomputes both halves.
+        void invalidate() {
+            last_var_index = -1;
+            last_syst_ptr = nullptr;
+            last_model_ptr = nullptr;
+        }
+    };
+
+    /**
+     * @brief Cached overload of the binned FillSpectra. See FillSpectraCache.
+     * @param cache  Single-slot cache; reuses physics or systematic half whose subvector matches.
+     * @return Same value as the non-cached FillSpectra; cache is updated as a side effect.
+     */
+    PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, FillSpectraCache &cache, bool binned = true, size_t var_index = 0);
+
+    /**
      * @brief Master spectrum-filling function combining oscillation weights and systematic spline weights.
      * @details Iterates over MC events (or uses pre-binned histograms when @p binned is true),
      * computes oscillation probabilities via @p inmodel, applies spline shifts from @p insyst,

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -47,6 +47,16 @@ namespace PROfit{
         Eigen::VectorXf last_shifts;          ///< Cached spline subvector for last_systw.
         Eigen::VectorXf last_result;          ///< Cached H_combined * probs (or trivial-model result).
         Eigen::VectorXf last_systw;           ///< Cached per-bin systematic-weight vector.
+
+        /// Per-spline factors at the cached "central" point, shape (nbins_var, nsplines).
+        /// central_factors(k, i) = spline i's multiplicative contribution to systw at bin k.
+        /// systw_central(k) = product over i of central_factors(k, i). Used by the Tier 1.3
+        /// incremental update path (single-spline-shift gradient calls) so we can divide
+        /// out the old contribution and multiply in the new one without rerunning the full
+        /// spline loop. Empty/zero-sized when the cache has not yet been populated by a
+        /// full recompute.
+        Eigen::MatrixXf central_factors;
+
         int last_var_index = -1;              ///< var_index for which the cache is valid.
         const PROsyst *last_syst_ptr = nullptr;
         const PROmodel *last_model_ptr = nullptr;

--- a/inc/PROchi.h
+++ b/inc/PROchi.h
@@ -25,6 +25,7 @@
 #include "PROpeller.h"
 #include "PROmodel.h"
 #include "PROmetric.h"
+#include "PROcess.h"
 
 namespace PROfit{
 
@@ -62,7 +63,16 @@ namespace PROfit{
 
             bool correlated_systematics;         ///< If true, use the correlated (off-diagonal) covariance for pull terms.
             Eigen::MatrixXf prior_covariance;    ///< Prior covariance matrix for nuisance parameters (used when correlated).
+            Eigen::MatrixXf prior_covariance_inv; ///< Inverse of prior_covariance, computed once in the ctor.
             Eigen::MatrixXf collapsed_stat_covariance; ///< Statistical covariance in the collapsed bin space.
+
+            // Cached non-empty-bin slicing for default mode. In shape_only mode
+            // normdata depends on `result` so these are rebuilt per call instead.
+            std::vector<Eigen::Index> nec_indices;          ///< Indices of bins with positive data; empty if cache invalid.
+            Eigen::MatrixXf nec_reduced_stat_cov;           ///< Reduced collapsed_stat_covariance for nec_indices (default mode only).
+            bool nec_valid = false;                         ///< True iff !shape_only and cache populated in the ctor.
+
+            FillSpectraCache fs_cache;                      ///< Per-thread split-half cache for FillSpectra.
 
 
             /*Function: Constructor bringing all objects together*/
@@ -78,6 +88,7 @@ namespace PROfit{
                 physics_param_fixed.clear();
                 last_value = 0;
                 last_param = Eigen::VectorXf::Constant(last_param.size(), 0);
+                fs_cache.invalidate();
             }
 
             /** @brief Return a heap-allocated copy of this PROchi. */
@@ -99,6 +110,7 @@ namespace PROfit{
             /** @brief Replace the internal systematic pointer with @p new_syst. */
             virtual void override_systs(const PROsyst &new_syst) {
                 syst = &new_syst;
+                fs_cache.invalidate();
             }
 
             /**

--- a/inc/PROchi.h
+++ b/inc/PROchi.h
@@ -71,7 +71,7 @@ namespace PROfit{
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd);
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient);
 
             /** @brief Reset cached state and clear any fixed-parameter list. */
             virtual void reset() {

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -380,7 +380,10 @@ namespace PROfit{
 
             std::vector<std::vector<std::pair<float,float>>> m_variable_bin_to_edges;
 
-            std::vector<Eigen::MatrixXf> variable_collapsing_matrices; 
+            std::vector<Eigen::MatrixXf> variable_collapsing_matrices;
+            // Sparse companions to variable_collapsing_matrices (one nonzero per row).
+            // Used by CollapseMatrix in the chi^2 inner loop; built once in construct_variable_collapsing_matrices.
+            std::vector<Eigen::SparseMatrix<float>> variable_collapsing_matrices_sparse;
             std::vector<Eigen::VectorXf> collapsed_bin_widths;
 
             //This section entirely for montecarlo generation of a covariance matrix or PROspec 
@@ -460,10 +463,14 @@ namespace PROfit{
              * Note: To collapse a full matrix M, please do T.transpose() * M * T
              * 	     To collapse a full vector V, please do T.transpose() * V
              */
-            inline 
-                Eigen::MatrixXf GetCollapsingMatrix() const {return variable_collapsing_matrices[i_prime]; }
             inline
-                Eigen::MatrixXf GetCollapsingMatrix(int other_index) const {return variable_collapsing_matrices[other_index]; }
+                const Eigen::MatrixXf& GetCollapsingMatrix() const {return variable_collapsing_matrices[i_prime]; }
+            inline
+                const Eigen::MatrixXf& GetCollapsingMatrix(int other_index) const {return variable_collapsing_matrices[other_index]; }
+            inline
+                const Eigen::SparseMatrix<float>& GetCollapsingMatrixSparse() const {return variable_collapsing_matrices_sparse[i_prime]; }
+            inline
+                const Eigen::SparseMatrix<float>& GetCollapsingMatrixSparse(int other_index) const {return variable_collapsing_matrices_sparse[other_index]; }
 
             /* Function: Calculate how big each mode block and decector block are, for any given number of channels/subchannels, before and after the collapse
              * Note: only consider mode/detector/channel/subchannels that are actually used 

--- a/inc/PROmetric.h
+++ b/inc/PROmetric.h
@@ -51,12 +51,12 @@ namespace PROfit {
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient) = 0;
             /**
              * @brief Evaluate the chi-squared, optionally skipping gradient computation.
-             * @param param    Current parameter vector.
-             * @param gradient Output gradient vector; may not be filled if @p nograd is true.
-             * @param nograd   If true, skip gradient computation for speed.
+             * @param param       Current parameter vector.
+             * @param gradient    Output gradient vector; only filled when @p rungradient is true.
+             * @param rungradient If true, compute the gradient; if false, skip it for speed.
              * @return Chi-squared value.
              */
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd) = 0;
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient) = 0;
             /** @brief Reset any cached state (e.g. last parameter vector and value). */
             virtual void reset() = 0;
             /** @brief Return a heap-allocated deep copy of this PROmetric. */

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -289,7 +289,7 @@ namespace PROfit{
      * @return PROerrorbar with per-bin asymmetric uncertainties and the histogram covariance.
      */
     template<class T, class P>
-        PROerrorbar getMCMCErrorBand(Metropolis<T, P> met, size_t burnin, size_t iterations, const PROconfig &config, const PROpeller &prop, PROmetric &metric, const Eigen::VectorXf &best_fit, std::vector<TH1D> &posteriors, Eigen::MatrixXf &post_covar, Eigen::VectorXf &param_err_lo, Eigen::VectorXf &param_err_hi, bool scale = false, int var_index=0) {
+        PROerrorbar getMCMCErrorBand(Metropolis<T, P> met, size_t burnin, size_t iterations, const PROconfig &config, const PROpeller &prop, PROmetric &metric, const Eigen::VectorXf &best_fit, std::vector<TH1D> &posteriors, Eigen::MatrixXf &post_covar, Eigen::VectorXf &param_err_lo, Eigen::VectorXf &param_err_hi, bool scale = false, int var_index=0, PROgressBar *pbar = nullptr) {
             for(size_t i = 0; i < metric.GetSysts().GetNSplines(); ++i)
                 posteriors.emplace_back("", (";"+config.m_mcgen_variation_plotname_map.at(metric.GetSysts().spline_names[i])).c_str(), 60, -3, 3);
 
@@ -324,7 +324,7 @@ namespace PROfit{
                 post_covar += diff * diff.transpose();
                 post_hist_covar += diff_hist * diff_hist.transpose();
             };
-            met.run(burnin, iterations, action);
+            met.run(burnin, iterations, action, pbar);
             post_hist_covar /= nsteps;
             post_covar /= nsteps;
 

--- a/inc/PROpoisson.h
+++ b/inc/PROpoisson.h
@@ -26,6 +26,7 @@
 #include "PROpeller.h"
 #include "PROmodel.h"
 #include "PROmetric.h"
+#include "PROcess.h"
 
 namespace PROfit{
 
@@ -61,6 +62,9 @@ namespace PROfit{
 
             bool correlated_systematics;      ///< If true, use correlated pull covariance.
             Eigen::MatrixXf prior_covariance; ///< Prior covariance matrix for nuisance parameters.
+            Eigen::MatrixXf prior_covariance_inv; ///< Inverse of prior_covariance, computed once in the ctor.
+
+            FillSpectraCache fs_cache;        ///< Per-thread split-half cache for FillSpectra.
 
 
             /*Function: Constructor bringing all objects together*/
@@ -76,6 +80,7 @@ namespace PROfit{
                 physics_param_fixed.clear();
                 last_value = 0;
                 last_param = Eigen::VectorXf::Constant(last_param.size(), 0);
+                fs_cache.invalidate();
             }
 
             /** @brief Return a heap-allocated copy of this PROpoisson. */
@@ -96,6 +101,7 @@ namespace PROfit{
             /** @brief Replace the internal systematic pointer with @p new_syst. */
             virtual void override_systs(const PROsyst &new_syst) {
                 syst = &new_syst;
+                fs_cache.invalidate();
             }
 
             /**

--- a/inc/PROpoisson.h
+++ b/inc/PROpoisson.h
@@ -69,7 +69,7 @@ namespace PROfit{
 
             /*Function: operator() is what is passed to minimizer.*/
             virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient);
-            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool nograd);
+            virtual float operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient, bool rungradient);
 
             /** @brief Reset cached state and clear any fixed-parameter list. */
             virtual void reset() {

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -39,6 +39,7 @@ PROCNP::PROCNP(const std::string tag, const PROconfig &conin, const PROpeller &p
             prior_covariance(iB, iA) = std::get<2>(t);
         }
         prior_covariance = systin->spline_priors.asDiagonal() * prior_covariance * systin->spline_priors.asDiagonal();
+        prior_covariance_inv = prior_covariance.inverse();
     }
 }
 
@@ -48,7 +49,18 @@ float PROCNP::Pull(const Eigen::VectorXf &systs) {
     if (!correlated_systematics) {
         return (centered.array().square() / syst->spline_priors.array().square()).sum();
     }
-    return centered.dot(prior_covariance.inverse() * centered);
+    return centered.dot(prior_covariance_inv * centered);
+}
+
+Eigen::VectorXf PROCNP::cachedNoshiftCollapsedCV(const Eigen::VectorXf &phys, Eigen::Index param_size) {
+    if(cnp_cv_cache_valid && cnp_cached_phys.size() == phys.size() && cnp_cached_phys == phys)
+        return cnp_cached_collapsed_cv;
+    Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param_size);
+    noshiftvec.head(model.nparams) = phys;
+    cnp_cached_collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec());
+    cnp_cached_phys = phys;
+    cnp_cv_cache_valid = true;
+    return cnp_cached_collapsed_cv;
 }
 
 void PROCNP::fixSpline(int fix, float valin){
@@ -78,14 +90,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
     Eigen::VectorXf subvector2 = param.segment(model.nparams, syst->GetNSplines());
     //log<LOG_DEBUG>(L"%1% || Created spline subvector with size %2%") % __func__ % subvector2.size();
-    Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-    noshiftvec.head(model.nparams) = subvector1;
 
-    PROspec result = FillSpectra(config, peller, *syst, model, param, strat == BinnedChi2);
+    PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2, config.i_prime);
 
 
     Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
-    Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec());
+    Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(subvector1, param.size());
     Eigen::MatrixXf collapsed_stat_covariance = Eigen::MatrixXf::Zero(data.Spec().size(), data.Spec().size());
     Eigen::VectorXf normdata = shape_only 
         ? data.Normalize(config,result)
@@ -162,14 +172,11 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
-                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                 Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
                 if(i < model.nparams) {
-                    Eigen::VectorXf subvector1 = param_plus.segment(0, model.nparams);
-                    Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-                    noshiftvec.head(model.nparams) = subvector1;
-                    Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec(),config.i_prime);
+                    Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(param_plus.segment(0, model.nparams), param.size());
                     for(long j = 0; j < data.Spec().size(); ++j)
                         new_collapsed_stat_covariance(j,j) = normdata(j) == 0 ? collapsed_cv(j)/2 :
                             3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
@@ -207,14 +214,11 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
                     chi2_plus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
                     if(i < model.nparams) {
-                        Eigen::VectorXf subvector1 = param_plus.segment(0, model.nparams);
-                        Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-                        noshiftvec.head(model.nparams) = subvector1;
-                        Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec(),config.i_prime);
+                        Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(param_plus.segment(0, model.nparams), param.size());
                         for(long j = 0; j < data.Spec().size(); ++j)
                             new_collapsed_stat_covariance(j,j) = normdata(j) == 0 ? collapsed_cv(j)/2 :
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
@@ -236,14 +240,11 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROCNP: Gradient evaluation point violates unitarity. Setting gradient to large value.") % __func__;
                     chi2_minus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
                     if(i < model.nparams) {
-                        Eigen::VectorXf subvector1 = param_minus.segment(0, model.nparams);
-                        Eigen::VectorXf noshiftvec = Eigen::VectorXf::Zero(param.size());
-                        noshiftvec.head(model.nparams) = subvector1;
-                        Eigen::VectorXf collapsed_cv = CollapseMatrix(config, FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent).Spec(),config.i_prime);
+                        Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(param_minus.segment(0, model.nparams), param.size());
                         for(long j = 0; j < data.Spec().size(); ++j)
                             new_collapsed_stat_covariance(j,j) = normdata(j) == 0 ? collapsed_cv(j)/2 :
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -94,10 +94,9 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         collapsed_stat_covariance(i,i) = data.Spec()(i) == 0 ? collapsed_cv(i)/2 :
             3 / (1.0 / normdata(i) + 2.0 / collapsed_cv(i));
 
-    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
-    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
     inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
 
     Eigen::VectorXf delta = CollapseMatrix(config, result.Spec()) - normdata;
@@ -176,8 +175,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                             3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
                 }
 
-                Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                 Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
 
@@ -222,8 +220,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
                     }
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
 
@@ -252,8 +249,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                                 3 / (1.0 / normdata(j) + 2.0 / collapsed_cv(j));
                     }
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
 
@@ -312,8 +308,7 @@ float PROCNP::getSingleChannelChi(size_t global_channel_index, const PROspec &cv
     //only calculate a syst covariance if we have any covariance parameters as defined in the xml
     if(syst->GetNCovar()){
         // Calculate Full Syst Covariance matrix
-        Eigen::MatrixXf diag =  cv.Spec().array().matrix().asDiagonal(); 
-        Eigen::MatrixXf full_covariance =  diag*(syst->fractional_covariance)*diag;
+        Eigen::MatrixXf full_covariance = cv.Spec().asDiagonal() * (syst->fractional_covariance) * cv.Spec().asDiagonal();
 
         // Collapse Covariance and Spectra 
         Eigen::MatrixXf collapsed_full_covariance =  CollapseMatrix(config,full_covariance);
@@ -368,10 +363,9 @@ void PROCNP::print(const Eigen::VectorXf &param){
     }
 
     log<LOG_INFO>(L"%1% || Collapsed stat Covariance is : \n %2%") % __func__ % collapsed_stat_covariance;
-    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
-    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
     inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
 
     // Calculate Chi^2  value
@@ -438,14 +432,13 @@ void PROCNP::print(const Eigen::VectorXf &param){
             }
         }
 
-        Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-        Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+        Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
-        Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+        Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
         inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
 
         // Calculate Chi^2  value
-        Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec(); 
+        Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec();
 
         float pull = Pull(subvector2);
         float value_grad = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;

--- a/src/PROCNP.cxx
+++ b/src/PROCNP.cxx
@@ -94,10 +94,9 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
     PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2, config.i_prime);
 
 
-    Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
     Eigen::VectorXf collapsed_cv = cachedNoshiftCollapsedCV(subvector1, param.size());
     Eigen::MatrixXf collapsed_stat_covariance = Eigen::MatrixXf::Zero(data.Spec().size(), data.Spec().size());
-    Eigen::VectorXf normdata = shape_only 
+    Eigen::VectorXf normdata = shape_only
         ? data.Normalize(config,result)
         : data.Spec();
     for(long i = 0; i < data.Spec().size(); ++i)
@@ -107,15 +106,13 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-    inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
+    Eigen::MatrixXf M = collapsed_stat_covariance + collapsed_full_covariance;
 
     Eigen::VectorXf delta = CollapseMatrix(config, result.Spec()) - normdata;
-    // Calculate Chi^2  value
-    //Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec(); 
 
     float pull = Pull(subvector2);
     float dmsq_penalty = 0;
-    float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
+    float covar_portion = delta.dot(M.llt().solve(delta));
     float value = covar_portion + dmsq_penalty + pull;
 
     if(std::isnan(value)) {
@@ -184,12 +181,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                 Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
+                Eigen::MatrixXf gM = new_collapsed_stat_covariance + collapsed_full_covariance;
 
                 Eigen::VectorXf delta = CollapseMatrix(config,result.Spec()) - normdata;
                 Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                 float pull = Pull(subvector2);
-                chi2_oneside = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+                chi2_oneside = delta.dot(gM.llt().solve(delta)) + pull;
 
                 gradient(i) = sign*(chi2_oneside - value) / h;
 
@@ -226,12 +223,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
+                    Eigen::MatrixXf gM = new_collapsed_stat_covariance + collapsed_full_covariance;
 
                     Eigen::VectorXf delta = CollapseMatrix(config,result.Spec()) - normdata;
                     Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
-                    chi2_plus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+                    chi2_plus = delta.dot(gM.llt().solve(delta)) + pull;
                 }
 
                 // minus point
@@ -252,12 +249,12 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    Eigen::MatrixXf inverted_collapsed_full_covariance = (new_collapsed_stat_covariance + collapsed_full_covariance).inverse();
+                    Eigen::MatrixXf gM = new_collapsed_stat_covariance + collapsed_full_covariance;
 
                     Eigen::VectorXf delta = CollapseMatrix(config,result.Spec()) - normdata;
                     Eigen::VectorXf subvector2 = param_minus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
-                    chi2_minus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+                    chi2_minus = delta.dot(gM.llt().solve(delta)) + pull;
                 }
 
                 // Central difference formula
@@ -293,8 +290,6 @@ float PROCNP::getSingleChannelChi(size_t global_channel_index, const PROspec &cv
     size_t startBin = config.GetCollapsedGlobalVariableBinStart(global_channel_index,var_index);
 
 
-    Eigen::MatrixXf inverted_collapsed_full_covariance(nbin,nbin);
-
     Eigen::VectorXf normdata = shape_only
         ? data.Normalize(config,cv)
         : data.Spec();
@@ -306,25 +301,19 @@ float PROCNP::getSingleChannelChi(size_t global_channel_index, const PROspec &cv
 
     Eigen::MatrixXf sub_collapsed_stat_covariance = collapsed_stat_covariance.block(startBin, startBin, nbin, nbin);
 
-    //only calculate a syst covariance if we have any covariance parameters as defined in the xml
+    Eigen::MatrixXf M(nbin, nbin);
     if(syst->GetNCovar()){
-        // Calculate Full Syst Covariance matrix
         Eigen::MatrixXf full_covariance = cv.Spec().asDiagonal() * (syst->fractional_covariance) * cv.Spec().asDiagonal();
-
-        // Collapse Covariance and Spectra 
-        Eigen::MatrixXf collapsed_full_covariance =  CollapseMatrix(config,full_covariance);
-        Eigen::MatrixXf sub_collapsed_full_covariance =  collapsed_full_covariance.block(startBin,startBin,nbin,nbin);
-
-        // Invert Collaped Matrix Matrix 
-        inverted_collapsed_full_covariance = (sub_collapsed_full_covariance+sub_collapsed_stat_covariance).inverse();
+        Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
+        Eigen::MatrixXf sub_collapsed_full_covariance = collapsed_full_covariance.block(startBin, startBin, nbin, nbin);
+        M = sub_collapsed_full_covariance + sub_collapsed_stat_covariance;
     } else {
-        inverted_collapsed_full_covariance = (sub_collapsed_stat_covariance).inverse();
+        M = sub_collapsed_stat_covariance;
     }
 
-    Eigen::VectorXf delta  = (CollapseMatrix(config, cv.Spec()) - normdata).segment(startBin,nbin);
-    //float pull = Pull(subvector2);
-    float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
-    float value = covar_portion;//pull;
+    Eigen::VectorXf delta = (CollapseMatrix(config, cv.Spec()) - normdata).segment(startBin, nbin);
+    float covar_portion = delta.dot(M.llt().solve(delta));
+    float value = covar_portion;
 
     return value;
 }
@@ -345,7 +334,6 @@ void PROCNP::print(const Eigen::VectorXf &param){
     log<LOG_INFO>(L"%1% || Result Spectra: ") % __func__ ;
     result.Print();
 
-    Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
     PROspec cv = FillSpectra(config, peller, *syst, model, noshiftvec, strat != EventByEvent);
     log<LOG_INFO>(L"%1% || CV is : \n ") % __func__ ;
     cv.Print();
@@ -367,16 +355,16 @@ void PROCNP::print(const Eigen::VectorXf &param){
     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-    inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
+    Eigen::MatrixXf M = collapsed_stat_covariance + collapsed_full_covariance;
 
     // Calculate Chi^2  value
-    Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec(); 
+    Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec();
     log<LOG_INFO>(L"%1% || DataSpectra Spectra: ") % __func__ ;
     data.Print();
 
     float pull = Pull(subvector2);
     float dmsq_penalty = 0;
-    float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
+    float covar_portion = delta.dot(M.llt().solve(delta));
     float value = covar_portion + dmsq_penalty + pull;
 
 
@@ -416,8 +404,6 @@ void PROCNP::print(const Eigen::VectorXf &param){
         }
 
         PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, strat != EventByEvent);
-        // Calcuate Full Covariance matrix
-        Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
 
         Eigen::MatrixXf new_collapsed_stat_covariance = collapsed_stat_covariance;
         if(i < model.nparams) {
@@ -436,13 +422,13 @@ void PROCNP::print(const Eigen::VectorXf &param){
         Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
         Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-        inverted_collapsed_full_covariance = (collapsed_stat_covariance+ collapsed_full_covariance).inverse();
+        Eigen::MatrixXf gM = collapsed_stat_covariance + collapsed_full_covariance;
 
         // Calculate Chi^2  value
         Eigen::VectorXf delta  = CollapseMatrix(config,result.Spec()) - data.Spec();
 
         float pull = Pull(subvector2);
-        float value_grad = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+        float value_grad = delta.dot(gM.llt().solve(delta)) + pull;
 
         gradient(i) = (value_grad-value)/(tmpParams(i) - param(i));
     }

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -42,6 +42,91 @@ namespace PROfit {
     }
 
 
+    PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, FillSpectraCache &cache, bool binned, size_t var_index) {
+        // Unbinned path can't be cleanly split phys/syst (per-event Fill mixes them).
+        // Fall back, invalidate cache.
+        if(!binned) {
+            cache.invalidate();
+            return FillSpectra(inconfig, inprop, insyst, inmodel, params, binned, var_index);
+        }
+
+        Eigen::VectorXf phys = params.segment(0, inmodel.nparams);
+        Eigen::VectorXf shifts = params.segment(inmodel.nparams, params.size() - inmodel.nparams);
+
+        const bool ctx_changed = (cache.last_var_index != (int)var_index ||
+                                  cache.last_syst_ptr != &insyst ||
+                                  cache.last_model_ptr != &inmodel);
+
+        // ---- Systematic-weights half (depends only on shifts) ----
+        const bool shifts_changed = ctx_changed ||
+                                    cache.last_shifts.size() != shifts.size() ||
+                                    cache.last_shifts != shifts;
+        if(shifts_changed) {
+            const size_t nbins_var = inconfig.m_num_variable_bins_total[var_index];
+            Eigen::VectorXf systw = Eigen::VectorXf::Constant(nbins_var, 1);
+            for(int i = 0; i < (int)insyst.GetNSplines(); ++i) {
+                size_t binning = insyst.spline_binnings[i];
+                if(binning == var_index) {
+                    for(size_t k = 0; k < nbins_var; ++k)
+                        systw(k) *= insyst.GetSplineShift(i, shifts(i), k);
+                } else {
+                    const size_t nbins_binning = inconfig.m_num_variable_bins_total[binning];
+                    Eigen::VectorXf spline_shifts(nbins_binning);
+                    for(size_t j = 0; j < nbins_binning; ++j)
+                        spline_shifts(j) = insyst.GetSplineShift(i, shifts(i), j);
+                    const auto &hist = inprop.variable_hist_storage(binning, var_index);
+                    Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts;
+                    Eigen::VectorXf unweighted_sum = hist.colwise().sum().transpose();
+                    for(size_t k = 0; k < nbins_var; ++k)
+                        if(unweighted_sum(k) > 0)
+                            systw(k) *= weighted_sum(k) / unweighted_sum(k);
+                }
+            }
+            cache.last_systw = std::move(systw);
+            cache.last_shifts = shifts;
+        }
+
+        // ---- Physics-result half (depends only on phys) ----
+        const bool phys_changed = ctx_changed ||
+                                  cache.last_phys.size() != phys.size() ||
+                                  cache.last_phys != phys;
+        if(phys_changed) {
+            Eigen::VectorXf result;
+            if(inmodel.is_trivial) {
+                result = inmodel.H_combined[var_index].col(0);
+            } else {
+                const size_t N_ivars = inmodel.ivars.size();
+                std::vector<size_t> ivar_sizes(N_ivars);
+                for(size_t k = 0; k < N_ivars; ++k)
+                    ivar_sizes[k] = inprop.variable_midbin[inmodel.ivars[k]].size();
+
+                std::vector<std::vector<float>> var_arrs(N_ivars, std::vector<float>(inmodel.n_phys_bins));
+                for(long int flat = 0; flat < inmodel.n_phys_bins; ++flat) {
+                    long int rem = flat;
+                    for(int k = (int)N_ivars - 1; k >= 0; --k) {
+                        var_arrs[k][flat] = inprop.variable_midbin[inmodel.ivars[k]][rem % ivar_sizes[k]];
+                        rem /= (long int)ivar_sizes[k];
+                    }
+                }
+
+                auto probs = inmodel.get_probs(phys, var_arrs);
+                Eigen::Map<const Eigen::VectorXf> probs_flat(probs.data(), probs.size());
+                result = inmodel.H_combined[var_index] * probs_flat;
+            }
+            cache.last_result = std::move(result);
+            cache.last_phys = phys;
+        }
+
+        cache.last_var_index = (int)var_index;
+        cache.last_syst_ptr = &insyst;
+        cache.last_model_ptr = &inmodel;
+
+        Eigen::VectorXf final_spec  = cache.last_systw.cwiseProduct(cache.last_result);
+        Eigen::VectorXf final_error = final_spec.array().abs().sqrt();
+        return PROspec(final_spec, final_error);
+    }
+
+
     PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned, size_t var_index){
         PROspec myspectrum(inconfig.m_num_variable_bins_total[var_index]);
         Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -58,32 +58,117 @@ namespace PROfit {
                                   cache.last_model_ptr != &inmodel);
 
         // ---- Systematic-weights half (depends only on shifts) ----
-        const bool shifts_changed = ctx_changed ||
-                                    cache.last_shifts.size() != shifts.size() ||
-                                    cache.last_shifts != shifts;
-        if(shifts_changed) {
-            const size_t nbins_var = inconfig.m_num_variable_bins_total[var_index];
+        // Three branches for the systw vector:
+        //   * full_systw_hit    : shifts identical to cached -> reuse cache.last_systw.
+        //   * try_incremental   : shifts differs in EXACTLY one spline-range element
+        //                          -> Tier 1.3: divide out old factor, multiply in new
+        //                          factor for that one spline. Cache stays pinned to
+        //                          its "central" state (no write-back).
+        //   * full recompute    : everything else (size mismatch, ctx change, multi-diff,
+        //                          or incremental gave a divide-by-near-zero on some bin).
+        //                          Re-runs the full loop AND populates central_factors.
+        const size_t       nbins_var      = inconfig.m_num_variable_bins_total[var_index];
+        const Eigen::Index nsplines_e     = (Eigen::Index)insyst.GetNSplines();
+        const bool         size_match     = (cache.last_shifts.size() == shifts.size());
+        const bool         factors_valid  = (cache.central_factors.cols() == nsplines_e &&
+                                             cache.central_factors.rows() == (Eigen::Index)nbins_var);
+        const bool         diff_check_ok  = !ctx_changed && size_match && factors_valid;
+
+        int diff_count = 0;
+        int diff_idx   = -1;
+        if(diff_check_ok) {
+            for(Eigen::Index i = 0; i < shifts.size(); ++i) {
+                if(cache.last_shifts(i) != shifts(i)) {
+                    diff_idx = (int)i;
+                    if(++diff_count > 1) break;
+                }
+            }
+        }
+        const bool full_systw_hit  = diff_check_ok && (diff_count == 0);
+        const bool try_incremental = diff_check_ok && (diff_count == 1)
+                                                   && (diff_idx >= 0)
+                                                   && (diff_idx < (int)insyst.GetNSplines());
+
+        Eigen::VectorXf       systw_local;            // populated only on the incremental path
+        const Eigen::VectorXf *systw_to_use = nullptr; // points to whichever vector we'll combine
+
+        if(full_systw_hit) {
+            systw_to_use = &cache.last_systw;
+        } else if(try_incremental) {
+            const size_t j       = (size_t)diff_idx;
+            const size_t binning = insyst.spline_binnings[j];
+
+            Eigen::VectorXf new_factor_j(nbins_var);
+            if(binning == var_index) {
+                for(size_t k = 0; k < nbins_var; ++k)
+                    new_factor_j(k) = insyst.GetSplineShift((int)j, shifts(j), (int)k);
+            } else {
+                const size_t nbins_binning = inconfig.m_num_variable_bins_total[binning];
+                Eigen::VectorXf spline_shifts_one(nbins_binning);
+                for(size_t b = 0; b < nbins_binning; ++b)
+                    spline_shifts_one(b) = insyst.GetSplineShift((int)j, shifts(j), (int)b);
+                const auto &hist = inprop.variable_hist_storage(binning, var_index);
+                Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts_one;
+                Eigen::VectorXf unweighted_sum = hist.colwise().sum().transpose();
+                for(size_t k = 0; k < nbins_var; ++k)
+                    new_factor_j(k) = (unweighted_sum(k) > 0) ? weighted_sum(k) / unweighted_sum(k)
+                                                              : 1.0f;
+            }
+
+            // Apply division+multiplication into a fresh local systw without touching cache.
+            // If any cached factor for spline j is too small, fall back to full recompute.
+            constexpr float kTiny = 1e-30f;
+            systw_local.resize(nbins_var);
+            bool ok = true;
+            for(size_t k = 0; k < nbins_var; ++k) {
+                const float old_f = cache.central_factors(k, (Eigen::Index)j);
+                if(std::abs(old_f) < kTiny) { ok = false; break; }
+                systw_local(k) = cache.last_systw(k) / old_f * new_factor_j(k);
+            }
+
+            if(ok) {
+                systw_to_use = &systw_local;
+                // CRITICAL: do NOT update cache.last_shifts, cache.last_systw, or
+                // cache.central_factors. Cache stays pinned to the central point so
+                // subsequent single-shift gradient calls also hit the incremental path.
+            }
+            // else fall through to full recompute below
+        }
+
+        if(systw_to_use == nullptr) {
+            // Full recompute: rebuild systw AND populate per-spline factors. The
+            // existing math is preserved bit-for-bit; we just stash each spline's
+            // contribution as we go.
             Eigen::VectorXf systw = Eigen::VectorXf::Constant(nbins_var, 1);
+            Eigen::MatrixXf factors(nbins_var, insyst.GetNSplines());
             for(int i = 0; i < (int)insyst.GetNSplines(); ++i) {
                 size_t binning = insyst.spline_binnings[i];
                 if(binning == var_index) {
-                    for(size_t k = 0; k < nbins_var; ++k)
-                        systw(k) *= insyst.GetSplineShift(i, shifts(i), k);
+                    for(size_t k = 0; k < nbins_var; ++k) {
+                        const float f = insyst.GetSplineShift(i, shifts(i), (int)k);
+                        factors(k, i) = f;
+                        systw(k) *= f;
+                    }
                 } else {
                     const size_t nbins_binning = inconfig.m_num_variable_bins_total[binning];
-                    Eigen::VectorXf spline_shifts(nbins_binning);
-                    for(size_t j = 0; j < nbins_binning; ++j)
-                        spline_shifts(j) = insyst.GetSplineShift(i, shifts(i), j);
+                    Eigen::VectorXf spline_shifts_loc(nbins_binning);
+                    for(size_t b = 0; b < nbins_binning; ++b)
+                        spline_shifts_loc(b) = insyst.GetSplineShift(i, shifts(i), (int)b);
                     const auto &hist = inprop.variable_hist_storage(binning, var_index);
-                    Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts;
+                    Eigen::VectorXf weighted_sum   = hist.transpose() * spline_shifts_loc;
                     Eigen::VectorXf unweighted_sum = hist.colwise().sum().transpose();
-                    for(size_t k = 0; k < nbins_var; ++k)
-                        if(unweighted_sum(k) > 0)
-                            systw(k) *= weighted_sum(k) / unweighted_sum(k);
+                    for(size_t k = 0; k < nbins_var; ++k) {
+                        const float f = (unweighted_sum(k) > 0) ? weighted_sum(k) / unweighted_sum(k)
+                                                                : 1.0f;
+                        factors(k, i) = f;
+                        systw(k) *= f;
+                    }
                 }
             }
-            cache.last_systw = std::move(systw);
-            cache.last_shifts = shifts;
+            cache.last_systw      = std::move(systw);
+            cache.last_shifts     = shifts;
+            cache.central_factors = std::move(factors);
+            systw_to_use          = &cache.last_systw;
         }
 
         // ---- Physics-result half (depends only on phys) ----
@@ -121,7 +206,9 @@ namespace PROfit {
         cache.last_syst_ptr = &insyst;
         cache.last_model_ptr = &inmodel;
 
-        Eigen::VectorXf final_spec  = cache.last_systw.cwiseProduct(cache.last_result);
+        // systw_to_use points to either cache.last_systw (full hit / full recompute) or
+        // to the local perturbed vector built by the Tier 1.3 incremental path.
+        Eigen::VectorXf final_spec  = systw_to_use->cwiseProduct(cache.last_result);
         Eigen::VectorXf final_error = final_spec.array().abs().sqrt();
         return PROspec(final_spec, final_error);
     }

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -87,10 +87,9 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
     Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
 
-    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal(); 
-    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
-   
-    Eigen::VectorXf normdata = shape_only 
+    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
+
+    Eigen::VectorXf normdata = shape_only
         ? data.Normalize(config,result)
         : data.Spec();
 
@@ -193,8 +192,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 // Calculate chi2_plus or chi2_minus, depending on boundary
                 PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
-                Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                 
                 // Reduce matrices using non_empty_indices
@@ -239,8 +237,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     
                     // Reduce matrices using non_empty_indices
@@ -269,8 +266,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 } else {
                     PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
 
-                    Eigen::MatrixXf diag = result.Spec().array().matrix().asDiagonal();
-                    Eigen::MatrixXf full_covariance = diag*(syst->fractional_covariance)*diag;
+                    Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
                     
                     // Reduce matrices using non_empty_indices
@@ -327,8 +323,7 @@ float PROchi::getSingleChannelChi(size_t global_channel_index, const PROspec & c
     //only calculate a syst covariance if we have any covariance parameters as defined in the xml
     if(syst->GetNCovar()){
         // Calculate Full Syst Covariance matrix
-        Eigen::MatrixXf diag =  cv.Spec().array().matrix().asDiagonal(); 
-        Eigen::MatrixXf full_covariance =  diag*(syst->fractional_covariance)*diag;
+        Eigen::MatrixXf full_covariance = cv.Spec().asDiagonal() * (syst->fractional_covariance) * cv.Spec().asDiagonal();
 
         // Collapse Covariance and Spectra 
         Eigen::MatrixXf collapsed_full_covariance =  CollapseMatrix(config,full_covariance);

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -126,32 +126,27 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
             log<LOG_ERROR>(L"%1% || ERROR: All data bins are empty!") % __func__;
             throw std::runtime_error("All data bins are empty in PROchi.");
         }
-        const size_t s = nei_local.size();
-        rstat_local.resize(s, s);
-        for(size_t i = 0; i < s; ++i)
-            for(size_t j = 0; j < s; ++j)
-                rstat_local(i, j) = collapsed_stat_covariance(nei_local[i], nei_local[j]);
+        const Eigen::Map<const Eigen::Matrix<Eigen::Index, Eigen::Dynamic, 1>>
+            idx_local(nei_local.data(), (Eigen::Index)nei_local.size());
+        rstat_local = Eigen::MatrixXf(normdata(idx_local).asDiagonal());
     }
     const std::vector<Eigen::Index> &non_empty_indices = nec_valid ? nec_indices : nei_local;
     const Eigen::MatrixXf &reduced_collapsed_stat_covariance = nec_valid ? nec_reduced_stat_cov : rstat_local;
     const size_t reduced_size = non_empty_indices.size();
 
+    // Eigen 3.4 indexing handle for all the per-call reductions below (and in the
+    // gradient blocks further down). Lightweight reference, no allocation.
+    const Eigen::Map<const Eigen::Matrix<Eigen::Index, Eigen::Dynamic, 1>>
+        idx(non_empty_indices.data(), (Eigen::Index)reduced_size);
+
     // Per-call: reduced_collapsed_full_covariance depends on `result` via collapsed_full_covariance.
-    Eigen::MatrixXf reduced_collapsed_full_covariance(reduced_size, reduced_size);
-    for (size_t i = 0; i < reduced_size; ++i) {
-        for (size_t j = 0; j < reduced_size; ++j) {
-            reduced_collapsed_full_covariance(i, j) = collapsed_full_covariance(non_empty_indices[i], non_empty_indices[j]);
-        }
-    }
+    Eigen::MatrixXf reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
 
     inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + reduced_collapsed_full_covariance).inverse();
 
     // Create reduced delta vector
     Eigen::VectorXf collapsed_mc_spec = CollapseMatrix(config, result.Spec());
-    Eigen::VectorXf delta(reduced_size);
-    for (size_t i = 0; i < reduced_size; ++i) {
-        delta(i) = collapsed_mc_spec(non_empty_indices[i]) - normdata(non_empty_indices[i]);
-    }
+    Eigen::VectorXf delta = collapsed_mc_spec(idx) - normdata(idx);
     
     float pull = Pull(subvector2);
     float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
@@ -218,21 +213,12 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                 Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                
-                // Reduce matrices using non_empty_indices
-                Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
-                for (size_t ii = 0; ii < reduced_size; ++ii) {
-                    for (size_t jj = 0; jj < reduced_size; ++jj) {
-                        grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
-                    }
-                }
+
+                Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
                 Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
                 Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
-                Eigen::VectorXf delta(reduced_size);
-                for (size_t ii = 0; ii < reduced_size; ++ii) {
-                    delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
-                }
+                Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                 Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                 float pull = Pull(subvector2);
                 chi2_oneside = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
@@ -263,21 +249,12 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    
-                    // Reduce matrices using non_empty_indices
-                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        for (size_t jj = 0; jj < reduced_size; ++jj) {
-                            grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
-                        }
-                    }
+
+                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
                     Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
-                    Eigen::VectorXf delta(reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
-                    }
+                    Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                     Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
                     chi2_plus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
@@ -292,21 +269,12 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
-                    
-                    // Reduce matrices using non_empty_indices
-                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance(reduced_size, reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        for (size_t jj = 0; jj < reduced_size; ++jj) {
-                            grad_reduced_collapsed_full_covariance(ii, jj) = collapsed_full_covariance(non_empty_indices[ii], non_empty_indices[jj]);
-                        }
-                    }
+
+                    Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
                     Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
 
                     Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
-                    Eigen::VectorXf delta(reduced_size);
-                    for (size_t ii = 0; ii < reduced_size; ++ii) {
-                        delta(ii) = collapsed_mc(non_empty_indices[ii]) - normdata(non_empty_indices[ii]);
-                    }
+                    Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                     Eigen::VectorXf subvector2 = param_minus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
                     chi2_minus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -37,14 +37,32 @@ PROchi::PROchi(const std::string tag, const PROconfig &conin, const PROpeller &p
           prior_covariance(iB, iA) = std::get<2>(t);
         }
         prior_covariance = systin->spline_priors.asDiagonal() * prior_covariance * systin->spline_priors.asDiagonal();
+        prior_covariance_inv = prior_covariance.inverse();
     }
-    
+
     // GP: What do you do if the MC has 0 events in a bin?
     //     Proposed solution (hack?) here. Set the error to 1. This will return
     //     the correct answer if there are no data events in the bin. It is a bit
     //     iffier if there are data events in the bin, we may want to implement some
     //     error handling there.
     collapsed_stat_covariance = data.Spec().array().cwiseMax(1).matrix().asDiagonal();
+
+    // Default-mode cache: in non-shape_only mode normdata == data.Spec() is constant
+    // across all operator() invocations, so non_empty_indices and the reduced stat
+    // covariance are constant. Build them once here and reuse them.
+    if(!shape_only) {
+        const Eigen::VectorXf &nd = data.Spec();
+        for(Eigen::Index i = 0; i < nd.size(); ++i)
+            if(nd(i) > 0) nec_indices.push_back(i);
+        if(!nec_indices.empty()) {
+            Eigen::VectorXf reduced_diag(nec_indices.size());
+            for(size_t k = 0; k < nec_indices.size(); ++k)
+                reduced_diag(k) = nd(nec_indices[k]);
+            nec_reduced_stat_cov = Eigen::MatrixXf(reduced_diag.asDiagonal());
+            nec_valid = true;
+        }
+        // If empty, leave nec_valid=false; operator() will throw on first call.
+    }
 }
 
 float PROchi::Pull(const Eigen::VectorXf &systs) {
@@ -54,8 +72,8 @@ float PROchi::Pull(const Eigen::VectorXf &systs) {
         return (centered.array().square() / syst->spline_priors.array().square()).sum();
     }
 
-    // Otherwise dot onto covariance
-    return centered.dot(prior_covariance.inverse() * centered);
+    // Otherwise dot onto covariance (prior_covariance_inv was computed in the ctor).
+    return centered.dot(prior_covariance_inv * centered);
 }
 
 void PROchi::fixSpline(int fix, float valin){
@@ -83,7 +101,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
     // Get Spectra from FillSpectra
     Eigen::VectorXf subvector2 = param.segment(nparams - nsyst, nsyst);
     
-    PROspec result = FillSpectra(config, peller, *syst, model, param, strat == BinnedChi2, config.i_prime);
+    PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2, config.i_prime);
 
     Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
 
@@ -93,30 +111,36 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         ? data.Normalize(config,result)
         : data.Spec();
 
-    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance); 
+    Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
     collapsed_stat_covariance = (normdata).matrix().asDiagonal();
 
-    // remove rows and columns corresponding to empty data bin indices here, avoiding any nan chi2 calculations for bins with no data events
-    std::vector<Eigen::Index> non_empty_indices;
-    for (Eigen::Index i = 0; i < normdata.size(); ++i) {
-        if (normdata(i) > 0) {
-            non_empty_indices.push_back(i);
+    // non_empty_indices and reduced_collapsed_stat_covariance are constant in default
+    // (non-shape_only) mode and were precomputed in the ctor; in shape_only mode
+    // normdata depends on `result` so we must rebuild them per call.
+    std::vector<Eigen::Index> nei_local;
+    Eigen::MatrixXf rstat_local;
+    if(!nec_valid) {
+        for(Eigen::Index i = 0; i < normdata.size(); ++i)
+            if(normdata(i) > 0) nei_local.push_back(i);
+        if(nei_local.empty()) {
+            log<LOG_ERROR>(L"%1% || ERROR: All data bins are empty!") % __func__;
+            throw std::runtime_error("All data bins are empty in PROchi.");
         }
+        const size_t s = nei_local.size();
+        rstat_local.resize(s, s);
+        for(size_t i = 0; i < s; ++i)
+            for(size_t j = 0; j < s; ++j)
+                rstat_local(i, j) = collapsed_stat_covariance(nei_local[i], nei_local[j]);
     }
-    
-    size_t reduced_size = non_empty_indices.size();
-    if (reduced_size == 0) {
-        log<LOG_ERROR>(L"%1% || ERROR: All data bins are empty!") % __func__;
-        throw std::runtime_error("All data bins are empty in PROchi.");
-    }
-    
-    // Create reduced covariance matrices by removing empty bin rows/columns
+    const std::vector<Eigen::Index> &non_empty_indices = nec_valid ? nec_indices : nei_local;
+    const Eigen::MatrixXf &reduced_collapsed_stat_covariance = nec_valid ? nec_reduced_stat_cov : rstat_local;
+    const size_t reduced_size = non_empty_indices.size();
+
+    // Per-call: reduced_collapsed_full_covariance depends on `result` via collapsed_full_covariance.
     Eigen::MatrixXf reduced_collapsed_full_covariance(reduced_size, reduced_size);
-    Eigen::MatrixXf reduced_collapsed_stat_covariance(reduced_size, reduced_size);
     for (size_t i = 0; i < reduced_size; ++i) {
         for (size_t j = 0; j < reduced_size; ++j) {
             reduced_collapsed_full_covariance(i, j) = collapsed_full_covariance(non_empty_indices[i], non_empty_indices[j]);
-            reduced_collapsed_stat_covariance(i, j) = collapsed_stat_covariance(non_empty_indices[i], non_empty_indices[j]);
         }
     }
 
@@ -190,7 +214,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
                 float chi2_oneside;
                 // Calculate chi2_plus or chi2_minus, depending on boundary
-                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                 Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
@@ -235,7 +259,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (plus) violates unitarity. Setting chi2_plus to large value.") % __func__;
                     chi2_plus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_plus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
@@ -264,7 +288,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     //log<LOG_ERROR>(L"%1% || WARNING In PROchi: Gradient evaluation point (minus) violates unitarity. Setting chi2_minus to large value.") % __func__;
                     chi2_minus = 1e10;
                 } else {
-                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, strat != EventByEvent,config.i_prime);
+                    PROspec result = FillSpectra(config, peller, *syst, model, param_minus, fs_cache, strat != EventByEvent, config.i_prime);
 
                     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);

--- a/src/PROchi.cxx
+++ b/src/PROchi.cxx
@@ -103,8 +103,6 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
     
     PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2, config.i_prime);
 
-    Eigen::MatrixXf inverted_collapsed_full_covariance(config.m_num_variable_bins_total_collapsed[config.i_prime],config.m_num_variable_bins_total_collapsed[config.i_prime]);
-
     Eigen::MatrixXf full_covariance = result.Spec().asDiagonal() * (syst->fractional_covariance) * result.Spec().asDiagonal();
 
     Eigen::VectorXf normdata = shape_only
@@ -142,14 +140,15 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
     // Per-call: reduced_collapsed_full_covariance depends on `result` via collapsed_full_covariance.
     Eigen::MatrixXf reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
 
-    inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + reduced_collapsed_full_covariance).inverse();
+    Eigen::MatrixXf M = reduced_collapsed_stat_covariance + reduced_collapsed_full_covariance;
 
     // Create reduced delta vector
     Eigen::VectorXf collapsed_mc_spec = CollapseMatrix(config, result.Spec());
     Eigen::VectorXf delta = collapsed_mc_spec(idx) - normdata(idx);
-    
+
     float pull = Pull(subvector2);
-    float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
+    // delta^T M^-1 delta via Cholesky solve: faster + more stable than forming the inverse.
+    float covar_portion = delta.dot(M.llt().solve(delta));
     float value = covar_portion + pull;
 
     if(std::isnan(value) || value!=value) {
@@ -215,13 +214,13 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                 Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
 
                 Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
-                Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
+                Eigen::MatrixXf gM = reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance;
 
                 Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
                 Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                 Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                 float pull = Pull(subvector2);
-                chi2_oneside = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+                chi2_oneside = delta.dot(gM.llt().solve(delta)) + pull;
 
                 gradient(i) = sign*(chi2_oneside - value) / h;
 
@@ -251,13 +250,13 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
 
                     Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
-                    Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
+                    Eigen::MatrixXf gM = reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance;
 
                     Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
                     Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                     Eigen::VectorXf subvector2 = param_plus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
-                    chi2_plus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+                    chi2_plus = delta.dot(gM.llt().solve(delta)) + pull;
                 }
 
                 // Minus point
@@ -271,13 +270,13 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
                     Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
 
                     Eigen::MatrixXf grad_reduced_collapsed_full_covariance = collapsed_full_covariance(idx, idx);
-                    Eigen::MatrixXf inverted_collapsed_full_covariance = (reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance).inverse();
+                    Eigen::MatrixXf gM = reduced_collapsed_stat_covariance + grad_reduced_collapsed_full_covariance;
 
                     Eigen::VectorXf collapsed_mc = CollapseMatrix(config,result.Spec());
                     Eigen::VectorXf delta = collapsed_mc(idx) - normdata(idx);
                     Eigen::VectorXf subvector2 = param_minus.segment(model.nparams, syst->GetNSplines());
                     float pull = Pull(subvector2);
-                    chi2_minus = (delta.transpose())*inverted_collapsed_full_covariance*(delta) + pull;
+                    chi2_minus = delta.dot(gM.llt().solve(delta)) + pull;
                 }
 
                 // Central difference formula
@@ -311,27 +310,19 @@ float PROchi::getSingleChannelChi(size_t global_channel_index, const PROspec & c
     if(shape_only)
         collapsed_stat_covariance = (data.Normalize(config,cv)).matrix().asDiagonal();
 
-    Eigen::MatrixXf inverted_collapsed_full_covariance(nbin,nbin);
-    //only calculate a syst covariance if we have any covariance parameters as defined in the xml
+    Eigen::MatrixXf M(nbin, nbin);
     if(syst->GetNCovar()){
-        // Calculate Full Syst Covariance matrix
         Eigen::MatrixXf full_covariance = cv.Spec().asDiagonal() * (syst->fractional_covariance) * cv.Spec().asDiagonal();
-
-        // Collapse Covariance and Spectra 
-        Eigen::MatrixXf collapsed_full_covariance =  CollapseMatrix(config,full_covariance);
-        Eigen::MatrixXf sub_collapsed_full_covariance =  collapsed_full_covariance.block(startBin,startBin,nbin,nbin);
-        Eigen::MatrixXf sub_collapsed_stat_covariance =  collapsed_stat_covariance.block(startBin,startBin,nbin,nbin);
-
-        // Invert Collaped Matrix Matrix 
-        inverted_collapsed_full_covariance = (sub_collapsed_full_covariance+sub_collapsed_stat_covariance).inverse();
+        Eigen::MatrixXf collapsed_full_covariance = CollapseMatrix(config, full_covariance);
+        Eigen::MatrixXf sub_collapsed_full_covariance = collapsed_full_covariance.block(startBin, startBin, nbin, nbin);
+        Eigen::MatrixXf sub_collapsed_stat_covariance = collapsed_stat_covariance.block(startBin, startBin, nbin, nbin);
+        M = sub_collapsed_full_covariance + sub_collapsed_stat_covariance;
     } else {
-        Eigen::MatrixXf sub_collapsed_stat_covariance =  collapsed_stat_covariance.block(startBin,startBin,nbin,nbin);
-        inverted_collapsed_full_covariance = (sub_collapsed_stat_covariance).inverse();
+        M = collapsed_stat_covariance.block(startBin, startBin, nbin, nbin);
     }
 
-    Eigen::VectorXf delta  = (CollapseMatrix(config, cv.Spec()) - (shape_only ? data.Normalize(config,cv) : data.Spec())).segment(startBin, nbin);
-    //float pull = Pull(subvector2);
-    float covar_portion = (delta.transpose())*inverted_collapsed_full_covariance*(delta);
+    Eigen::VectorXf delta = (CollapseMatrix(config, cv.Spec()) - (shape_only ? data.Normalize(config,cv) : data.Spec())).segment(startBin, nbin);
+    float covar_portion = delta.dot(M.llt().solve(delta));
     float value = covar_portion;//pull;
 
     return value;

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -2233,6 +2233,14 @@ void PROconfig::construct_variable_collapsing_matrices(){
         }
 
     }
+
+    // Build sparse companions. Each row of T has exactly one 1.0, so nnz = m_num_variable_bins_total[io].
+    variable_collapsing_matrices_sparse.clear();
+    variable_collapsing_matrices_sparse.reserve(m_num_variables);
+    for(size_t io = 0; io < m_num_variables; ++io) {
+        variable_collapsing_matrices_sparse.emplace_back(variable_collapsing_matrices[io].sparseView());
+        variable_collapsing_matrices_sparse.back().makeCompressed();
+    }
     return;
 }
 

--- a/src/PROpoisson.cxx
+++ b/src/PROpoisson.cxx
@@ -41,6 +41,7 @@ PROpoisson::PROpoisson(const std::string tag, const PROconfig &conin, const PROp
           prior_covariance(iB, iA) = std::get<2>(t);
         }
         prior_covariance = systin->spline_priors.asDiagonal() * prior_covariance * systin->spline_priors.asDiagonal();
+        prior_covariance_inv = prior_covariance.inverse();
     }
 }
 
@@ -51,7 +52,7 @@ float PROpoisson::Pull(const Eigen::VectorXf &systs) {
         return (centered.array().square() / syst->spline_priors.array().square()).sum();
     }
 
-    return centered.dot(prior_covariance.inverse() * centered);
+    return centered.dot(prior_covariance_inv * centered);
 }
 
 void PROpoisson::fixSpline(int fix, float valin){
@@ -78,9 +79,9 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
     }
     Eigen::VectorXf subvector2 = param.segment(nparams - nsyst, nsyst);
     
-    PROspec result = FillSpectra(config, peller, *syst, model, param, strat == BinnedChi2);
+    PROspec result = FillSpectra(config, peller, *syst, model, param, fs_cache, strat == BinnedChi2);
 
-    const Eigen::VectorXf vdata = shape_only 
+    const Eigen::VectorXf vdata = shape_only
         ? data.Normalize(config,result)
         : data.Spec();
     const Eigen::VectorXf vmc = CollapseMatrix(config, result.Spec());
@@ -111,7 +112,7 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
                     continue;
                 }
             }
-            PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, strat != EventByEvent);
+            PROspec result = FillSpectra(config, peller, *syst, model, tmpParams, fs_cache, strat != EventByEvent);
 
             const Eigen::VectorXf vdata = shape_only 
                 ? data.Normalize(config,result)

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -914,10 +914,9 @@ namespace PROfit {
     }
 
     Eigen::MatrixXf PROsyst::DecomposeFractionalCovariance(const PROconfig &config, const Eigen::VectorXf &cv_vec) const {
-        if(cv_vec.size() == last_decomp_spec.size() && cv_vec == last_decomp_spec) 
+        if(cv_vec.size() == last_decomp_spec.size() && cv_vec == last_decomp_spec)
           return last_decomp_mat;
-        Eigen::MatrixXf diag = cv_vec.asDiagonal();
-        Eigen::MatrixXf full_cov = diag * fractional_covariance * diag;
+        Eigen::MatrixXf full_cov = cv_vec.asDiagonal() * fractional_covariance * cv_vec.asDiagonal();
         Eigen::MatrixXf coll = other_index < 0 ? CollapseMatrix(config, full_cov) : CollapseMatrix(config, full_cov, other_index);
         /*Eigen::LDLT<Eigen::MatrixXf> ldlt(coll);
           Eigen::MatrixXf L = ldlt.matrixL(); 

--- a/src/PROtocall.cxx
+++ b/src/PROtocall.cxx
@@ -38,53 +38,45 @@ namespace PROfit{
     }
 
     Eigen::MatrixXf CollapseMatrix(const PROconfig &inconfig, const Eigen::MatrixXf& full_matrix){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix();
-        int num_bin_before_collapse = variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse();
+        const Eigen::Index num_bin_before_collapse = T.rows();
         if(full_matrix.rows() != num_bin_before_collapse || full_matrix.cols() != num_bin_before_collapse){
             log<LOG_ERROR>(L"%1% || Matrix dimension doesn't match expected size. Provided matrix: %2% x %3%. Expected matrix size: %4% x %5%") % __func__ % full_matrix.rows() % full_matrix.cols() % num_bin_before_collapse% num_bin_before_collapse;
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-
-        //log<LOG_DEBUG>(L"%1% || CT  %2% x %3%. Full matrix: %4% x %5% ") % __func__ % variable_collapsing_matrices[config.i_prime].transpose().rows() %  variable_collapsing_matrices[config.i_prime].transpose().cols() % full_matrix.rows() % full_matrix.cols();
-        Eigen::MatrixXf result_matrix   = variable_collapsing_matrix.transpose()*full_matrix*variable_collapsing_matrix;
-        return result_matrix;
+        return Eigen::MatrixXf(T.transpose() * full_matrix * T);
     }
 
     Eigen::VectorXf CollapseMatrix(const PROconfig &inconfig, const Eigen::VectorXf& full_vector){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix();
-        if(full_vector.size() != variable_collapsing_matrix.rows()){
-            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse();
+        if(full_vector.size() != T.rows()){
+            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % T.rows();
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-        Eigen::VectorXf result_vector = variable_collapsing_matrix.transpose() * full_vector;
-        return result_vector;
+        return Eigen::VectorXf(T.transpose() * full_vector);
     }
 
     Eigen::MatrixXf CollapseMatrix(const PROconfig &inconfig, const Eigen::MatrixXf& full_matrix, int other_index){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix(other_index);
-        int num_bin_before_collapse = variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse(other_index);
+        const Eigen::Index num_bin_before_collapse = T.rows();
         if(full_matrix.rows() != num_bin_before_collapse || full_matrix.cols() != num_bin_before_collapse){
             log<LOG_ERROR>(L"%1% || Matrix dimension doesn't match expected size. Provided matrix: %2% x %3%. Expected matrix size: %4% x %5%") % __func__ % full_matrix.rows() % full_matrix.cols() % num_bin_before_collapse% num_bin_before_collapse;
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-
-        //log<LOG_DEBUG>(L"%1% || CT  %2% x %3%. Full matrix: %4% x %5% ") % __func__ % variable_collapsing_matrix.transpose().rows() %  variable_collapsing_matrices[config.i_prime].transpose().cols() % full_matrix.rows() % full_matrix.cols();
-        Eigen::MatrixXf result_matrix   = variable_collapsing_matrix.transpose()*full_matrix*variable_collapsing_matrix;
-        return result_matrix;
+        return Eigen::MatrixXf(T.transpose() * full_matrix * T);
     }
 
     Eigen::VectorXf CollapseMatrix(const PROconfig &inconfig, const Eigen::VectorXf& full_vector, int other_index){
-        Eigen::MatrixXf variable_collapsing_matrix = inconfig.GetCollapsingMatrix(other_index);
-        if(full_vector.size() != variable_collapsing_matrix.rows()){
-            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % variable_collapsing_matrix.rows();
+        const Eigen::SparseMatrix<float>& T = inconfig.GetCollapsingMatrixSparse(other_index);
+        if(full_vector.size() != T.rows()){
+            log<LOG_ERROR>(L"%1% || Vector dimension doesn't match expected size. Provided vector size: %2% . Expected size: %3%") % __func__ % full_vector.size() % T.rows();
             log<LOG_ERROR>(L"Terminating.");
             exit(EXIT_FAILURE);
         }
-        Eigen::VectorXf result_vector = variable_collapsing_matrix.transpose() * full_vector;
-        return result_vector;
+        return Eigen::VectorXf(T.transpose() * full_vector);
     }
     void PrintVariableInfo(const PROconfig &inconfig){
 


### PR DESCRIPTION
Built on top of #410, see [here](https://github.com/markrosslonergan/Elephant_Vanishes/compare/speedup/project-SBN-dev/markross_tier13ActualNewNEW2...leehagaman:PROfit:mcmc_tweaks) for a minimal diff.

MCMC tweaks
* Adds logging about bins with low prediction, less than one event
* Adds MCMC progress bar
* Increases MCMC adapt_factor from 1.02 to 1.1

Chi2 calculation speedup
* Avoids explicit matrix inversion, instead using Cholesky solving, replacing `(delta.transpose())*inverted_collapsed_full_covariance*(delta)` with `delta.dot(M.llt().solve(delta))` (`M.llt()` could be cached for further speedup when re-using the same covariance matrix) (could use ldlt rather than llt for more stability)