### PR TITLE
Make msg_counts thread_local in formatted_log_t

### DIFF
--- a/inc/PROlog.h
+++ b/inc/PROlog.h
@@ -107,7 +107,7 @@ namespace log_impl {
             formatted_log_t( log_level_t level, const wchar_t* msg ) : level(level), fmt(msg) {}
             ~formatted_log_t() {
                 static const int SUPPRESS_AFTER = 1000;
-                static std::unordered_map<std::wstring, int> msg_counts;
+                thread_local static std::unordered_map<std::wstring, int> msg_counts;
                 std::wstring formatted_msg = boost::str(fmt);
                 int& count = msg_counts[formatted_msg];
                 count++;


### PR DESCRIPTION
Change msg_counts to be thread_local for better concurrency. Based on core dumps from multi-node FC scaling tests on Aurora, which all pointed to this unordered_map in PROlog, this seemed to be the issue. Adding this resulting in a 900 node job, with 2000 universes each running in < 10 min.

