### PR TITLE
Getting units from xml for --scale-by-width y-axis labels

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1159,7 +1159,7 @@ int main(int argc, char* argv[])
                 fixed.push_back(i);
         }
         //Metropolis mh(simple_target{*metric}, simple_proposal(*metric, dseed(PROseed::global_rng)), best_fit, dseed(PROseed::global_rng));
-        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -1259,7 +1259,8 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
+        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -1268,7 +1269,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -1322,13 +1323,16 @@ int main(int argc, char* argv[])
         spline_cov.SetMinimum(-1);
 
         c.Print((final_output_tag+"_postfit_correlation_matrix_nuisance_only.pdf").c_str());
+
+        plot_mcmc_1sigma(final_output_tag+"_PROfile", config, metric->GetSysts(), metric->GetModel(), best_fit, post_param_lo, post_param_hi, !systs_only, fakedataparams);
+
         log<LOG_INFO>(L"%1% ||  Beginning full PROfile ") % __func__;
 
         if(progress_bar)scanFitConfig.progress_bar = true;
 
         std::vector<Eigen::VectorXf> seeds = fitter.freq_seed_points;//to be updated to v1.1.5 harmoincs [DONE]
         if(!seeds.size()) seeds.push_back(best_fit);
-        PROfile profile(config, metric->GetSysts(), metric->GetModel(), *metric, myseed, scanFitConfig, 
+        PROfile profile(config, metric->GetSysts(), metric->GetModel(), *metric, myseed, scanFitConfig,
                 final_output_tag+"_PROfile", best_chi2, !systs_only, nthread, seeds,
                 fakedataparams);
         log<LOG_INFO>(L"%1% || fakedataparams for Plot (true_params/red stars): %2%") % __func__ % fakedataparams;
@@ -2599,7 +2603,7 @@ int main(int argc, char* argv[])
             if(global_fixed.at(i) == 1)
                 fixed.push_back(i);
         }
-        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -2697,7 +2701,8 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
+        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -2706,7 +2711,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -3184,8 +3189,10 @@ int main(int argc, char* argv[])
 void mcmc_worker(std::vector<Metropolis<simple_target, adaptive_proposal>> &mets, Eigen::VectorXf initial, PROmetric *metric, uint32_t seed, size_t nchains, size_t burnin, size_t steps) {
     std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
     std::mt19937 rng(seed);
+    Eigen::VectorXf empty_grad = initial;
+    const float chi2_ref = (*metric)(initial, empty_grad, false);
     for(size_t i = 0; i < nchains; ++i) {
-        simple_target target{*metric};
+        simple_target target{*metric, chi2_ref};
         adaptive_proposal proposal(*metric, dseed(rng));
         mets.emplace_back(target, proposal, initial, dseed(rng));
         mets.back().run(burnin, steps);

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1159,7 +1159,7 @@ int main(int argc, char* argv[])
                 fixed.push_back(i);
         }
         //Metropolis mh(simple_target{*metric}, simple_proposal(*metric, dseed(PROseed::global_rng)), best_fit, dseed(PROseed::global_rng));
-        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -1260,8 +1260,7 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
-        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -1270,7 +1269,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -2604,7 +2603,7 @@ int main(int argc, char* argv[])
             if(global_fixed.at(i) == 1)
                 fixed.push_back(i);
         }
-        Metropolis mh(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed), best_fit, dseed(PROseed::global_rng));
 
         Eigen::MatrixXf covmat = Eigen::MatrixXf::Constant(N_params, N_params, 0);
         size_t count = 0;
@@ -2703,8 +2702,7 @@ int main(int argc, char* argv[])
 
 
         log<LOG_INFO>(L"%1% || Starting global getErrorBand() ") % __func__;
-        const float pull_at_bf = metric->Pull(best_fit.segment(N_phys_params, metric->GetSysts().GetNSplines()));
-        Metropolis mh_pre(prior_only_target{*metric, pull_at_bf}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_pre(prior_only_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
 
         std::optional<PROgressBar> errband_pre_pbar;
         if(progress_bar && MCMC_prefit_errors) errband_pre_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC prefit");
@@ -2713,7 +2711,7 @@ int main(int argc, char* argv[])
             ? getMCMCErrorBand(mh_pre, fitConfig.MCMCburn, fitConfig.MCMCiter, config, prop, *metric, best_fit, priors, prior_covariance, prior_param_lo, prior_param_hi, binwidth_scale,config.i_prime, errband_pre_pbar ? &*errband_pre_pbar : nullptr)
             : getErrorBand(config, prop, variable_systs[config.i_prime], *model, cv,CVParams, binwidth_scale,config.i_prime);
 
-        Metropolis mh_post(simple_target{*metric, best_chi2}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
+        Metropolis mh_post(simple_target{*metric}, adaptive_proposal(*metric, dseed(PROseed::global_rng), fixed_pars), best_fit, dseed(PROseed::global_rng));
         log<LOG_INFO>(L"%1% || Starting global getPostFitErrorBand() ") % __func__;
         std::optional<PROgressBar> errband_post_pbar;
         if(progress_bar) errband_post_pbar.emplace(int(fitConfig.MCMCburn + fitConfig.MCMCiter), 30, "MCMC postfit band");
@@ -3191,10 +3189,8 @@ int main(int argc, char* argv[])
 void mcmc_worker(std::vector<Metropolis<simple_target, adaptive_proposal>> &mets, Eigen::VectorXf initial, PROmetric *metric, uint32_t seed, size_t nchains, size_t burnin, size_t steps) {
     std::uniform_int_distribution<uint32_t> dseed(0, std::numeric_limits<uint32_t>::max());
     std::mt19937 rng(seed);
-    Eigen::VectorXf empty_grad = initial;
-    const float chi2_ref = (*metric)(initial, empty_grad, false);
     for(size_t i = 0; i < nchains; ++i) {
-        simple_target target{*metric, chi2_ref};
+        simple_target target{*metric};
         adaptive_proposal proposal(*metric, dseed(rng));
         mets.emplace_back(target, proposal, initial, dseed(rng));
         mets.back().run(burnin, steps);

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1238,8 +1238,9 @@ int main(int argc, char* argv[])
         std::string hname = "#chi^{2}/ndf = " + to_string(best_chi2) + "/" + to_string(config.m_num_variable_bins_total_collapsed[config.i_prime]);
         PROspec cv = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), CVParams , true,config.i_prime);
         PROspec bf = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), best_fit, true,config.i_prime);
-        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
-        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
+        // Concatenated bins across all channels share no common x-axis, so use bin-index axis.
+        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
+        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
         for(size_t i = 0; i < config.m_num_variable_bins_total_collapsed[config.i_prime]; ++i) {
             post_hist.SetBinContent(i+1, bf.Spec()(i));
             pre_hist.SetBinContent(i+1, cv.Spec()(i));
@@ -2680,8 +2681,9 @@ int main(int argc, char* argv[])
         PROspec cv = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), CVParams , true,config.i_prime);
         PROspec bf = FillSpectra(config, prop, metric->GetSysts(), metric->GetModel(), best_fit, true,config.i_prime);
 
