### PR TITLE
Allow turning off mirroring of 0-1 systematics

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -425,6 +425,7 @@ namespace PROfit{
             std::vector<std::string> m_mcgen_variation_allowlist;
             std::vector<std::string> m_mcgen_variation_denylist;
             std::vector<std::string> m_mcgen_variation_type;
+            std::set<std::string> m_mcgen_variation_unmirrored;
             std::map<std::string, std::string> m_mcgen_variation_external_filename_map;
             std::map<std::string, std::array<int, 2>> m_mcgen_variation_histaxisvars_map;
             std::map<std::string, TH1*> m_mcgen_variation_hist1d_map;

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -202,7 +202,7 @@ namespace PROfit {
             static bool isPositiveSemiDefinite(const Eigen::MatrixXf& in_matrix);
 
             /* Function: Fill splines assuming p_cv and p_multi_spec have been filled in the SystStruct*/
-            void FillSpline(const SystStruct& syst);
+            void FillSpline(const SystStruct& syst, bool unmirrored);
 
             /* Function: Get weight for bin for a given shift using spline */
             float GetSplineShift(int syst_num, float shift, int bin) const;

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1189,7 +1189,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 }
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar", "restrict"};
+                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar", "restrict", "mirror"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -1213,6 +1213,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *filename = pAllowList->Attribute("filename");
                 const char *xvar = pAllowList->Attribute("xvar");
                 const char *yvar = pAllowList->Attribute("yvar");
+                const char *mirrored = pAllowList->Attribute("mirror");
 
 
                 m_mcgen_variation_type.push_back(variation_type);
@@ -1338,6 +1339,10 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(scale) {
                     m_mcgen_variation_scale[wt] = std::strtof(scale, NULL);
                     log<LOG_INFO>(L"%1% || Parsed scale=%2% for systematic %3%") % __func__ % m_mcgen_variation_scale[wt] % wt.c_str();
+                }
+                if(mirrored) {
+                    if(strcmp(mirrored, "false") == 0 || strcmp(mirrored, "no") == 0 || strcmp(mirrored, "0") == 0)
+                        m_mcgen_variation_unmirrored.insert(wt);
                 }
                 log<LOG_DEBUG>(L"%1% || Allowlisting variations: %2%") % __func__ % wt.c_str() ;
                 tinyxml2::XMLElement *pNext = pAllowList->NextSiblingElement("allowlist");

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -17,7 +17,8 @@ namespace PROfit {
         for(const auto& syst: systs) {
             log<LOG_DEBUG>(L"%1% || syst mode: %2%") % __func__ % syst.mode.c_str();
             if(syst.mode == "spline" || syst.mode == "norm" || syst.mode == "hist1d" || syst.mode == "hist2d") {
-                FillSpline(syst);
+                bool unmirrored = config.m_mcgen_variation_unmirrored.find(syst.systname) != config.m_mcgen_variation_unmirrored.end();
+                FillSpline(syst, unmirrored);
                 ++n_splines;
             } else if(syst.mode == "spline_to_covariance") {
                 if(model == nullptr){
@@ -27,7 +28,8 @@ namespace PROfit {
                     exit(EXIT_FAILURE);
                 }
                 // Build spline first, then convert to covariance matrix
-                FillSpline(syst);
+                bool unmirrored = config.m_mcgen_variation_unmirrored.find(syst.systname) != config.m_mcgen_variation_unmirrored.end();
+                FillSpline(syst, unmirrored);
                 size_t spline_idx = splines.size() - 1;
 
                 // Build temporary priors/centers for the current spline list (including the
@@ -654,7 +656,7 @@ namespace PROfit {
         return c[0] + x*(c[1] + x*(c[2] + x*c[3]));
     }
 
-    void PROsyst::FillSpline(const SystStruct& syst) {
+    void PROsyst::FillSpline(const SystStruct& syst, bool unmirrored) {
         std::vector<PROspec> ratios;
         ratios.reserve(syst.p_multi_spec.size());
         float cv_integral = syst.p_cv->Spec().sum();
@@ -736,7 +738,10 @@ namespace PROfit {
                 const float y1 = ratios[0].GetBinContent(i);
                 const float y2 = ratios[1].GetBinContent(i);
                 const float slope = (y2 - y1) / (knobvals[1] - knobvals[0]);
-                bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {y2, -slope, 0, 0}});
+                if(unmirrored)
+                    bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {-y2, slope, 0, 0}});
+                else
+                    bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {y2, -slope, 0, 0}});
                 bin_segments.push_back(SplineSegment{(float)knobvals[0], {slope * (float)knobvals[0] + y1, slope, 0, 0}});
             } else {
                 {

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -739,7 +739,7 @@ namespace PROfit {
                 const float y2 = ratios[1].GetBinContent(i);
                 const float slope = (y2 - y1) / (knobvals[1] - knobvals[0]);
                 if(unmirrored)
-                    bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {-y2, slope, 0, 0}});
+                    bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {slope * (-knobvals[1]) + y1, slope, 0, 0}});
                 else
                     bin_segments.push_back(SplineSegment{(float)(-knobvals[1]), {y2, -slope, 0, 0}});
                 bin_segments.push_back(SplineSegment{(float)knobvals[0], {slope * (float)knobvals[0] + y1, slope, 0, 0}});


### PR DESCRIPTION
Right now 0-1 systs are mirrored about 0. For the ICARUS detector systs we want to instead linearly extrapolate backwards. This allows the existing `restrict` attribute to do that by changing the mirroring to instead just manually extrapolate back 1 point.

Control this behavior with `mirror` attribute. Default is still to mirror. You would instead write something like
```xml
<systematic ... mirror="false">...</systematic>
```
`false`, `no`, and `0` all work to turn mirroring off. Anything else will leave it on.