### PR TITLE
Fix typo in global fit bounds for PROfile

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1086,7 +1086,7 @@ int main(int argc, char* argv[])
     if(*profile_command){
 
         PROfitter fitter(global_ub, global_lb, fitConfig);
-        metric->setBounds(global_ub, global_ub);
+        metric->setBounds(global_ub, global_lb);
 
         log<LOG_INFO>(L"%1% || ########### Starting Global Best Fit Minimizing ############") % __func__;
 
@@ -2525,10 +2525,8 @@ int main(int argc, char* argv[])
     //***********************************************************************
     if(*proglobal_command){
 
-
-
-        PROfitter fitter(metric->UpperBound(), metric->LowerBound(), fitConfig);
-        metric->setBounds(metric->UpperBound(), metric->LowerBound());
+        PROfitter fitter(global_ub, global_lb, fitConfig);
+        metric->setBounds(global_ub, global_lb);
 
         log<LOG_INFO>(L"%1% || ########### Print of inputs ############") % __func__;
         //metric->print(fakedataparams); //fix


### PR DESCRIPTION
I think this fixes #401 

I get the same global fit with both `global` and `profile` using the same seed in the tests I ran. But others who were seeing this bug should check this fixes their issues before we mark #401 fixed.

Typo in bounds for profile global fit where we were setting the lower bound to be the same as the upper bound. 

Another bug, which somehow wasn't causing issues in global bounds. We were setting the PROfitter bounds using the metric bounds before setting the metric bounds. We must have been setting the metric bounds somewhere else first, but this at least makes the local code make sense.