-        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
-        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], config.m_channel_variable_bins[config.i_prime][0].Edges().data());
+        // Concatenated bins across all channels share no common x-axis, so use bin-index axis.
+        TH1D post_hist("ph", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
+        TH1D pre_hist("prh", hname.c_str(), config.m_num_variable_bins_total_collapsed[config.i_prime], 0, config.m_num_variable_bins_total_collapsed[config.i_prime]);
         for(size_t i = 0; i < config.m_num_variable_bins_total_collapsed[config.i_prime]; ++i) {
             post_hist.SetBinContent(i+1, bf.Spec()(i));
             pre_hist.SetBinContent(i+1, cv.Spec()(i));

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1847,10 +1847,18 @@ int main(int argc, char* argv[])
                                         cv_total->SetFillColor(kWhite);
                                         cv_total->SetFillStyle(0);
                                         cv_total->SetTitle((config.m_mode_names[im] + " " + config.m_detector_names[id] + " " + config.m_channel_names[ic] + " DetVar (sec " + std::to_string(sec_idx) + ")").c_str());
-                                        if(binwidth_scale)
-                                            cv_total->GetYaxis()->SetTitle("Events/GeV");
-                                        else
-                                            cv_total->GetYaxis()->SetTitle("Events");
+                                        {
+                                            std::string chan_unit = config.GetChannelUnit(ic, config.i_prime);
+                                            std::string ytitle;
+                                            if(!binwidth_scale) {
+                                                ytitle = "Events";
+                                            } else if(chan_unit.empty()) {
+                                                ytitle = "Events/unit";
+                                            } else {
+                                                ytitle = "Events/" + chan_unit;
+                                            }
+                                            cv_total->GetYaxis()->SetTitle(ytitle.c_str());
+                                        }
 
                                         float ymax = cv_total->GetMaximum();
 
@@ -1975,8 +1983,18 @@ int main(int argc, char* argv[])
                                             cv_total_ov->SetMaximum(ymax_ov * 1.15);
                                             std::string ov_title = config.m_mode_names[im] + " " + config.m_detector_names[id] + " " + config.m_channel_names[ic] + " " + detvar_names[idv] + " (Matched)";
                                             cv_total_ov->SetTitle(ov_title.c_str());
-                                            if(binwidth_scale) cv_total_ov->GetYaxis()->SetTitle("Events/GeV");
-                                            else cv_total_ov->GetYaxis()->SetTitle("Events");
+                                            {
+                                                std::string chan_unit = config.GetChannelUnit(ic, config.i_prime);
+                                                std::string ytitle;
+                                                if(!binwidth_scale) {
+                                                    ytitle = "Events";
+                                                } else if(chan_unit.empty()) {
+                                                    ytitle = "Events/unit";
+                                                } else {
+                                                    ytitle = "Events/" + chan_unit;
+                                                }
+                                                cv_total_ov->GetYaxis()->SetTitle(ytitle.c_str());
+                                            }
 
                                             std::unique_ptr<TLegend> ov_leg = std::make_unique<TLegend>(0.55, 0.75, 0.89, 0.89);
                                             ov_leg->SetFillStyle(0);
@@ -2043,10 +2061,18 @@ int main(int argc, char* argv[])
                             }
                             ++global_subchannel_index;
                         }
-                        if(binwidth_scale )
-                            cv_hist->GetYaxis()->SetTitle("Events/GeV");
-                        else
-                            cv_hist->GetYaxis()->SetTitle("Events");
+                        {
+                            std::string chan_unit = config.GetChannelUnit(ic, config.i_prime);
+                            std::string ytitle;
+                            if(!binwidth_scale) {
+                                ytitle = "Events";
+                            } else if(chan_unit.empty()) {
+                                ytitle = "Events/unit";
+                            } else {
+                                ytitle = "Events/" + chan_unit;
+                            }
+                            cv_hist->GetYaxis()->SetTitle(ytitle.c_str());
+                        }
                         cv_hist->SetTitle((config.m_mode_names[im]  +" "+ config.m_detector_names[id]+" "+ config.m_channel_names[ic]).c_str());
                         cv_hist->GetXaxis()->SetTitle("");
                         cv_hist->SetLineColor(kBlack);
@@ -2227,7 +2253,7 @@ int main(int argc, char* argv[])
                     size_t sbi = config.GetSubchannelIndexFromVariableGlobalBin(bin,config.i_prime);
                     std::string nsubchannel = config.GetSubchannelName(sbi);
                     size_t local_channel_index = config.GetLocalChannelIndexFromGlobalSubchannelIndex(sbi);
