### PR TITLE
Fail if data xml and MC xml disagree on detector POT

### DIFF
--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -67,6 +67,11 @@ bool PROconfig::SameChannels(const PROconfig &one, const PROconfig &two) {
                 % __func__ % one.m_detector_names[i].c_str() % two.m_detector_names[i].c_str();
             return false;
         }
+        if(one.m_det_pot[i] != two.m_det_pot[i]) {
+            log<LOG_WARNING>(L"%1% || Found different POTs for detector %2%, %3% vs %4%")
+                % __func__ % one.m_detector_names[i].c_str() % one.m_det_pot[i] % two.m_det_pot[i];
+            return false;
+        }
     }
     if(one.m_num_channels != two.m_num_channels) {
         log<LOG_WARNING>(L"%1% || Found different number of channels %2% vs %3%")


### PR DESCRIPTION
This came up recently from one of the SBN analysis groups. Their MC xml had the nominal POT for that analysis while the data POT had a smaller POT since it was only looking at a small dataset.

We have 2 options in this case:
1. Fail because we don't know which POT to use for that detector
2. Prefer one over the other, probably the data POT

This PR implements 1, but maybe we want 2? 2 would have allowed this analysis team to continue to use the same MC xml for MC only studies and for real data studies. But maybe we want to force people to maintain separate xmls for real data and fake/asimov data?