### PR TITLE
Save Error Bands as TGraphAsymmErrors in root file outputs

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -2229,13 +2229,36 @@ int main(int argc, char* argv[])
         for(const auto &[name, mat]: matrices)
             mat->Write(name.c_str());
 
-        //fout.mkdir("ErrorBand");
-        //fout.cd("ErrorBand");
-        //err_band->Write("err_band");
-        //io = 0;
-        //for(const auto &band: other_err_bands)
-        //band->Write(("other_"+std::to_string(io++)+"_err_band").c_str());
-
+        fout.mkdir("ErrorBand");
+        fout.cd("ErrorBand");
+        for(size_t io = 0; io < config.m_num_variables; ++io) {
+            if(!config.m_channel_variable_plot_bool.at(io))continue;// For now skip the L/E 250 bin. 
+            size_t tot_offset = 0;
+            const PROerrorbar &err = other_err_bands[io];
+            for(size_t mode = 0; mode < config.m_num_modes; ++mode) {
+                for(size_t det = 0; det < config.m_num_detectors; ++det) {
+                    for(size_t channel = 0; channel < config.m_num_channels; ++channel) {
+                        size_t channel_nbins_x = config.m_channel_variable_bins[channel][io].NBinsAlong(0);
+                        // default is 1d, but catch 2d case for ybins
+                        size_t channel_nbins_y = 1;
+                        if(config.m_channel_variable_dims[channel][io] == 2)  channel_nbins_y = config.m_channel_variable_bins[channel][io].NBinsAlong(1);
+                        size_t nbins_p_2dchan = channel_nbins_y*channel_nbins_x;
+                        TGraphAsymmErrors eband(nbins_p_2dchan);
+                        for(size_t i = 0; i < nbins_p_2dchan; ++i) {
+                            float x = channel_nbins_y == 1 ? 
+                                (config.m_channel_variable_bins[channel][io].Edges(0)[i+1] - config.m_channel_variable_bins[channel][io].Edges(0)[i])/2 :
+                                i;
+                            eband.SetPoint(i, x, err.error_point(tot_offset + i));
+                            eband.SetPointEYhigh(i, err.error_up(tot_offset + i));
+                            eband.SetPointEYlow(i, err.error_down(tot_offset + i));
+                        }
+                        std::string name = config.m_mode_names[mode]+"_"+config.m_detector_names[det]+"_"+config.m_channel_names[channel]+"_var"+std::to_string(io);
+                        eband.Write(name.c_str());
+                        tot_offset += nbins_p_2dchan;
+                    }
+                }
+            }
+        }
 
         if((with_splines)) {
             std::map<std::string, std::vector<std::pair<std::unique_ptr<TGraph>,std::unique_ptr<TGraph>>>> spline_graphs = getSplineGraphs(variable_systs[config.i_prime], config);

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -2138,7 +2138,7 @@ int main(int argc, char* argv[])
 
         std::vector<PROerrorbar> other_err_bands;
         for(size_t io = 0; io < config.m_num_variables; ++io) {
-            if(!config.m_channel_variable_plot_bool.at(io))continue;// For now skip the L/E 250 bin. 
+            if(!config.m_channel_variable_plot_bool.at(io)) continue; // For now skip the L/E 250 bin. 
             other_err_bands.push_back(getErrorBand(config, prop, variable_systs[io], *model, variable_cvs[io], CVParams, binwidth_scale, io));
             plot_channels(final_output_tag+"_PROplot_Variable_"+std::to_string(io)+"_ErrorBand.pdf", config, variable_cvs[io], {}, variable_data[io], 
                     other_err_bands.back(), {}, other_channel_chitexts[io], pbounds, opt | PlotOptions::DataMCRatio, io);
@@ -2231,10 +2231,13 @@ int main(int argc, char* argv[])
 
         fout.mkdir("ErrorBand");
         fout.cd("ErrorBand");
+        size_t eind = 0;
         for(size_t io = 0; io < config.m_num_variables; ++io) {
             if(!config.m_channel_variable_plot_bool.at(io))continue;// For now skip the L/E 250 bin. 
             size_t tot_offset = 0;
-            const PROerrorbar &err = other_err_bands[io];
+            // We need to use a different index here since we don't add error bars to the vector if
+            // plot="false" in the xml
+            const PROerrorbar &err = other_err_bands.at(eind++);
             for(size_t mode = 0; mode < config.m_num_modes; ++mode) {
                 for(size_t det = 0; det < config.m_num_detectors; ++det) {
                     for(size_t channel = 0; channel < config.m_num_channels; ++channel) {
@@ -2246,11 +2249,16 @@ int main(int argc, char* argv[])
                         TGraphAsymmErrors eband(nbins_p_2dchan);
                         for(size_t i = 0; i < nbins_p_2dchan; ++i) {
                             float x = channel_nbins_y == 1 ? 
-                                (config.m_channel_variable_bins[channel][io].Edges(0)[i+1] - config.m_channel_variable_bins[channel][io].Edges(0)[i])/2 :
+                                (config.m_channel_variable_bins[channel][io].Edges(0)[i+1] + config.m_channel_variable_bins[channel][io].Edges(0)[i])/2 :
                                 i;
+                            float xerr = channel_nbins_y == 1 ?
+                                (config.m_channel_variable_bins[channel][io].Edges(0)[i+1] - config.m_channel_variable_bins[channel][io].Edges(0)[i])/2 :
+                                0.5;
                             eband.SetPoint(i, x, err.error_point(tot_offset + i));
                             eband.SetPointEYhigh(i, err.error_up(tot_offset + i));
                             eband.SetPointEYlow(i, err.error_down(tot_offset + i));
+                            eband.SetPointEXhigh(i, xerr);
+                            eband.SetPointEXlow(i, xerr);
                         }
                         std::string name = config.m_mode_names[mode]+"_"+config.m_detector_names[det]+"_"+config.m_channel_names[channel]+"_var"+std::to_string(io);
                         eband.Write(name.c_str());

--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -1286,6 +1286,42 @@ int main(int argc, char* argv[])
         TFile fout((final_output_tag+"_PROfile.root").c_str(), "RECREATE");
         profile.onesig.Write("one_sigma_errs");
         pre_hist.Write("cv");
+        size_t tot_offset = 0;
+        for(size_t mode = 0; mode < config.m_num_modes; ++mode) {
+            for(size_t det = 0; det < config.m_num_detectors; ++det) {
+                for(size_t channel = 0; channel < config.m_num_channels; ++channel) {
+                    size_t channel_nbins_x = config.m_channel_variable_bins[channel][config.i_prime].NBinsAlong(0);
+                    // default is 1d, but catch 2d case for ybins
+                    size_t channel_nbins_y = 1;
+                    if(config.m_channel_variable_dims[channel][config.i_prime] == 2)  channel_nbins_y = config.m_channel_variable_bins[channel][config.i_prime].NBinsAlong(1);
+                    size_t nbins_p_2dchan = channel_nbins_y*channel_nbins_x;
+                    TGraphAsymmErrors preband(nbins_p_2dchan);
+                    TGraphAsymmErrors postband(nbins_p_2dchan);
+                    for(size_t i = 0; i < nbins_p_2dchan; ++i) {
+                        float x = channel_nbins_y == 1 ? 
+                            (config.m_channel_variable_bins[channel][config.i_prime].Edges(0)[i+1] + config.m_channel_variable_bins[channel][config.i_prime].Edges(0)[i])/2 :
+                            i;
+                        float xerr = channel_nbins_y == 1 ?
+                            (config.m_channel_variable_bins[channel][config.i_prime].Edges(0)[i+1] - config.m_channel_variable_bins[channel][config.i_prime].Edges(0)[i])/2 :
+                            0.5;
+                        preband.SetPoint(i, x, fitres.err_band->error_point(tot_offset + i));
+                        preband.SetPointEYhigh(i, fitres.err_band->error_up(tot_offset + i));
+                        preband.SetPointEYlow(i, fitres.err_band->error_down(tot_offset + i));
+                        preband.SetPointEXhigh(i, xerr);
+                        preband.SetPointEXlow(i, xerr);
+                        postband.SetPoint(i, x, fitres.post_err_band->error_point(tot_offset + i));
+                        postband.SetPointEYhigh(i, fitres.post_err_band->error_up(tot_offset + i));
+                        postband.SetPointEYlow(i, fitres.post_err_band->error_down(tot_offset + i));
+                        postband.SetPointEXhigh(i, xerr);
+                        postband.SetPointEXlow(i, xerr);
+                    }
+                    std::string name = config.m_mode_names[mode]+"_"+config.m_detector_names[det]+"_"+config.m_channel_names[channel];
+                    preband.Write((name+"_prefit_err").c_str());
+                    postband.Write((name+"_postfit_err").c_str());
+                    tot_offset += nbins_p_2dchan;
+                }
+            }
+        }
         //err_band->Write("prefit_errband");
         //post_err_band->Write("postfit_errband");
         post_hist.Write("best_fit");


### PR DESCRIPTION
Fix in plot is good as a long term solution I think (maybe some refactoring and cleanup needed).

For profile and global (global doesn't save anything in root files right now) I think we want a different solution. I'm going to work on a different PR that has `plot_channels` return all the ROOT objects it plotted so we can save those to some root file.