### PR TITLE
MCMC Underflow Fix

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1159,7 +1159,7 @@ int main(int argc, char* argv[])
                 fixed.push_back(i);
         }
         //Metropolis mh(simple_target{*metric}, simple_proposal(*metric, dseed(PROseed::global_rng)), best_fit, dseed(PROseed::global_rng));
-        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -1259,7 +1259,8 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
+        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -1268,7 +1269,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -1322,13 +1323,16 @@ int main(int argc, char* argv[])
         spline_cov.SetMinimum(-1);
 
         c.Print((final_output_tag+"_postfit_correlation_matrix_nuisance_only.pdf").c_str());
+
+        plot_mcmc_1sigma(final_output_tag+"_PROfile", config, metric->GetSysts(), metric->GetModel(), best_fit, post_param_lo, post_param_hi, !systs_only, fakedataparams);
+
         log<LOG_INFO>(L"%1% ||  Beginning full PROfile ") % __func__;
 
         if(progress_bar)scanFitConfig.progress_bar = true;
 
         std::vector<Eigen::VectorXf> seeds = fitter.freq_seed_points;//to be updated to v1.1.5 harmoincs [DONE]
         if(!seeds.size()) seeds.push_back(best_fit);
-        PROfile profile(config, metric->GetSysts(), metric->GetModel(), *metric, myseed, scanFitConfig, 
+        PROfile profile(config, metric->GetSysts(), metric->GetModel(), *metric, myseed, scanFitConfig,
                 final_output_tag+"_PROfile", best_chi2, !systs_only, nthread, seeds,
                 fakedataparams);
         log<LOG_INFO>(L"%1% || fakedataparams for Plot (true_params/red stars): %2%") % __func__ % fakedataparams;
@@ -2599,7 +2603,7 @@ int main(int argc, char* argv[])
             if(global_fixed.at(i) == 1)
                 fixed.push_back(i);
         }
-        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -2697,7 +2701,8 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
+        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -2706,7 +2711,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -3184,8 +3189,10 @@ int main(int argc, char* argv[])
 void mcmc_worker(std::vector<Metropolis<simple_target, adaptive_proposal>> &mets, Eigen::VectorXf initial, PROmetric *metric, uint32_t seed, size_t nchains, size_t burnin, size_t steps) {
     std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
     std::mt19937 rng(seed);
+    Eigen::VectorXf empty_grad = initial;
+    const float chi2_ref = (*metric)(initial, empty_grad, false);
     for(size_t i = 0; i < nchains; ++i) {
-        simple_target target{*metric};
+        simple_target target{*metric, chi2_ref};
         adaptive_proposal proposal(*metric, dseed(rng));
         mets.emplace_back(target, proposal, initial, dseed(rng));
         mets.back().run(burnin, steps);

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1159,7 +1159,7 @@ int main(int argc, char* argv[])
                 fixed.push_back(i);
         }
         //Metropolis mh(simple_target{*metric}, simple_proposal(*metric, dseed(PROseed::global_rng)), best_fit, dseed(PROseed::global_rng));
-        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -1260,8 +1260,7 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
-        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -1270,7 +1269,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -2604,7 +2603,7 @@ int main(int argc, char* argv[])
             if(global_fixed.at(i) == 1)
                 fixed.push_back(i);
         }
-        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -2703,8 +2702,7 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
-        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -2713,7 +2711,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -3191,10 +3189,8 @@ int main(int argc, char* argv[])
 void mcmc_worker(std::vector<Metropolis<simple_target, adaptive_proposal>> &mets, Eigen::VectorXf initial, PROmetric *metric, uint32_t seed, size_t nchains, size_t burnin, size_t steps) {
     std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
     std::mt19937 rng(seed);
-    Eigen::VectorXf empty_grad = initial;
-    const float chi2_ref = (*metric)(initial, empty_grad, false);
     for(size_t i = 0; i < nchains; ++i) {
-        simple_target target{*metric, chi2_ref};
+        simple_target target{*metric};
         adaptive_proposal proposal(*metric, dseed(rng));
         mets.emplace_back(target, proposal, initial, dseed(rng));
         mets.back().run(burnin, steps);

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1238,8 +1238,9 @@ int main(int argc, char* argv[])
         std::string hname = "#chi^{2}/ndf = " + to_string(best_chi2) + "/" + to_string(config.m_num_variable_bins_total_collapsed[config.i_prime]);
         PROspec cv = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), CVParams , true,config.i_prime);
         PROspec bf = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), best_fit, true,config.i_prime);