-                    std::string chan_units = config.m_channel_variable_units[local_channel_index][config.i_prime];
+                    std::string chan_units = config.GetChannelXAxisTitle(local_channel_index, config.i_prime);
                     int edges_vec_sz = (int)config.m_variable_bin_to_edges[config.i_prime].size();
                     size_t safe_bin = (edges_vec_sz>0) ? std::min((size_t)bin, (size_t)edges_vec_sz-1) : 0;
                     std::pair<float,float> edg = config.m_variable_bin_to_edges[config.i_prime][safe_bin];

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -45,7 +45,8 @@ namespace PROfit {
                 bool step() {
                     Eigen::VectorXf p = proposal(current);
                     float acceptance;
-                    acceptance = proposal.within_bound(p) ? std::min(1.0f, target(p)/target(current) * proposal.P(current, p)/proposal.P(p, current)) : 0;
+                    // Targets return log-density (e.g. -0.5*chi^2); subtract before exp to avoid float32 underflow when chi^2 is large.
+                    acceptance = proposal.within_bound(p) ? std::min(1.0f, std::exp(target(p) - target(current)) * proposal.P(current, p)/proposal.P(p, current)) : 0;
                     float u = uniform(rng);
 
                     if(u <= acceptance) {
@@ -191,27 +192,21 @@ namespace PROfit {
 
     struct simple_target {
         PROmetric &metric;
-        // Reference chi^2 (typically chi^2 at best fit). The exp argument becomes
-        // -0.5*(chi^2 - chi2_ref), keeping it near 0 for typical samples and avoiding
-        // float32 underflow that would occur if chi^2 >> ~170 was exponentiated directly.
-        // The constant cancels in target(p)/target(current), so the sampled distribution
-        // is unchanged.
-        float chi2_ref = 0.0f;
 
+        // Returns log-target (-0.5*chi^2). Metropolis::step does exp(target(p) - target(current))
+        // so the exp argument stays in safe float32 range even when chi^2 is large.
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf empty = value;
-            return std::exp(-0.5f*(metric(value, empty, false) - chi2_ref));
+            return -0.5f*metric(value, empty, false);
         }
     };
 
     struct prior_only_target {
         PROmetric &metric;
-        // Reference Pull (typically Pull at best fit). See note on simple_target::chi2_ref.
-        float pull_ref = 0.0f;
 
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf nuisance = value.segment(metric.GetModel().nparams, metric.GetSysts().GetNSplines());
-            return std::exp(-0.5f*(metric.Pull(nuisance) - pull_ref));
+            return -0.5f*metric.Pull(nuisance);
         }
     };
 

--- a/inc/PROMCMC.h
+++ b/inc/PROMCMC.h
@@ -191,19 +191,27 @@ namespace PROfit {
 
     struct simple_target {
         PROmetric &metric;
+        // Reference chi^2 (typically chi^2 at best fit). The exp argument becomes
+        // -0.5*(chi^2 - chi2_ref), keeping it near 0 for typical samples and avoiding
+        // float32 underflow that would occur if chi^2 >> ~170 was exponentiated directly.
+        // The constant cancels in target(p)/target(current), so the sampled distribution
+        // is unchanged.
+        float chi2_ref = 0.0f;
 
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf empty = value;
-            return std::exp(-0.5f*metric(value, empty, false));
+            return std::exp(-0.5f*(metric(value, empty, false) - chi2_ref));
         }
     };
 
     struct prior_only_target {
         PROmetric &metric;
+        // Reference Pull (typically Pull at best fit). See note on simple_target::chi2_ref.
+        float pull_ref = 0.0f;
 
         float operator()(Eigen::VectorXf &value) {
             Eigen::VectorXf nuisance = value.segment(metric.GetModel().nparams, metric.GetSysts().GetNSplines());
-            return std::exp(-0.5f*metric.Pull(nuisance));
+            return std::exp(-0.5f*(metric.Pull(nuisance) - pull_ref));
         }
     };
 

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -359,10 +359,12 @@ namespace PROfit{
             std::vector<std::string> m_detector_names; 		
             std::vector<std::string> m_detector_plotnames; 		
 
-            std::vector<std::string> m_channel_names; 		
-            std::vector<std::string> m_channel_plotnames; 		
-            std::vector<std::string> m_channel_units; 		
+            std::vector<std::string> m_channel_names;
+            std::vector<std::string> m_channel_plotnames;
+            std::vector<std::string> m_channel_xaxis_labels;
+            std::vector<std::string> m_channel_units;
 
+            std::vector<std::vector<std::string>> m_channel_variable_xaxis_labels;
             std::vector<std::vector<std::string>> m_channel_variable_units;
             std::vector<std::vector<int>> m_channel_variable_dims;
 
@@ -512,6 +514,22 @@ namespace PROfit{
 
             /* Function: given channel index, return list of bin edges for this channel */
             const Binning& GetChannelVariableBins(size_t channel_index, size_t other_index) const;
+
+            /* Function: build the X-axis title for a channel as "label [unit]",
+             * omitting either part if empty. For 2D variables, the legacy
+             * combined "xtitle;ytitle" string in m_channel_variable_units is
+             * returned as-is.
+             */
+            std::string GetChannelXAxisTitle(size_t channel_index) const;
+            std::string GetChannelXAxisTitle(size_t channel_index, size_t other_index) const;
+
+            /* Function: return the unit string for a channel's variable
+             * (e.g. "MeV"), preferring the per-variable <bins unit="..."> entry
+             * and falling back to the channel-level <channel unit="..."> entry.
+             * Returns "" if neither is set, or for 2D variables (whose units
+             * field stores the legacy combined "xtitle;ytitle" string).
+             */
+            std::string GetChannelUnit(size_t channel_index, size_t other_index) const;
 
             /* Function: Hex to int*/
             int HexToROOTColor(const std::string& hexColor) const;

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -378,6 +378,24 @@ namespace PROfit{
             return ebar;
         }
 
+    /**
+     * @brief Produce a 1-sigma summary plot from MCMC results only (no profile scan).
+     * @details Mirrors the post-MCMC pieces of PROfile::Plot's "_1sigma_detailed.pdf":
+     * a gray ±1 prior band, blue post-fit MCMC bars centered on @p best_fit (widths
+     * from @p param_err_lo / @p param_err_hi), red squares for the global best-fit, and
+     * orange diamonds for any injected truth values. Intended to be called between the
+     * MCMC error-band step and the (slow) profile scan.
+     * @param filename     Output prefix; final file is @p filename + "_1sigmaMCMC.pdf".
+     * @param config       Analysis configuration (used for parameter pretty names).
+     * @param systs        PROsyst (provides spline names and count).
+     * @param model        Physics model.
+     * @param best_fit     Best-fit parameter vector (length nphys + nspline).
+     * @param param_err_lo Per-spline lower 1σ from MCMC quantiles (length nspline).
+     * @param param_err_hi Per-spline upper 1σ from MCMC quantiles (length nspline).
+     * @param with_osc     If true, also plot physics parameters; if false, splines only.
+     * @param true_params  Optional injected truth values.
+     */
+    void plot_mcmc_1sigma(const std::string &filename, const PROconfig &config, const PROsyst &systs, const PROmodel &model, const Eigen::VectorXf &best_fit, const Eigen::VectorXf &param_err_lo, const Eigen::VectorXf &param_err_hi, bool with_osc = false, const Eigen::VectorXf &true_params = Eigen::VectorXf());
 
 };
 

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -14,8 +14,49 @@
 #include "TFriendElement.h"
 using namespace PROfit;
 
+namespace {
+    // Trim trailing whitespace from a string (in place).
+    void RTrim(std::string &s) {
+        while(!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) s.pop_back();
+    }
 
-PROconfig::PROconfig(const std::string &xml, bool rate_only): 
+    // Resolve the (label, unit) pair from the optional `xaxislabel` and `unit`
+    // XML attributes. New form: both attributes are passed through. Legacy
+    // form (only `unit` set): if it ends with a trailing "[...]", split into
+    // label = everything before the bracket, unit = bracket contents;
+    // otherwise label = the whole string, unit = "".
+    void ResolveAxisLabelAndUnit(const char* xaxislabel_attr, const char* unit_attr,
+                                 std::string &label_out, std::string &unit_out) {
+        if(xaxislabel_attr != nullptr) {
+            label_out = xaxislabel_attr;
+            unit_out = unit_attr ? unit_attr : "";
+            return;
+        }
+        if(unit_attr == nullptr) {
+            label_out = "";
+            unit_out = "";
+            return;
+        }
+        std::string s(unit_attr);
+        std::string trimmed = s;
+        RTrim(trimmed);
+        if(!trimmed.empty() && trimmed.back() == ']') {
+            auto open = trimmed.rfind('[');
+            if(open != std::string::npos) {
+                std::string label = trimmed.substr(0, open);
+                RTrim(label);
+                unit_out = trimmed.substr(open + 1, trimmed.size() - open - 2);
+                label_out = label;
+                return;
+            }
+        }
+        label_out = s;
+        unit_out = "";
+    }
+}
+
+
+PROconfig::PROconfig(const std::string &xml, bool rate_only):
     m_xmlname(xml), 
     m_det_pot(),
     m_num_detectors(0),
@@ -276,7 +317,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
         exit(EXIT_FAILURE);
     }else{
 
-        std::vector<std::string> expected_attrs = {"name","plotname","use","unit"};
+        std::vector<std::string> expected_attrs = {"name","plotname","use","unit","xaxislabel"};
         for (const tinyxml2::XMLAttribute* attr = pChan->FirstAttribute(); attr; attr = attr->Next()) {
             std::string name = attr->Name();
             if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -315,16 +356,19 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 m_channel_bool.push_back(false);
 
 
+            const char* channel_xaxislabel = pChan->Attribute("xaxislabel");
             const char* channel_unit= pChan->Attribute("unit");
-            if(channel_unit==NULL){
-                m_channel_units.push_back("");
-            }else{
-                m_channel_units.push_back(channel_unit);
+            {
+                std::string label, unit;
+                ResolveAxisLabelAndUnit(channel_xaxislabel, channel_unit, label, unit);
+                m_channel_xaxis_labels.push_back(label);
+                m_channel_units.push_back(unit);
             }
 
             log<LOG_DEBUG>(L"%1% || Loading Channel %2% with   ") % __func__ % m_channel_names.back().c_str() ;
 
             m_channel_variable_bins.push_back({});
+            m_channel_variable_xaxis_labels.push_back({});
             m_channel_variable_units.push_back({});
             m_channel_variable_dims.push_back({});
 
@@ -348,6 +392,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                         (omin_y == NULL && omax_y == NULL && onbins_y == NULL && oedges_y == NULL)) {
                     log<LOG_DEBUG>(L"%1% || This variable has a NO other binning (or attribute min,max,nbins)  ") % __func__ ;
                     m_channel_variable_bins.back().push_back(PROconfig::Binning());
+                    m_channel_variable_xaxis_labels.back().push_back("");
                     m_channel_variable_units.back().push_back("");
                     m_channel_variable_dims.back().push_back(2);
                     m_channel_variable_plot_bool.push_back(true);
@@ -405,6 +450,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     }
 
                     m_channel_variable_bins.back().push_back(PROconfig::Binning(std::vector<std::vector<float>>({binedge_x, binedge_y})));
+                    m_channel_variable_xaxis_labels.back().push_back("");
                     m_channel_variable_units.back().push_back(ounits ? ounits : "");
                     m_channel_variable_dims.back().push_back(2);
                 }
@@ -414,7 +460,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
             tinyxml2::XMLElement *pBinO = pChan->FirstChildElement("bins"); // 1D Bins
             while(pBinO){
-                expected_attrs = {"min","max","nbins","edges","unit","plot"};
+                expected_attrs = {"min","max","nbins","edges","unit","xaxislabel","plot"};
                 for (const tinyxml2::XMLAttribute* attr = pBinO->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -429,10 +475,12 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char* onbins = pBinO->Attribute("nbins");
                 const char* oedges = pBinO->Attribute("edges");
                 const char* ounits = pBinO->Attribute("unit");
+                const char* oxaxislabel = pBinO->Attribute("xaxislabel");
                 const char* oplot = pBinO->Attribute("plot");
                 if(omin==NULL && omax==NULL && onbins==NULL && oedges == NULL) {
                     log<LOG_DEBUG>(L"%1% || This variable has a NO other binning (or attribute min,max,nbins)  ") % __func__ ;
                     m_channel_variable_bins.back().push_back(PROconfig::Binning());
+                    m_channel_variable_xaxis_labels.back().push_back("");
                     m_channel_variable_units.back().push_back("");
                     m_channel_variable_dims.back().push_back(1);
                     m_channel_variable_plot_bool.push_back(true);
@@ -469,7 +517,12 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     }
 
                     m_channel_variable_bins.back().push_back({binedge});
-                    m_channel_variable_units.back().push_back(ounits ? ounits : "");
+                    {
+                        std::string label, unit;
+                        ResolveAxisLabelAndUnit(oxaxislabel, ounits, label, unit);
+                        m_channel_variable_xaxis_labels.back().push_back(label);
+                        m_channel_variable_units.back().push_back(unit);
+                    }
                     m_channel_variable_dims.back().push_back(1);
                 }
                 pBinO = pBinO->NextSiblingElement("bins");
@@ -1846,6 +1899,51 @@ const PROconfig::Binning& PROconfig::GetChannelVariableBins(size_t channel_index
     return m_channel_variable_bins[GetLocalChannelIndexFromGlobalChannelIndex(channel_index)][other_index];
 }
 
+namespace {
+    std::string FormatLabelUnit(const std::string &label, const std::string &unit) {
+        if(label.empty() && unit.empty()) return "";
+        if(unit.empty()) return label;
+        if(label.empty()) return "[" + unit + "]";
+        return label + " [" + unit + "]";
+    }
+}
+
+std::string PROconfig::GetChannelXAxisTitle(size_t channel_index) const {
+    if(channel_index >= m_channel_units.size()) return "";
+    return FormatLabelUnit(m_channel_xaxis_labels[channel_index], m_channel_units[channel_index]);
+}
+
+std::string PROconfig::GetChannelXAxisTitle(size_t channel_index, size_t other_index) const {
+    if(channel_index >= m_channel_variable_units.size()) return "";
+    if(other_index >= m_channel_variable_units[channel_index].size()) return "";
+    // 2D variables keep the legacy combined "xtitle;ytitle" string.
+    if(channel_index < m_channel_variable_dims.size() &&
+       other_index < m_channel_variable_dims[channel_index].size() &&
+       m_channel_variable_dims[channel_index][other_index] == 2) {
+        return m_channel_variable_units[channel_index][other_index];
+    }
+    return FormatLabelUnit(m_channel_variable_xaxis_labels[channel_index][other_index],
+                           m_channel_variable_units[channel_index][other_index]);
+}
+
+std::string PROconfig::GetChannelUnit(size_t channel_index, size_t other_index) const {
+    // 2D variables keep the legacy combined "xtitle;ytitle" string in their
+    // units slot, so it isn't a real unit -- skip straight to the channel-level.
+    bool is_2d = (channel_index < m_channel_variable_dims.size() &&
+                  other_index < m_channel_variable_dims[channel_index].size() &&
+                  m_channel_variable_dims[channel_index][other_index] == 2);
+    if(!is_2d &&
+       channel_index < m_channel_variable_units.size() &&
+       other_index < m_channel_variable_units[channel_index].size() &&
+       !m_channel_variable_units[channel_index][other_index].empty()) {
+        return m_channel_variable_units[channel_index][other_index];
+    }
+    if(channel_index < m_channel_units.size()) {
+        return m_channel_units[channel_index];
+    }
+    return "";
+}
+
 //------------ Start of private function ------------------
 //------------ Start of private function ------------------
 //------------ Start of private function ------------------
@@ -1899,15 +1997,19 @@ void PROconfig::remove_unused_channel(){
         std::vector<std::string> temp_channel_names(m_num_channels);
         std::vector<std::vector<int>> temp_variable_dims(m_num_channels);
         std::vector<std::string> temp_channel_plotnames(m_num_channels);
+        std::vector<std::string> temp_channel_xaxis_labels(m_num_channels);
         std::vector<std::string> temp_channel_units(m_num_channels);
+        std::vector<std::vector<std::string>> temp_channel_other_xaxis_labels(m_num_channels);
         std::vector<std::vector<std::string>> temp_channel_other_units(m_num_channels);
         for(size_t i=0, chan_index = 0; i< m_channel_bool.size(); ++i){
             if(m_channel_bool[i]){
                 temp_channel_names[chan_index] = m_channel_names[i];
                 temp_channel_plotnames[chan_index] = m_channel_plotnames[i];
+                temp_channel_xaxis_labels[chan_index] = m_channel_xaxis_labels[i];
                 temp_channel_units[chan_index] = m_channel_units[i];
 
                 temp_channel_other_bins[chan_index] = m_channel_variable_bins[i];
+                temp_channel_other_xaxis_labels[chan_index] = m_channel_variable_xaxis_labels[i];
                 temp_channel_other_units[chan_index] = m_channel_variable_units[i];
 
                 ++chan_index;
@@ -1916,6 +2018,7 @@ void PROconfig::remove_unused_channel(){
 
         m_channel_names = temp_channel_names;
         m_channel_plotnames = temp_channel_plotnames;
+        m_channel_xaxis_labels = temp_channel_xaxis_labels;
         m_channel_units = temp_channel_units;
     }
 

--- a/src/PROdata.cxx
+++ b/src/PROdata.cxx
@@ -51,7 +51,7 @@ TH1D PROdata::toTH1D(const PROconfig &inconfig, int global_channel_index, int ot
     int nbins_dim = inconfig.m_channel_variable_bins[local_channel_index][other_index].NBinsAlong(dim);
     std::vector<float> bin_edges =  inconfig.m_channel_variable_bins[local_channel_index][other_index].Edges();
     std::string hist_name = inconfig.m_channel_names[local_channel_index] + " Data";
-    std::string xaxis_title =  inconfig.m_channel_variable_units[local_channel_index][other_index];
+    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(local_channel_index, other_index);
 
 
     //fill 1D hist
@@ -258,7 +258,7 @@ void PROdata::plotSpectrum(const PROconfig& inconfig, const std::string& output_
                 }
 
                 hists.back()->SetTitle((inconfig.m_mode_names[im]  +" "+ inconfig.m_detector_names[id]+" "+ inconfig.m_channel_names[ic]).c_str());
-                hists.back()->GetXaxis()->SetTitle(inconfig.m_channel_units[ic].c_str());
+                hists.back()->GetXaxis()->SetTitle(inconfig.GetChannelXAxisTitle(ic).c_str());
                 hists.back()->GetYaxis()->SetTitle("Events");
                 hists.back()->Draw("hist");
                 ++global_channel_index;

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -1,5 +1,12 @@
 #include "PROplot.h"
 #include "TStyle.h"
+#include "TArrow.h"
+#include "TBox.h"
+#include "TH1F.h"
+#include "TLatex.h"
+#include "TLegend.h"
+#include "TMarker.h"
+#include "TText.h"
 #include <cmath>
 #include <Eigen/SVD>
 
@@ -1984,4 +1991,179 @@ namespace PROfit{
         c.Print((filename+"]").c_str());
         return 0;
     };
+
+    void plot_mcmc_1sigma(const std::string &filename, const PROconfig &config, const PROsyst &systs, const PROmodel &model, const Eigen::VectorXf &best_fit, const Eigen::VectorXf &param_err_lo, const Eigen::VectorXf &param_err_hi, bool with_osc, const Eigen::VectorXf &true_params) {
+        const int nBins = (int)systs.GetNSplines() + (with_osc ? (int)model.nparams : 0);
+        if(nBins == 0) {
+            log<LOG_WARNING>(L"%1% || No parameters to plot, skipping _1sigmaMCMC.pdf") % __func__;
+            return;
+        }
+
+        std::vector<std::string> names;
+        if(with_osc) for(const auto &n: model.pretty_param_names) names.push_back(n);
+        for(const auto &n: systs.spline_names) names.push_back(n);
+
+        std::vector<float> bfvalues(nBins, 0.0f);
+        for(int i = 0; i < nBins; ++i) {
+            int vec_idx = with_osc ? i : (i + (int)model.nparams);
+            if(vec_idx < (int)best_fit.size()) bfvalues[i] = (float)best_fit(vec_idx);
+        }
+
+        // Y range: cover post-fit bars, always show ±1
+        float minVal = -1.2f, maxVal = 1.2f;
+        for(int i = 0; i < nBins; ++i) {
+            int syst_idx = with_osc ? (i - (int)model.nparams) : i;
+            if(syst_idx >= 0 && syst_idx < (int)param_err_lo.size() && syst_idx < (int)param_err_hi.size()) {
+                minVal = std::min(minVal, bfvalues[i] - param_err_lo(syst_idx));
+                maxVal = std::max(maxVal, bfvalues[i] + param_err_hi(syst_idx));
+            }
+        }
+        // Clamp to ±5 so a runaway bar doesn't squash everything
+        minVal = std::max(minVal, -5.0f);
+        maxVal = std::min(maxVal,  5.0f);
+        const float y_axis_min = minVal * 1.15f;
+        const float y_axis_max = maxVal * 1.15f;
+        const float y_range_size = y_axis_max - y_axis_min;
+        const float arrow_margin = y_range_size * 0.07f;
+        const float arrow_length = y_range_size * 0.05f;
+
+        const int c_width  = std::max(600, std::min(5000, 50 * nBins));
+        const int c_height = 500;
+        const float axis_label_size = std::max(0.030f, std::min(0.045f, 1.8f / nBins));
+        const float x_label_size    = std::max(0.015f, std::min(0.030f, 1.2f / nBins));
+        const float bar_halfwidth   = std::max(0.08f, std::min(0.4f,  4.0f / nBins));
+        const float marker_offset   = bar_halfwidth * 0.6f;
+        const float marker_size     = std::max(0.5f, std::min(1.4f, 6.0f / std::sqrt((float)nBins)));
+
+        TCanvas *c = new TCanvas((filename+"1sigmaMCMC").c_str(), (filename+"1sigmaMCMC").c_str(), c_width, c_height);
+        c->cd();
+        c->SetLeftMargin(0.09);
+        c->SetBottomMargin(0.30);
+        c->SetRightMargin(0.28);
+        c->SetTopMargin(0.08);
+
+        TH1F *frame = new TH1F((filename+"_frame_mcmc1s").c_str(), "", nBins, 0, nBins);
+        frame->SetMinimum(y_axis_min);
+        frame->SetMaximum(y_axis_max);
+        frame->SetStats(0);
+        frame->GetXaxis()->SetLabelSize(0);
+        frame->GetXaxis()->SetTickLength(0);
+        frame->GetYaxis()->SetTitle("Parameter value (prior #kern[0.3]{} #sigma = 1)");
+        frame->GetYaxis()->SetTitleSize(axis_label_size);
+        frame->GetYaxis()->SetLabelSize(axis_label_size);
+        frame->GetYaxis()->SetTitleOffset(1.0);
+        frame->Draw("AXIS");
+
+        TBox *prior_band = new TBox(0.0f, -1.0f, (float)nBins, 1.0f);
+        prior_band->SetFillColor(kGray);
+        prior_band->SetFillStyle(1001);
+        prior_band->SetLineColor(kGray+1);
+        prior_band->SetLineWidth(1);
+        prior_band->Draw("same");
+
+        TGraphAsymmErrors *postbars = new TGraphAsymmErrors(nBins);
+        for(int i = 0; i < nBins; ++i) {
+            int syst_idx = with_osc ? (i - (int)model.nparams) : i;
+            float err_lo = 0.0f, err_hi = 0.0f;
+            if(syst_idx >= 0 && syst_idx < (int)param_err_lo.size() && syst_idx < (int)param_err_hi.size()) {
+                err_lo = param_err_lo(syst_idx);
+                err_hi = param_err_hi(syst_idx);
+            }
+            postbars->SetPoint(i, i + 0.5f, bfvalues[i]);
+            postbars->SetPointError(i, bar_halfwidth, bar_halfwidth, err_lo, err_hi);
+        }
+        postbars->SetFillColor(kBlue-7);
+        postbars->SetFillStyle(1001);
+        postbars->SetLineColor(kBlue-8);
+        postbars->SetLineWidth(1);
+        postbars->Draw("2 same");
+
+        TLine *l_zero = new TLine(0, 0, nBins, 0);
+        l_zero->SetLineStyle(2); l_zero->SetLineColor(kGray+2); l_zero->SetLineWidth(1);
+        l_zero->Draw();
+        TLine *l_pm1 = new TLine(0, 1, nBins, 1);
+        l_pm1->SetLineStyle(3); l_pm1->SetLineColor(kGray+2); l_pm1->SetLineWidth(1);
+        l_pm1->Draw();
+        TLine *l_mm1 = new TLine(0, -1, nBins, -1);
+        l_mm1->SetLineStyle(3); l_mm1->SetLineColor(kGray+2); l_mm1->SetLineWidth(1);
+        l_mm1->Draw();
+
+        auto drawMarkerWithArrow = [&](float x, float y, int color, int marker_style, float msize) {
+            bool clamp_below = y < -5.0f;
+            bool clamp_above = y >  5.0f;
+            if(!clamp_below && !clamp_above && (y < y_axis_min || y > y_axis_max)) return;
+            float draw_y = clamp_below ? y_axis_min + arrow_margin : (clamp_above ? y_axis_max - arrow_margin : y);
+            TMarker *m = new TMarker(x, draw_y, marker_style);
+            m->SetMarkerSize(msize); m->SetMarkerColor(color); m->Draw();
+            if(clamp_below) {
+                TArrow *a = new TArrow(x, draw_y - arrow_length*0.3f, x, y_axis_min + arrow_length*0.2f, 0.008, "|>");
+                a->SetLineColor(color); a->SetFillColor(color); a->SetLineWidth(1); a->Draw();
+            } else if(clamp_above) {
+                TArrow *a = new TArrow(x, draw_y + arrow_length*0.3f, x, y_axis_max - arrow_length*0.2f, 0.008, "|>");
+                a->SetLineColor(color); a->SetFillColor(color); a->SetLineWidth(1); a->Draw();
+            }
+        };
+
+        for(int i = 0; i < nBins; ++i) {
+            int vec_idx = with_osc ? i : (i + (int)model.nparams);
+            float x_center = i + 0.5f;
+            if(vec_idx < (int)best_fit.size()) {
+                drawMarkerWithArrow(x_center - marker_offset, (float)best_fit(vec_idx), kRed, 21, marker_size);
+            }
+            if(vec_idx < (int)true_params.size()) {
+                drawMarkerWithArrow(x_center + marker_offset, (float)true_params(vec_idx), kOrange+7, 33, marker_size * 1.1f);
+            }
+        }
+
+        const float label_y = y_axis_min - y_range_size * 0.04f;
+        for(int i = 0; i < nBins; ++i) {
+            std::string label;
+            if(with_osc && i < (int)model.nparams) {
+                label = "Log_{10}(" + model.pretty_param_names[i] + ")";
+            } else {
+                auto it = config.m_mcgen_variation_plotname_map.find(names[i]);
+                label = (it != config.m_mcgen_variation_plotname_map.end()) ? it->second : names[i];
+            }
+            TLatex *t = new TLatex(i + 0.5f, label_y, label.c_str());
+            t->SetTextAlign(13);
+            t->SetTextSize(x_label_size);
+            t->SetTextAngle(-45);
+            t->Draw();
+        }
+
+        TLegend *leg = new TLegend(0.73, 0.60, 0.99, 0.92);
+        leg->SetFillStyle(1001);
+        leg->SetBorderSize(1);
+        leg->SetTextSize(std::max(0.022f, std::min(0.030f, axis_label_size * 0.85f)));
+        leg->AddEntry(prior_band, "Pre-fit #pm1#sigma (prior)", "f");
+        leg->AddEntry(postbars,    "Post-fit #pm1#sigma (MCMC)", "f");
+        TGraph *leg_bf = new TGraph(1);
+        leg_bf->SetPoint(0, 0, 0);
+        leg_bf->SetMarkerStyle(21);
+        leg_bf->SetMarkerColor(kRed);
+        leg_bf->SetMarkerSize(marker_size);
+        leg->AddEntry(leg_bf, "Global best-fit", "p");
+        TGraph *leg_tp = nullptr;
+        if(true_params.size() > 0) {
+            leg_tp = new TGraph(1);
+            leg_tp->SetPoint(0, 0, 0);
+            leg_tp->SetMarkerStyle(33);
+            leg_tp->SetMarkerColor(kOrange+7);
+            leg_tp->SetMarkerSize(marker_size * 1.1f);
+            leg->AddEntry(leg_tp, "Injected values", "p");
+        }
+        leg->Draw();
+
+        TText *vt = new TText();
+        vt->SetNDC();
+        vt->SetTextFont(42);
+        vt->SetTextSize(0.028f);
+        vt->SetTextAlign(33);
+        std::string pv = "PROfit v" + std::string(PROJECT_VERSION_STR);
+        vt->DrawText(0.96, 0.97, pv.c_str());
+
+        c->Update();
+        c->SaveAs((filename+"_1sigmaMCMC.pdf").c_str(), "pdf");
+        delete c;
+    }
 }

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -49,6 +49,7 @@ namespace PROfit{
                         const std::string& color = inconfig.m_subchannel_colors[ic][sc];
                         int rcolor = color == "NONE" ? kRed - 7 : inconfig.HexToROOTColor(color);
                         std::unique_ptr<TH1D> htmp = std::make_unique<TH1D>(spec.toTH1D(inconfig, global_subchannel_index, other_index));
+                        htmp->SetDirectory(nullptr);  // copy ctor re-registers with gDirectory; detach to avoid name-collision warnings on repeated calls.
                         htmp->SetLineWidth(1);
                         htmp->SetLineColor(kBlack);
                         htmp->SetFillColor(rcolor);
@@ -56,6 +57,7 @@ namespace PROfit{
                         hists[subchannel_name] = std::move(htmp);
                         std::unique_ptr<TH1D> htmp_slc = std::make_unique<TH1D>(spec.toTH1DSlices(inconfig, global_subchannel_index, other_index));
                         if(htmp_slc){
+                            htmp_slc->SetDirectory(nullptr);
                             hists[subchannel_name+"slc"] = std::move(htmp_slc);
                         }
                         ++global_subchannel_index;
@@ -76,6 +78,7 @@ namespace PROfit{
                     for(size_t sc = 0; sc < inconfig.m_num_subchannels[ic]; sc++){
                         const std::string& subchannel_name  = inconfig.m_fullnames[global_subchannel_index];
                         std::unique_ptr<TH2D> htmp = std::make_unique<TH2D>(spec.toTH2D(inconfig, global_subchannel_index, other_index));
+                        htmp->SetDirectory(nullptr);  // copy ctor re-registers with gDirectory; detach to avoid name-collision warnings on repeated calls.
                         if(scale) htmp->Scale(1,"width");
                         hists[subchannel_name] = std::move(htmp);
                         ++global_subchannel_index;

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -940,12 +940,6 @@ namespace PROfit{
         log<LOG_DEBUG>(L"%1% || Starting plot_channels") % __func__;
         std::string rat_y_title = bool(opt&PlotOptions::DataMCRatio) ? "Data/MC" : "Data/Best-Fit";
 
-        std::string ytitle = bool(opt&PlotOptions::AreaNormalized)
-            ? "Area Normalized"
-            : bool(opt&PlotOptions::BinWidthScaled) 
-            ? "Events/GeV" 
-            : "Events";
-
         TCanvas c;
         c.Print((filename+"[").c_str());
 
@@ -978,8 +972,22 @@ namespace PROfit{
 
                     log<LOG_DEBUG>(L"%1% || channel %2%") % __func__ % channel;
 
-                    std::string xtitle = config.m_channel_variable_units[channel][other_index];
+                    std::string xtitle = config.GetChannelXAxisTitle(channel, other_index);
                     std::string ratio_titles = ";"+xtitle+";"+rat_y_title;
+
+                    std::string chan_unit = config.GetChannelUnit(channel, other_index);
+                    std::string ytitle;
+                    if(bool(opt&PlotOptions::AreaNormalized)) {
+                        ytitle = "Area Normalized";
+                    } else if(bool(opt&PlotOptions::BinWidthScaled)) {
+                        if(chan_unit.empty()) {
+                            ytitle = "Events/unit";
+                        } else {
+                            ytitle = "Events/" + chan_unit;
+                        }
+                    } else {
+                        ytitle = "Events";
+                    }
 
                     size_t channel_nbins_x = config.m_channel_variable_bins[channel][other_index].NBinsAlong(0);
 
@@ -1845,7 +1853,7 @@ namespace PROfit{
                                 int color_idx = i % colors.size();
                                 int style_idx = (i / 4) % line_styles.size();  
                                 i++;
-                                TH1F* h = new TH1F((tag+"_Channel_"+std::to_string(global_channel_index)+"_"+std::to_string(i)).c_str(), (tag + ";" + config.m_channel_variable_units[channel][other_index]).c_str(), bin_edges.size()-1, bin_edges.data());
+                                TH1F* h = new TH1F((tag+"_Channel_"+std::to_string(global_channel_index)+"_"+std::to_string(i)).c_str(), (tag + ";" + config.GetChannelXAxisTitle(channel, other_index)).c_str(), bin_edges.size()-1, bin_edges.data());
 
                                 if(config.m_channel_variable_dims[channel][other_index] == 2) {
                                     channel_nbins_y = config.m_channel_variable_bins[channel][other_index].NBinsAlong(1);
@@ -1903,7 +1911,7 @@ namespace PROfit{
                             log<LOG_INFO>(L"%1% || hsum for tag '%2%': nbins=%3%, max=%4%, integral=%5%")
                                 % __func__ % tag.c_str() % hsum->GetNbinsX() % hsum->GetMaximum() % hsum->Integral();
 
-                            hsum->SetXTitle((config.m_detector_plotnames[det]+"/"+config.m_detector_plotnames[det2]+" "+config.m_channel_variable_units[channel][other_index]).c_str());
+                            hsum->SetXTitle((config.m_detector_plotnames[det]+"/"+config.m_detector_plotnames[det2]+" "+config.GetChannelXAxisTitle(channel, other_index)).c_str());
                             hsum->SetYTitle("Fractional Uncertainty");
                             hsum->SetLineColor(kBlack);
                             hsum->SetLineWidth(2);
@@ -1958,7 +1966,7 @@ namespace PROfit{
                             hsum->SetBinContent(i+1, sqrt(hsum->GetBinContent(i+1)));
                         }
                         leg->AddEntry(hsum,"Sum","l");
-                        hsum->SetXTitle((config.m_detector_plotnames[det]+"/"+config.m_detector_plotnames[det2]+" "+config.m_channel_variable_units[channel][other_index]).c_str());
+                        hsum->SetXTitle((config.m_detector_plotnames[det]+"/"+config.m_detector_plotnames[det2]+" "+config.GetChannelXAxisTitle(channel, other_index)).c_str());
                         hsum->SetTitle(("Summary: "+name).c_str());
                         hsum->SetYTitle("Fractional Uncertainty");
                         hsum->SetLineColor(kBlack);

--- a/src/PROspec.cxx
+++ b/src/PROspec.cxx
@@ -108,7 +108,8 @@ TH1D PROspec::toTH1DSlices(PROconfig const & inconfig, int subchannel_index, int
     std::string xaxis_title =  inconfig.m_channel_variable_units[channel_index][other_index];
 
     //fill 1D hist
-    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]); 
+    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]);
+    hSpec.SetDirectory(nullptr);  // detach from gDirectory; multiple calls reuse names and would otherwise warn.
     hSpec.GetXaxis()->SetTitle(xaxis_title.c_str());
 
     if(inconfig.m_channel_variable_dims[channel_index][other_index] == 2){
@@ -141,7 +142,8 @@ TH1D PROspec::toTH1D(PROconfig const & inconfig, int subchannel_index, int other
     Eigen::VectorXf error_proj = inconfig.m_channel_variable_bins[channel_index][other_index].ProjectSpectraErrors(error(Eigen::seqN(global_bin_start, nbins_tot)), dim);
 
     //fill 1D hist
-    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]); 
+    TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]);
+    hSpec.SetDirectory(nullptr);  // detach from gDirectory; multiple calls reuse names and would otherwise warn.
     hSpec.GetXaxis()->SetTitle(xaxis_title.c_str());
 
     for(int i = 1; i <= nbins_dim; ++i){
@@ -171,6 +173,7 @@ TH2D PROspec::toTH2D(PROconfig const & inconfig, int subchannel_index, int other
     Eigen::VectorXf spec_2d = spec(Eigen::seqN(global_bin_start, nbins_tot));
 
     TH2D hSpec(hist_name.c_str(),hist_name.c_str(), channel_nbins_x, edges_x.data(), channel_nbins_y, edges_y.data());
+    hSpec.SetDirectory(nullptr);  // detach from gDirectory; multiple calls reuse names and would otherwise warn.
     hSpec.GetXaxis()->SetTitle(xaxis_title.c_str());
 
     for(int xbin = 0; xbin < (int)channel_nbins_x; xbin++){

--- a/src/PROspec.cxx
+++ b/src/PROspec.cxx
@@ -78,7 +78,7 @@ TH1D PROspec::toTH1D_Collapsed(const PROconfig &inconfig, int channel_index, siz
     int nbins_dim = inconfig.m_channel_variable_bins[channel_index][var_index].NBinsAlong(dim);
     std::vector<float> bin_edges = inconfig.m_channel_variable_bins[channel_index][var_index].Edges(dim);
     std::string hist_name = inconfig.m_channel_names[channel_index];
-    std::string xaxis_title = inconfig.m_channel_units[channel_index];
+    std::string xaxis_title = inconfig.GetChannelXAxisTitle(channel_index);
 
     Eigen::VectorXf coll_spec = CollapseMatrix(inconfig,spec)(Eigen::seqN(global_bin_start, nbins_tot));
     //Eigen::VectorXf coll_error = CollapseMatrix(inconfig,error);
@@ -105,7 +105,7 @@ TH1D PROspec::toTH1DSlices(PROconfig const & inconfig, int subchannel_index, int
     int nbins_dim = inconfig.m_channel_variable_bins[channel_index][other_index].NBinsAlong(dim);
     std::vector<float> bin_edges = inconfig.m_channel_variable_bins[channel_index][other_index].Edges(dim);
     std::string hist_name = inconfig.m_fullnames[subchannel_index];
-    std::string xaxis_title =  inconfig.m_channel_variable_units[channel_index][other_index];
+    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(channel_index, other_index);
 
     //fill 1D hist
     TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]);
@@ -134,7 +134,7 @@ TH1D PROspec::toTH1D(PROconfig const & inconfig, int subchannel_index, int other
     int nbins_dim = inconfig.m_channel_variable_bins[channel_index][other_index].NBinsAlong(dim);
     std::vector<float> bin_edges = inconfig.m_channel_variable_bins[channel_index][other_index].Edges(dim);
     std::string hist_name = inconfig.m_fullnames[subchannel_index];
-    std::string xaxis_title =  inconfig.m_channel_variable_units[channel_index][other_index];
+    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(channel_index, other_index);
 
 
     // project along input dimension
@@ -161,7 +161,7 @@ TH2D PROspec::toTH2D(PROconfig const & inconfig, int subchannel_index, int other
     //set up hist specs
     std::vector<float> bin_edges = inconfig.m_channel_variable_bins[channel_index][other_index].Edges(dim);
     std::string hist_name = inconfig.m_fullnames[subchannel_index];
-    std::string xaxis_title =  inconfig.m_channel_variable_units[channel_index][other_index];
+    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(channel_index, other_index);
 
     // 2D binning info
     size_t channel_nbins_x = inconfig.m_channel_variable_bins[channel_index][other_index].NBinsAlong(0);
@@ -437,7 +437,7 @@ void PROspec::plotSpectrum(const PROconfig& inconfig, const std::string& output_
 
                 if(collapsed) {
                     hists.back()->SetTitle((inconfig.m_mode_names[im]  +" "+ inconfig.m_detector_names[id]+" "+ inconfig.m_channel_names[ic]).c_str());
-                    hists.back()->GetXaxis()->SetTitle(inconfig.m_channel_units[ic].c_str());
+                    hists.back()->GetXaxis()->SetTitle(inconfig.GetChannelXAxisTitle(ic).c_str());
                     hists.back()->GetYaxis()->SetTitle("Events");
                     hists.back()->Draw("hist");
                 } else {
@@ -447,8 +447,15 @@ void PROspec::plotSpectrum(const PROconfig& inconfig, const std::string& output_
                     legs.back()->Draw();
 
                     stacks.back()->SetTitle((inconfig.m_mode_names[im]  +" "+ inconfig.m_detector_names[id]+" "+ inconfig.m_channel_names[ic]).c_str());
-                    stacks.back()->GetXaxis()->SetTitle(inconfig.m_channel_units[ic].c_str());
-                    stacks.back()->GetYaxis()->SetTitle("Events/GeV");
+                    stacks.back()->GetXaxis()->SetTitle(inconfig.GetChannelXAxisTitle(ic).c_str());
+                    std::string chan_unit = inconfig.GetChannelUnit(ic, inconfig.i_prime);
+                    std::string ytitle;
+                    if(chan_unit.empty()) {
+                        ytitle = "Events/unit";
+                    } else {
+                        ytitle = "Events/" + chan_unit;
+                    }
+                    stacks.back()->GetYaxis()->SetTitle(ytitle.c_str());
                 }
 
                 ++global_channel_index;


### PR DESCRIPTION
Updates to the xml parsing and --scale-by-width plotting to understand the units when labeling the y-axis with "events/MeV" or another unit. Backwards compatible with existing xmls.

Old pattern: `<bins unit="Reconstructed Neutrino Energy [MeV]" edges="0 200 300 400 500 600 700 800 900 1000 1200 2000"/>`

New pattern: `<bins xaxislabel="Reconstructed Neutrino Energy" unit="MeV" edges="0 200 300 400 500 600 700 800 900 1000 1200 2000"/>`

Built on top of PR #417, minimal diff: https://github.com/leehagaman/PROfit/compare/more_mcmc_tweaks...leehagaman:PROfit:xml_unit

