### PR TITLE
Fix seg fault when we don't want to plot fit var

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -721,7 +721,7 @@ int main(int argc, char* argv[])
     std::vector<PROsyst> variable_systs;
     for(size_t i = 0; i < config.m_num_variables; ++i){
 
-        if(config.m_channel_variable_plot_bool.at(i)){ 
+        if(config.m_channel_variable_plot_bool.at(i) || i == config.i_prime){ 
             variable_systs.emplace_back(prop, config, systsstructs.at(i), shapeonly, i, model.get(), nullptr);
         }else{
             variable_systs.emplace_back();


### PR DESCRIPTION
A bit of a niche case, but one analyzer noticed this and it's an easy fix.
NOTE: This only affects plot and not other subcommands. I think profile and global will still plot the fit variable even if `plot="false"` is on.