-        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
-        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
+        // Concatenated bins across all channels share no common x-axis, so use bin-index axis.
+        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
+        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
         for(size_t i = 0; i < config.m_num_variable_bins_total_collapsed[config.i_prime]; ++i) {
             post_hist.SetBinContent(i+1, bf.Spec()(i));
             pre_hist.SetBinContent(i+1, cv.Spec()(i));
@@ -2680,8 +2681,9 @@ int main(int argc, char* argv[])
         PROspec cv = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), CVParams , true,config.i_prime);
         PROspec bf = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), best_fit, true,config.i_prime);
 
-        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
-        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
+        // Concatenated bins across all channels share no common x-axis, so use bin-index axis.
+        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
+        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
         for(size_t i = 0; i < config.m_num_variable_bins_total_collapsed[config.i_prime]; ++i) {
             post_hist.SetBinContent(i+1, bf.Spec()(i));
             pre_hist.SetBinContent(i+1, cv.Spec()(i));

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -45,7 +45,8 @@ namespace PROfit {
                 bool step() {
                     Eigen::VectorXf p = proposal(current);
                     float acceptance;
-                    acceptance = proposal.within_bound(p) ? std::min(1.0f, target(p)/target(current) * proposal.P(current, p)/proposal.P(p, current)) : 0;
+                    // Targets return log-density (e.g. -0.5*chi^2); subtract before exp to avoid float32 underflow when chi^2 is large.
+                    acceptance = proposal.within_bound(p) ? std::min(1.0f, std::exp(target(p) - target(current)) * proposal.P(current, p)/proposal.P(p, current)) : 0;
                     float u = uniform(rng);
 
                     if(u <= acceptance) {
@@ -191,27 +192,21 @@ namespace PROfit {
 
     struct simple_target {
         PROmetric &metric;
-        // Reference chi^2 (typically chi^2 at best fit). The exp argument becomes
-        // -0.5*(chi^2 - chi2_ref), keeping it near 0 for typical samples and avoiding
-        // float32 underflow that would occur if chi^2 >> ~170 was exponentiated directly.
-        // The constant cancels in target(p)/target(current), so the sampled distribution
-        // is unchanged.
-        float chi2_ref = 0.0f;
 
+        // Returns log-target (-0.5*chi^2). Metropolis::step does exp(target(p) - target(current))
+        // so the exp argument stays in safe float32 range even when chi^2 is large.
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf empty = value;
-            return std::exp(-0.5f*(metric(value, empty, false) - chi2_ref));
+            return -0.5f*metric(value, empty, false);
         }
     };
 
     struct prior_only_target {
         PROmetric &metric;
-        // Reference Pull (typically Pull at best fit). See note on simple_target::chi2_ref.
-        float pull_ref = 0.0f;
 
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf nuisance = value.segment(metric.GetModel().nparams, metric.GetSysts().GetNSplines());
-            return std::exp(-0.5f*(metric.Pull(nuisance) - pull_ref));
+            return -0.5f*metric.Pull(nuisance);
         }
     };
 

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -191,19 +191,27 @@ namespace PROfit {
 
     struct simple_target {
         PROmetric &metric;
+        // Reference chi^2 (typically chi^2 at best fit). The exp argument becomes
+        // -0.5*(chi^2 - chi2_ref), keeping it near 0 for typical samples and avoiding
+        // float32 underflow that would occur if chi^2 >> ~170 was exponentiated directly.
+        // The constant cancels in target(p)/target(current), so the sampled distribution
+        // is unchanged.
+        float chi2_ref = 0.0f;
 
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf empty = value;
-            return std::exp(-0.5f*metric(value, empty, false));
+            return std::exp(-0.5f*(metric(value, empty, false) - chi2_ref));
         }
     };
 
     struct prior_only_target {
         PROmetric &metric;
+        // Reference Pull (typically Pull at best fit). See note on simple_target::chi2_ref.
+        float pull_ref = 0.0f;
 
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf nuisance = value.segment(metric.GetModel().nparams, metric.GetSysts().GetNSplines());
-            return std::exp(-0.5f*metric.Pull(nuisance));
+            return std::exp(-0.5f*(metric.Pull(nuisance) - pull_ref));
         }
     };
 

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -378,6 +378,24 @@ namespace PROfit{
             return ebar;
         }
 
+    /**
+     * @brief Produce a 1-sigma summary plot from MCMC results only (no profile scan).
+     * @details Mirrors the post-MCMC pieces of PROfile::Plot's "_1sigma_detailed.pdf":
+     * a gray ±1 prior band, blue post-fit MCMC bars centered on @p best_fit (widths
+     * from @p param_err_lo / @p param_err_hi), red squares for the global best-fit, and
+     * orange diamonds for any injected truth values. Intended to be called between the
+     * MCMC error-band step and the (slow) profile scan.
+     * @param filename     Output prefix; final file is @p filename + "_1sigmaMCMC.pdf".
+     * @param config       Analysis configuration (used for parameter pretty names).
+     * @param systs        PROsyst (provides spline names and count).
+     * @param model        Physics model.
+     * @param best_fit     Best-fit parameter vector (length nphys + nspline).
+     * @param param_err_lo Per-spline lower 1σ from MCMC quantiles (length nspline).
+     * @param param_err_hi Per-spline upper 1σ from MCMC quantiles (length nspline).
+     * @param with_osc     If true, also plot physics parameters; if false, splines only.
+     * @param true_params  Optional injected truth values.
+     */
+    void plot_mcmc_1sigma(const std::string &filename, const PROconfig &config, const PROsyst &systs, const PROmodel &model, const Eigen::VectorXf &best_fit, const Eigen::VectorXf &param_err_lo, const Eigen::VectorXf &param_err_hi, bool with_osc = false, const Eigen::VectorXf &true_params = Eigen::VectorXf());
 
 };
 

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -1,5 +1,12 @@
 #include "PROplot.h"
 #include "TStyle.h"
+#include "TArrow.h"
+#include "TBox.h"
+#include "TH1F.h"
+#include "TLatex.h"
+#include "TLegend.h"
+#include "TMarker.h"
+#include "TText.h"
 #include <cmath>
 #include <Eigen/SVD>
 
@@ -1984,4 +1991,179 @@ namespace PROfit{
         c.Print((filename+"]").c_str());
         return 0;
     };
+
+    void plot_mcmc_1sigma(const std::string &filename, const PROconfig &config, const PROsyst &systs, const PROmodel &model, const Eigen::VectorXf &best_fit, const Eigen::VectorXf &param_err_lo, const Eigen::VectorXf &param_err_hi, bool with_osc, const Eigen::VectorXf &true_params) {
+        const int nBins = (int)systs.GetNSplines() + (with_osc ? (int)model.nparams : 0);
+        if(nBins == 0) {
+            log<LOG_WARNING>(L"%1% || No parameters to plot, skipping _1sigmaMCMC.pdf") % __func__;
+            return;
+        }
+
+        std::vector<std::string> names;
+        if(with_osc) for(const auto &n: model.pretty_param_names) names.push_back(n);
+        for(const auto &n: systs.spline_names) names.push_back(n);
+
+        std::vector<float> bfvalues(nBins, 0.0f);
+        for(int i = 0; i < nBins; ++i) {
+            int vec_idx = with_osc ? i : (i + (int)model.nparams);
+            if(vec_idx < (int)best_fit.size()) bfvalues[i] = (float)best_fit(vec_idx);
+        }
+
+        // Y range: cover post-fit bars, always show ±1
+        float minVal = -1.2f, maxVal = 1.2f;
+        for(int i = 0; i < nBins; ++i) {
+            int syst_idx = with_osc ? (i - (int)model.nparams) : i;
+            if(syst_idx >= 0 && syst_idx < (int)param_err_lo.size() && syst_idx < (int)param_err_hi.size()) {
+                minVal = std::min(minVal, bfvalues[i] - param_err_lo(syst_idx));
+                maxVal = std::max(maxVal, bfvalues[i] + param_err_hi(syst_idx));
+            }
+        }
+        // Clamp to ±5 so a runaway bar doesn't squash everything
+        minVal = std::max(minVal, -5.0f);
+        maxVal = std::min(maxVal,  5.0f);
+        const float y_axis_min = minVal * 1.15f;
+        const float y_axis_max = maxVal * 1.15f;
+        const float y_range_size = y_axis_max - y_axis_min;
+        const float arrow_margin = y_range_size * 0.07f;
+        const float arrow_length = y_range_size * 0.05f;
+
+        const int c_width  = std::max(600, std::min(5000, 50 * nBins));
+        const int c_height = 500;
+        const float axis_label_size = std::max(0.030f, std::min(0.045f, 1.8f / nBins));
+        const float x_label_size    = std::max(0.015f, std::min(0.030f, 1.2f / nBins));
+        const float bar_halfwidth   = std::max(0.08f, std::min(0.4f,  4.0f / nBins));
+        const float marker_offset   = bar_halfwidth * 0.6f;
+        const float marker_size     = std::max(0.5f, std::min(1.4f, 6.0f / std::sqrt((float)nBins)));
+
+        TCanvas *c = new TCanvas((filename+"1sigmaMCMC").c_str(), (filename+"1sigmaMCMC").c_str(), c_width, c_height);
+        c->cd();
+        c->SetLeftMargin(0.09);
+        c->SetBottomMargin(0.30);
+        c->SetRightMargin(0.28);
+        c->SetTopMargin(0.08);
+
+        TH1F *frame = new TH1F((filename+"_frame_mcmc1s").c_str(), "", nBins, 0, nBins);
+        frame->SetMinimum(y_axis_min);
+        frame->SetMaximum(y_axis_max);
+        frame->SetStats(0);
+        frame->GetXaxis()->SetLabelSize(0);
+        frame->GetXaxis()->SetTickLength(0);
+        frame->GetYaxis()->SetTitle("Parameter value (prior #kern[0.3]{} #sigma = 1)");
+        frame->GetYaxis()->SetTitleSize(axis_label_size);
+        frame->GetYaxis()->SetLabelSize(axis_label_size);
+        frame->GetYaxis()->SetTitleOffset(1.0);
+        frame->Draw("AXIS");
+
+        TBox *prior_band = new TBox(0.0f, -1.0f, (float)nBins, 1.0f);
+        prior_band->SetFillColor(kGray);
+        prior_band->SetFillStyle(1001);
+        prior_band->SetLineColor(kGray+1);
+        prior_band->SetLineWidth(1);
+        prior_band->Draw("same");
+
+        TGraphAsymmErrors *postbars = new TGraphAsymmErrors(nBins);
+        for(int i = 0; i < nBins; ++i) {
+            int syst_idx = with_osc ? (i - (int)model.nparams) : i;
+            float err_lo = 0.0f, err_hi = 0.0f;
+            if(syst_idx >= 0 && syst_idx < (int)param_err_lo.size() && syst_idx < (int)param_err_hi.size()) {
+                err_lo = param_err_lo(syst_idx);
+                err_hi = param_err_hi(syst_idx);
+            }
+            postbars->SetPoint(i, i + 0.5f, bfvalues[i]);
+            postbars->SetPointError(i, bar_halfwidth, bar_halfwidth, err_lo, err_hi);
+        }
+        postbars->SetFillColor(kBlue-7);
+        postbars->SetFillStyle(1001);
+        postbars->SetLineColor(kBlue-8);
+        postbars->SetLineWidth(1);
+        postbars->Draw("2 same");
+
+        TLine *l_zero = new TLine(0, 0, nBins, 0);
+        l_zero->SetLineStyle(2); l_zero->SetLineColor(kGray+2); l_zero->SetLineWidth(1);
+        l_zero->Draw();
+        TLine *l_pm1 = new TLine(0, 1, nBins, 1);
+        l_pm1->SetLineStyle(3); l_pm1->SetLineColor(kGray+2); l_pm1->SetLineWidth(1);
+        l_pm1->Draw();
+        TLine *l_mm1 = new TLine(0, -1, nBins, -1);
+        l_mm1->SetLineStyle(3); l_mm1->SetLineColor(kGray+2); l_mm1->SetLineWidth(1);
+        l_mm1->Draw();
+
+        auto drawMarkerWithArrow = [&](float x, float y, int color, int marker_style, float msize) {
+            bool clamp_below = y < -5.0f;
+            bool clamp_above = y >  5.0f;
+            if(!clamp_below && !clamp_above && (y < y_axis_min || y > y_axis_max)) return;
+            float draw_y = clamp_below ? y_axis_min + arrow_margin : (clamp_above ? y_axis_max - arrow_margin : y);
+            TMarker *m = new TMarker(x, draw_y, marker_style);
+            m->SetMarkerSize(msize); m->SetMarkerColor(color); m->Draw();
+            if(clamp_below) {
+                TArrow *a = new TArrow(x, draw_y - arrow_length*0.3f, x, y_axis_min + arrow_length*0.2f, 0.008, "|>");
+                a->SetLineColor(color); a->SetFillColor(color); a->SetLineWidth(1); a->Draw();
+            } else if(clamp_above) {
+                TArrow *a = new TArrow(x, draw_y + arrow_length*0.3f, x, y_axis_max - arrow_length*0.2f, 0.008, "|>");
+                a->SetLineColor(color); a->SetFillColor(color); a->SetLineWidth(1); a->Draw();
+            }
+        };
+
+        for(int i = 0; i < nBins; ++i) {
+            int vec_idx = with_osc ? i : (i + (int)model.nparams);
+            float x_center = i + 0.5f;
+            if(vec_idx < (int)best_fit.size()) {
+                drawMarkerWithArrow(x_center - marker_offset, (float)best_fit(vec_idx), kRed, 21, marker_size);
+            }
+            if(vec_idx < (int)true_params.size()) {
+                drawMarkerWithArrow(x_center + marker_offset, (float)true_params(vec_idx), kOrange+7, 33, marker_size * 1.1f);
+            }
+        }
+
+        const float label_y = y_axis_min - y_range_size * 0.04f;
+        for(int i = 0; i < nBins; ++i) {
+            std::string label;
+            if(with_osc && i < (int)model.nparams) {
+                label = "Log_{10}(" + model.pretty_param_names[i] + ")";
+            } else {
+                auto it = config.m_mcgen_variation_plotname_map.find(names[i]);
+                label = (it != config.m_mcgen_variation_plotname_map.end()) ? it->second : names[i];
+            }
+            TLatex *t = new TLatex(i + 0.5f, label_y, label.c_str());
+            t->SetTextAlign(13);
+            t->SetTextSize(x_label_size);
+            t->SetTextAngle(-45);
+            t->Draw();
+        }
+
+        TLegend *leg = new TLegend(0.73, 0.60, 0.99, 0.92);
+        leg->SetFillStyle(1001);
+        leg->SetBorderSize(1);
+        leg->SetTextSize(std::max(0.022f, std::min(0.030f, axis_label_size * 0.85f)));
+        leg->AddEntry(prior_band, "Pre-fit #pm1#sigma (prior)", "f");
+        leg->AddEntry(postbars,    "Post-fit #pm1#sigma (MCMC)", "f");
+        TGraph *leg_bf = new TGraph(1);
+        leg_bf->SetPoint(0, 0, 0);
+        leg_bf->SetMarkerStyle(21);
+        leg_bf->SetMarkerColor(kRed);
+        leg_bf->SetMarkerSize(marker_size);
+        leg->AddEntry(leg_bf, "Global best-fit", "p");
+        TGraph *leg_tp = nullptr;
+        if(true_params.size() > 0) {
+            leg_tp = new TGraph(1);
+            leg_tp->SetPoint(0, 0, 0);
+            leg_tp->SetMarkerStyle(33);
+            leg_tp->SetMarkerColor(kOrange+7);
+            leg_tp->SetMarkerSize(marker_size * 1.1f);
+            leg->AddEntry(leg_tp, "Injected values", "p");
+        }
+        leg->Draw();
+
+        TText *vt = new TText();
+        vt->SetNDC();
+        vt->SetTextFont(42);
+        vt->SetTextSize(0.028f);
+        vt->SetTextAlign(33);
+        std::string pv = "PROfit v" + std::string(PROJECT_VERSION_STR);
+        vt->DrawText(0.96, 0.97, pv.c_str());
+
+        c->Update();
+        c->SaveAs((filename+"_1sigmaMCMC.pdf").c_str(), "pdf");
+        delete c;
+    }
 }

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -49,6 +49,7 @@ namespace PROfit{
                         const std::string& color = inconfig.m_subchannel_colors[ic][sc];
                         int rcolor = color == "NONE" ? kRed - 7 : inconfig.HexToROOTColor(color);
                         std::unique_ptr<TH1D> htmp = std::make_unique<TH1D>(spec.toTH1D(inconfig, global_subchannel_index, other_index));
+                        htmp->SetDirectory(nullptr);  // copy ctor re-registers with gDirectory; detach to avoid name-collision warnings on repeated calls.
                         htmp->SetLineWidth(1);
                         htmp->SetLineColor(kBlack);
                         htmp->SetFillColor(rcolor);
@@ -56,6 +57,7 @@ namespace PROfit{
                         hists[subchannel_name] = std::move(htmp);
                         std::unique_ptr<TH1D> htmp_slc = std::make_unique<TH1D>(spec.toTH1DSlices(inconfig, global_subchannel_index, other_index));
                         if(htmp_slc){
+                            htmp_slc->SetDirectory(nullptr);
                             hists[subchannel_name+"slc"] = std::move(htmp_slc);
                         }
                         ++global_subchannel_index;
@@ -76,6 +78,7 @@ namespace PROfit{
                     for(size_t sc = 0; sc < inconfig.m_num_subchannels[ic]; sc++){
                         const std::string& subchannel_name  = inconfig.m_fullnames[global_subchannel_index];
                         std::unique_ptr<TH2D> htmp = std::make_unique<TH2D>(spec.toTH2D(inconfig, global_subchannel_index, other_index));
+                        htmp->SetDirectory(nullptr);  // copy ctor re-registers with gDirectory; detach to avoid name-collision warnings on repeated calls.
                         if(scale) htmp->Scale(1,"width");
                         hists[subchannel_name] = std::move(htmp);
                         ++global_subchannel_index;

--- a/src/PROspec.cxx
+++ b/src/PROspec.cxx
@@ -108,7 +108,8 @@ TH1D PROspec::toTH1DSlices(PROconfig const & inconfig, int subchannel_index, int
     std::string xaxis_title =  inconfig.m_channel_variable_units[channel_index][other_index];
 
     //fill 1D hist
-    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]); 
+    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]);
+    hSpec.SetDirectory(nullptr);  // detach from gDirectory; multiple calls reuse names and would otherwise warn.
     hSpec.GetXaxis()->SetTitle(xaxis_title.c_str());
 
     if(inconfig.m_channel_variable_dims[channel_index][other_index] == 2){
@@ -141,7 +142,8 @@ TH1D PROspec::toTH1D(PROconfig const & inconfig, int subchannel_index, int other
     Eigen::VectorXf error_proj = inconfig.m_channel_variable_bins[channel_index][other_index].ProjectSpectraErrors(error(Eigen::seqN(global_bin_start, nbins_tot)), dim);
 
     //fill 1D hist
-    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]); 
+    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]);
+    hSpec.SetDirectory(nullptr);  // detach from gDirectory; multiple calls reuse names and would otherwise warn.
     hSpec.GetXaxis()->SetTitle(xaxis_title.c_str());
 
     for(int i = 1; i <= nbins_dim; ++i){
@@ -171,6 +173,7 @@ TH2D PROspec::toTH2D(PROconfig const & inconfig, int subchannel_index, int other
     Eigen::VectorXf spec_2d = spec(Eigen::seqN(global_bin_start, nbins_tot));
 
     TH2D hSpec(hist_name.c_str(),hist_name.c_str(), channel_nbins_x, edges_x.data(), channel_nbins_y, edges_y.data());
+    hSpec.SetDirectory(nullptr);  // detach from gDirectory; multiple calls reuse names and would otherwise warn.
     hSpec.GetXaxis()->SetTitle(xaxis_title.c_str());
 
     for(int xbin = 0; xbin < (int)channel_nbins_x; xbin++){


### PR DESCRIPTION
The MCMC used a target probability density of exp(-chi2/2), and with many bins, you can get a large chi2 that causes this exponential to underflow to zero. Here, we fix this by using log probabilities and subtracting to get probability ratios. This should be exactly equivalent to the previous algorithm with better numerical stability.

Also added 1sigmaMCMC plot, more quickly getting a preview of what we expect from the profile scan 1sigma plot.

Also fixed `Error in <TAxis::TAxis::Set>: bins must be in increasing order` by changing post_hist and pre_hist binnings to bin-index rather than x-axis values, which didn't work when using multiple channels.

Also avoided `Replacing existing TH1` warnings by adding `htmp->SetDirectory(nullptr);` commands.