### PR TITLE
covariance_to_spline updates

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -2334,6 +2334,13 @@ int main(int argc, char* argv[])
 
         }
 
+        // Debug PDF for covariance_to_spline systematics — only emitted if at least one is present.
+        if(!variable_systs[config.i_prime].cov2spline_debug_info.empty()) {
+            const std::string cov2spline_pdf = final_output_tag + "_covariance_to_spline_checks.pdf";
+            plotCov2SplineChecks(config, variable_cvs[config.i_prime], variable_systs[config.i_prime], cov2spline_pdf, config.i_prime);
+            log<LOG_INFO>(L"%1% || covariance_to_spline diagnostics written to %2%") % __func__ % cov2spline_pdf.c_str();
+        }
+
         //now onto root files
         TFile fout((final_output_tag+"_PROplot.root").c_str(), "RECREATE");
 

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -134,11 +134,11 @@ namespace PROfit{
       bool GetReweight() const {return hist_reweight;}
 
        int GetModelRule() const{
-	return model_rule;
+        return model_rule;
       };
 
       int GetIncludeSystematics() const{
-	return include_systematics;
+        return include_systematics;
       };
 
 
@@ -447,6 +447,7 @@ namespace PROfit{
             std::map<std::string, std::pair<float,float>> m_mcgen_variation_restrict; //map of systematics with restrict="lo, hi" (clamp knob value during evaluation and fitting)
             std::map<std::string, float> m_mcgen_variation_scale; //map of systematics with scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
             std::map<std::string, int> m_mcgen_variation_num_decomp_knobs; //map of covariance_to_spline systematics to the number of eigenpairs to keep (-1 or missing = keep all)
+            std::map<std::string, bool> m_mcgen_variation_include_resid_cov; //map of covariance_to_spline systematics to whether the un-kept eigenpairs are retained as a residual covariance (missing = true)
       
             //FIX skepic
             std::vector<std::string> systematic_name;

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -84,6 +84,7 @@ namespace PROfit{
         std::vector<int> include_only_weights; ///< 1-based indices of weight universes to include; empty = all.
         float scale = 1.0f;         ///< Scale factor applied to all weights (e.g. 0.001 for weights stored as x1000).
         int num_decomp_knobs = -1;  ///< For "covariance_to_spline": number of top eigenpairs to keep as spline knobs (-1 = keep all).
+        bool include_resid_cov = true; ///< For "covariance_to_spline": if true, retain the un-kept (smaller) eigenpairs as a "<systname>_resid_cov" covariance matrix instead of dropping them.
         bool has_restrict = false;  ///< If true, clamp the knob value to [restrict_lo, restrict_hi] during evaluation and fitting.
         float restrict_lo = 0.0f;   ///< Lower clamp bound (used only when has_restrict is true).
         float restrict_hi = 0.0f;   ///< Upper clamp bound (used only when has_restrict is true).
@@ -116,6 +117,9 @@ namespace PROfit{
             }
             if (version >= 2) {
                 ar & num_decomp_knobs;
+            }
+            if (version >= 3) {
+                ar & include_resid_cov;
             }
         }
 
@@ -321,6 +325,6 @@ namespace PROfit{
 
 };
 
-BOOST_CLASS_VERSION(PROfit::SystStruct, 2)
+BOOST_CLASS_VERSION(PROfit::SystStruct, 3)
 
 #endif

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -298,6 +298,24 @@ namespace PROfit{
     int plotPriorFractionalSystematicRatios(const PROconfig &config, const PROspec &spec, const PROsyst &allsplinesyst, std::string filename, int other_index);
 
     /**
+     * @brief Produce a multi-page diagnostic PDF for every covariance_to_spline systematic.
+     * @details For each parent systematic the PDF includes: a summary page, the original vs.
+     * reconstructed fractional covariance with residual, the per-bin fractional uncertainty
+     * (sqrt of the diagonal) original vs. reconstructed, the eigenvalue scree plot and the
+     * cumulative variance, an eigenvector heatmap of the kept modes, per-knob bin-response
+     * panels, per-knob CV ± 1σ bands, and an aggregate CV band built from the original
+     * covariance vs. summed over the synthesized knobs.  Only writes the file if at least
+     * one covariance_to_spline systematic was processed.
+     * @param config    Analysis configuration.
+     * @param cv        CV spectrum (used for the ±1σ band overlays).
+     * @param syst      PROsyst whose cov2spline_debug_info map will be iterated.
+     * @param filename  Output PDF path.
+     * @param var_index Variable (binning) index.
+     * @return 0 on success, 1 if there were no covariance_to_spline systematics.
+     */
+    int plotCov2SplineChecks(const PROconfig &config, const PROspec &cv, const PROsyst &syst, const std::string &filename, int var_index);
+
+    /**
      * @brief Compute a posterior error band using Markov Chain Monte Carlo sampling.
      * @details Runs the Metropolis algorithm for @p burnin + @p iterations steps.  At each
      * accepted step after burn-in, the corresponding spectrum is computed and accumulated;

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -55,6 +55,21 @@ namespace PROfit {
     };
 
     /**
+     * @brief Diagnostic info captured when a "covariance_to_spline" systematic is processed.
+     * @details Populated by FillSplinesFromCovariance; consumed by plotCov2SplineChecks to
+     * make a covariance_to_spline_checks.pdf debug document.
+     */
+    struct Cov2SplineDebugInfo {
+        Eigen::MatrixXf original_frac_cov;  ///< Fractional covariance built from multisim throws (pre-symmetrized residual saved separately).
+        float pre_symm_asymmetry = 0.0f;     ///< ||C - C^T||_F before symmetrization (sanity number).
+        Eigen::VectorXf eigenvalues;         ///< All eigenvalues, ascending (Eigen convention).
+        Eigen::MatrixXf eigenvectors;        ///< Eigenvectors as columns (Eigen convention).
+        std::vector<int> kept_indices;       ///< Indices into eigenvalues/eigenvectors for retained modes, descending eigenvalue.
+        std::vector<std::string> knob_names; ///< Names of synthesized spline knobs, same order as kept_indices.
+        int binning = -1;                    ///< Binning index the covariance lives on.
+    };
+
+    /**
      * @brief Aggregator for all systematic uncertainties acting on a PROfit analysis.
      * @details PROsyst groups both spline-based and covariance-matrix-based systematics.
      * On construction it processes the input SystStruct vector and:
@@ -238,6 +253,7 @@ namespace PROfit {
             std::vector<int> spline_binnings;        ///< Binning-scheme index for each spline.
             Eigen::VectorXf spline_priors;           ///< Prior width (sigma) for each spline nuisance parameter.
             Eigen::VectorXf spline_centers;          ///< Prior centre for each spline nuisance parameter.
+            std::map<std::string, Cov2SplineDebugInfo> cov2spline_debug_info; ///< Debug info per "covariance_to_spline" systematic, keyed by parent systname.
         private:
             std::map<std::string, std::pair<size_t, SystType>> syst_map; ///< Map from systematic name to (index, type).
             std::vector<Spline> splines;             ///< Ordered list of spline objects.

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -67,6 +67,10 @@ namespace PROfit {
         std::vector<int> kept_indices;       ///< Indices into eigenvalues/eigenvectors for retained modes, descending eigenvalue.
         std::vector<std::string> knob_names; ///< Names of synthesized spline knobs, same order as kept_indices.
         int binning = -1;                    ///< Binning index the covariance lives on.
+        bool has_residual = false;           ///< True if the un-kept eigenpairs were retained as a residual covariance.
+        int n_residual_modes = 0;            ///< Number of positive eigenpairs folded into the residual covariance.
+        Eigen::MatrixXf residual_cov;        ///< Residual fractional covariance from un-kept positive eigenpairs (empty if has_residual is false).
+        std::string residual_cov_name;       ///< Name under which the residual covariance was registered ("<systname>_resid_cov").
     };
 
     /**

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1247,7 +1247,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 }
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar", "restrict", "mirror", "num_decomp_knobs"};
+                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar", "restrict", "mirror", "num_decomp_knobs", "include_resid_cov"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -1273,6 +1273,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *yvar = pAllowList->Attribute("yvar");
                 const char *mirrored = pAllowList->Attribute("mirror");
                 const char *num_decomp_knobs = pAllowList->Attribute("num_decomp_knobs");
+                const char *include_resid_cov = pAllowList->Attribute("include_resid_cov");
 
 
                 m_mcgen_variation_type.push_back(variation_type);
@@ -1406,6 +1407,11 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(num_decomp_knobs) {
                     m_mcgen_variation_num_decomp_knobs[wt] = atoi(num_decomp_knobs);
                     log<LOG_INFO>(L"%1% || Parsed num_decomp_knobs=%2% for systematic %3%") % __func__ % m_mcgen_variation_num_decomp_knobs[wt] % wt.c_str();
+                }
+                if(include_resid_cov) {
+                    bool keep_resid = !(strcmp(include_resid_cov, "false") == 0 || strcmp(include_resid_cov, "no") == 0 || strcmp(include_resid_cov, "0") == 0);
+                    m_mcgen_variation_include_resid_cov[wt] = keep_resid;
+                    log<LOG_INFO>(L"%1% || Parsed include_resid_cov=%2% for systematic %3%") % __func__ % keep_resid % wt.c_str();
                 }
                 log<LOG_DEBUG>(L"%1% || Allowlisting variations: %2%") % __func__ % wt.c_str() ;
                 tinyxml2::XMLElement *pNext = pAllowList->NextSiblingElement("allowlist");

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -518,6 +518,11 @@ namespace PROfit {
                         sv.back().num_decomp_knobs = it_nk->second;
                         log<LOG_INFO>(L"%1% || Setting num_decomp_knobs=%2% for systematic %3%") % __func__ % sv.back().num_decomp_knobs % sys_name.c_str();
                     }
+                    auto it_rc = inconfig.m_mcgen_variation_include_resid_cov.find(sys_name);
+                    if(it_rc != inconfig.m_mcgen_variation_include_resid_cov.end()) {
+                        sv.back().include_resid_cov = it_rc->second;
+                    }
+                    log<LOG_INFO>(L"%1% || Setting include_resid_cov=%2% for systematic %3%") % __func__ % sv.back().include_resid_cov % sys_name.c_str();
                     log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a covariance_to_spline systematic. Processing as such. ") % __func__ % sys_name.c_str();
                 }
                 if(sys_mode == "flat"){

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -2316,10 +2316,12 @@ namespace PROfit{
                 const Eigen::VectorXf v = dbg.eigenvectors.col(idx);
                 recon.noalias() += lam * (v * v.transpose());
             }
-            const Eigen::MatrixXf residual = dbg.original_frac_cov - recon;
-            const float resid_frob = residual.norm();
+            // "difference" = what the rank-K splines alone fail to capture (distinct from the
+            // "residual covariance" feature, which folds the un-kept eigenpairs back in).
+            const Eigen::MatrixXf difference = dbg.original_frac_cov - recon;
+            const float diff_frob = difference.norm();
             const float orig_frob = dbg.original_frac_cov.norm();
-            const float resid_max_abs = residual.cwiseAbs().maxCoeff();
+            const float diff_max_abs = difference.cwiseAbs().maxCoeff();
 
             // ---- Page 1: summary text ----
             int n_pos = 0, n_zero = 0, n_neg = 0;
@@ -2350,14 +2352,31 @@ namespace PROfit{
                     pt.AddText(Form("Largest eigenvalue: %.4g    Smallest kept eigenvalue: %.4g", lam_max, lam_min_kept));
                 }
                 pt.AddText(Form("Pre-symmetrization asymmetry (||C - C^T||_F): %.4g", dbg.pre_symm_asymmetry));
-                pt.AddText(Form("Residual ||C_orig - C_recon||_F: %.4g   (relative: %.4g)", resid_frob, orig_frob > 0 ? resid_frob/orig_frob : 0.0f));
-                pt.AddText(Form("Max |residual element|: %.4g", resid_max_abs));
+                pt.AddText(Form("Difference ||C_orig - C_recon||_F: %.4g   (relative: %.4g)", diff_frob, orig_frob > 0 ? diff_frob/orig_frob : 0.0f));
+                pt.AddText(Form("Max |difference element|: %.4g", diff_max_abs));
+                pt.AddText("");
+                if(dbg.has_residual) {
+                    const float resid_cov_frob = dbg.residual_cov.norm();
+                    TText *rt = pt.AddText(Form("Residual covariance: ON  -  %d un-kept mode(s) retained as '%s'",
+                                                dbg.n_residual_modes, dbg.residual_cov_name.c_str()));
+                    if(rt) rt->SetTextColor(kGreen + 3);
+                    pt.AddText(Form("   ||C_resid_cov||_F: %.4g   (relative to original: %.4g)",
+                                    resid_cov_frob, orig_frob > 0 ? resid_cov_frob/orig_frob : 0.0f));
+                    pt.AddText("   The K splines plus this covariance reproduce the full systematic;");
+                    pt.AddText("   only negative-eigenvalue numerical noise is discarded.");
+                } else if(K < n_pos) {
+                    TText *rt = pt.AddText(Form("Residual covariance: OFF  -  %d smaller mode(s) DROPPED (include_resid_cov=false)", n_pos - K));
+                    if(rt) rt->SetTextColor(kRed + 1);
+                    pt.AddText("   The rank-K model underestimates the systematic by the difference shown above.");
+                } else {
+                    pt.AddText("Residual covariance: n/a  -  all positive eigenpairs kept as splines.");
+                }
                 pt.Draw();
                 draw_version_stamp();
                 c.Print(filename.c_str(), "pdf");
             }
 
-            // ---- Page 2: original, reconstructed, residual covariance heatmaps ----
+            // ---- Page 2: original, rank-K reconstruction, and their difference ----
             auto fill_th2 = [&](const Eigen::MatrixXf &M, const std::string &name, const std::string &title) {
                 auto h = std::make_unique<TH2D>(name.c_str(), title.c_str(), nbins, 0, nbins, nbins, 0, nbins);
                 h->SetDirectory(nullptr);
@@ -2372,31 +2391,59 @@ namespace PROfit{
             {
                 auto h_orig  = fill_th2(dbg.original_frac_cov, "h_cov_orig_"+systname,  (display+" original frac cov;Bin index;Bin index").c_str());
                 auto h_recon = fill_th2(recon,                  "h_cov_recon_"+systname, (display+Form(" reconstructed (rank %d);Bin index;Bin index", K)).c_str());
-                auto h_resid = fill_th2(residual,               "h_cov_resid_"+systname, (display+" residual = orig - recon;Bin index;Bin index").c_str());
+                auto h_diff  = fill_th2(difference,             "h_cov_diff_"+systname,  (display+" difference = orig - recon;Bin index;Bin index").c_str());
                 c.Clear();
                 c.Divide(3, 1);
                 c.cd(1); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_orig->Draw("colz");  draw_channel_dividers_2d(spans, nbins);
                 c.cd(2); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_recon->Draw("colz"); draw_channel_dividers_2d(spans, nbins);
-                c.cd(3); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_resid->Draw("colz"); draw_channel_dividers_2d(spans, nbins);
+                c.cd(3); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_diff->Draw("colz");  draw_channel_dividers_2d(spans, nbins);
                 c.cd(0);
                 draw_version_stamp();
                 c.Print(filename.c_str(), "pdf");
             }
 
-            // ---- Page 3: sqrt(diag) per bin, original vs reconstructed ----
+            // ---- Page 2b: closure check when include_resid_cov is on ----
+            // Compare the original against the actual model used in the fit (K splines + residual
+            // covariance). Their difference should be ~0 (only negative-eigenvalue noise remains),
+            // which is the meaningful check now that the un-kept eigenpairs are retained.
+            if(dbg.has_residual) {
+                const Eigen::MatrixXf full_model = recon + dbg.residual_cov;
+                const Eigen::MatrixXf closure = dbg.original_frac_cov - full_model;
+                const float closure_frob = closure.norm();
+                auto h_orig  = fill_th2(dbg.original_frac_cov, "h_cov_orig2_"+systname, (display+" original frac cov;Bin index;Bin index").c_str());
+                auto h_model = fill_th2(full_model,            "h_cov_model_"+systname, (display+Form(" K=%d splines + residual cov;Bin index;Bin index", K)).c_str());
+                auto h_clos  = fill_th2(closure,               "h_cov_clos_"+systname,  (display+Form(" difference (||.||_F=%.2g);Bin index;Bin index", closure_frob)).c_str());
+                c.Clear();
+                c.Divide(3, 1);
+                // Titles read left-to-right as: [original] vs [splines + residual cov] -> [difference ~ 0].
+                c.cd(1); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_orig->Draw("colz");  draw_channel_dividers_2d(spans, nbins);
+                c.cd(2); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_model->Draw("colz"); draw_channel_dividers_2d(spans, nbins);
+                c.cd(3); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_clos->Draw("colz");  draw_channel_dividers_2d(spans, nbins);
+                c.cd(0);
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+
+            // ---- Page 3: sqrt(diag) per bin, original vs reconstructed (+ splines+resid when on) ----
             {
                 auto h_d_orig  = std::make_unique<TH1D>(("h_diag_orig_"+systname).c_str(), (display+" fractional uncertainty per bin;Bin index;#sqrt{diag}").c_str(), nbins, 0, nbins);
                 auto h_d_recon = std::make_unique<TH1D>(("h_diag_recon_"+systname).c_str(), "", nbins, 0, nbins);
-                h_d_orig->SetDirectory(nullptr); h_d_recon->SetDirectory(nullptr);
+                auto h_d_sum   = std::make_unique<TH1D>(("h_diag_sum_"+systname).c_str(), "", nbins, 0, nbins);
+                h_d_orig->SetDirectory(nullptr); h_d_recon->SetDirectory(nullptr); h_d_sum->SetDirectory(nullptr);
                 for(int b = 0; b < nbins; ++b) {
                     h_d_orig ->SetBinContent(b+1, std::sqrt(std::max(0.0f, dbg.original_frac_cov(b,b))));
                     h_d_recon->SetBinContent(b+1, std::sqrt(std::max(0.0f, recon(b,b))));
+                    if(dbg.has_residual)
+                        h_d_sum->SetBinContent(b+1, std::sqrt(std::max(0.0f, recon(b,b) + dbg.residual_cov(b,b))));
                 }
                 h_d_orig->SetLineColor(kBlack);
                 h_d_orig->SetLineWidth(2);
                 h_d_recon->SetLineColor(kRed);
                 h_d_recon->SetLineWidth(2);
                 h_d_recon->SetLineStyle(2);
+                h_d_sum->SetLineColor(kGreen + 2);
+                h_d_sum->SetLineWidth(2);
+                h_d_sum->SetLineStyle(3);
                 const double ymax = 1.15 * std::max(h_d_orig->GetMaximum(), h_d_recon->GetMaximum());
                 h_d_orig->SetMaximum(ymax);
                 h_d_orig->SetMinimum(0.0);
@@ -2404,12 +2451,14 @@ namespace PROfit{
                 gPad->SetTopMargin(0.13);
                 h_d_orig->Draw("hist");
                 h_d_recon->Draw("hist same");
+                if(dbg.has_residual) h_d_sum->Draw("hist same");
                 draw_channel_dividers_1d(spans, 0.0, ymax);
-                auto *leg = new TLegend(0.7, 0.78, 0.92, 0.9);
+                auto *leg = new TLegend(0.62, 0.74, 0.92, 0.9);
                 leg->SetBorderSize(0);
                 leg->SetFillStyle(0);
                 leg->AddEntry(h_d_orig.get(), "Original (multisim)", "l");
-                leg->AddEntry(h_d_recon.get(), Form("Reconstructed (K=%d)", K), "l");
+                leg->AddEntry(h_d_recon.get(), Form("K=%d splines only", K), "l");
+                if(dbg.has_residual) leg->AddEntry(h_d_sum.get(), "Splines + residual cov", "l");
                 leg->Draw();
                 draw_version_stamp();
                 c.Print(filename.c_str(), "pdf");
@@ -2611,18 +2660,26 @@ namespace PROfit{
                 auto h_odn = std::make_unique<TH1D>(("h_aggodn_"+systname).c_str(), "", nbins, 0, nbins);
                 auto h_kup = std::make_unique<TH1D>(("h_aggkup_"+systname).c_str(), "", nbins, 0, nbins);
                 auto h_kdn = std::make_unique<TH1D>(("h_aggkdn_"+systname).c_str(), "", nbins, 0, nbins);
-                h_cv->SetDirectory(nullptr); h_oup->SetDirectory(nullptr); h_odn->SetDirectory(nullptr); h_kup->SetDirectory(nullptr); h_kdn->SetDirectory(nullptr);
+                auto h_sup = std::make_unique<TH1D>(("h_aggsup_"+systname).c_str(), "", nbins, 0, nbins);
+                auto h_sdn = std::make_unique<TH1D>(("h_aggsdn_"+systname).c_str(), "", nbins, 0, nbins);
+                h_cv->SetDirectory(nullptr); h_oup->SetDirectory(nullptr); h_odn->SetDirectory(nullptr);
+                h_kup->SetDirectory(nullptr); h_kdn->SetDirectory(nullptr); h_sup->SetDirectory(nullptr); h_sdn->SetDirectory(nullptr);
                 double ymax = 0;
                 for(int b = 0; b < nbins; ++b) {
                     const double y0 = cv_full(b);
                     const double sigma_orig  = std::sqrt(std::max(0.0f, dbg.original_frac_cov(b,b))) * y0;
                     const double sigma_recon = std::sqrt(std::max(0.0f, recon(b,b))) * y0;
+                    // Combined model = K splines (in quadrature) + residual covariance diagonal.
+                    const double var_comb = recon(b,b) + (dbg.has_residual ? dbg.residual_cov(b,b) : 0.0f);
+                    const double sigma_comb = std::sqrt(std::max(0.0, var_comb)) * y0;
                     h_cv->SetBinContent(b+1, y0);
                     h_oup->SetBinContent(b+1, y0 + sigma_orig);
                     h_odn->SetBinContent(b+1, y0 - sigma_orig);
                     h_kup->SetBinContent(b+1, y0 + sigma_recon);
                     h_kdn->SetBinContent(b+1, y0 - sigma_recon);
-                    ymax = std::max({ymax, y0 + sigma_orig, y0 + sigma_recon});
+                    h_sup->SetBinContent(b+1, y0 + sigma_comb);
+                    h_sdn->SetBinContent(b+1, y0 - sigma_comb);
+                    ymax = std::max({ymax, y0 + sigma_orig, y0 + sigma_recon, y0 + sigma_comb});
                 }
                 h_cv->SetLineColor(kBlack);
                 h_cv->SetLineWidth(2);
@@ -2630,23 +2687,28 @@ namespace PROfit{
                 h_oup->SetLineStyle(2); h_odn->SetLineStyle(2);
                 h_kup->SetLineColor(kRed + 1); h_kdn->SetLineColor(kRed + 1);
                 h_kup->SetLineStyle(1); h_kdn->SetLineStyle(1);
+                h_sup->SetLineColor(kGreen + 2); h_sdn->SetLineColor(kGreen + 2);
+                h_sup->SetLineStyle(1); h_sdn->SetLineStyle(1);
+                h_sup->SetLineWidth(2); h_sdn->SetLineWidth(2);
                 h_cv->SetMaximum(1.15 * ymax);
                 h_cv->SetMinimum(0.0);
                 c.Clear();
                 gPad->SetTopMargin(0.13);
                 h_cv->Draw("hist");
-                // Draw rank-K band first, then original-multisim dashed lines on top so they
-                // remain visible when the two overlap.
+                // Draw rank-K band first, then the combined (splines+resid) band, then the
+                // original-multisim dashed lines on top so each stays visible where they overlap.
                 h_kup->Draw("hist same");
                 h_kdn->Draw("hist same");
+                if(dbg.has_residual) { h_sup->Draw("hist same"); h_sdn->Draw("hist same"); }
                 h_oup->Draw("hist same");
                 h_odn->Draw("hist same");
                 draw_channel_dividers_1d(spans, 0.0, 1.15 * ymax);
-                auto *leg = new TLegend(0.68, 0.76, 0.92, 0.9);
+                auto *leg = new TLegend(0.6, 0.72, 0.92, 0.9);
                 leg->SetBorderSize(0); leg->SetFillStyle(0);
                 leg->AddEntry(h_cv.get(),  "CV", "l");
                 leg->AddEntry(h_oup.get(), "CV #pm 1#sigma (original multisim)", "l");
-                leg->AddEntry(h_kup.get(), Form("CV #pm 1#sigma (rank-%d knobs)", K), "l");
+                leg->AddEntry(h_kup.get(), Form("CV #pm 1#sigma (K=%d splines only)", K), "l");
+                if(dbg.has_residual) leg->AddEntry(h_sup.get(), "CV #pm 1#sigma (splines + residual cov)", "l");
                 leg->Draw();
                 draw_version_stamp();
                 c.Print(filename.c_str(), "pdf");

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -2215,4 +2215,445 @@ namespace PROfit{
         c->SaveAs((filename+"_1sigmaMCMC.pdf").c_str(), "pdf");
         delete c;
     }
+
+    namespace {
+        struct ChannelSpan {
+            std::string label;     // subchannel plot/full name
+            size_t start_bin = 0;  // inclusive, in full-bin space
+            size_t nbins   = 0;
+        };
+
+        // Walk all subchannels and return their [start, nbins) span in the full bin space for var_index.
+        std::vector<ChannelSpan> cov2spline_channel_spans(const PROconfig &config, int var_index) {
+            std::vector<ChannelSpan> spans;
+            size_t isub = 0;
+            for(size_t im = 0; im < config.m_num_modes; ++im) {
+                for(size_t id = 0; id < config.m_num_detectors; ++id) {
+                    for(size_t ic = 0; ic < config.m_num_channels; ++ic) {
+                        for(size_t sc = 0; sc < config.m_num_subchannels[ic]; ++sc) {
+                            ChannelSpan s;
+                            s.label    = config.m_fullnames[isub];
+                            s.start_bin = config.GetGlobalVariableBinStart(isub, var_index);
+                            s.nbins   = config.m_channel_variable_bins[ic][var_index].NBins();
+                            spans.push_back(std::move(s));
+                            ++isub;
+                        }
+                    }
+                }
+            }
+            return spans;
+        }
+
+        void draw_channel_dividers_1d(const std::vector<ChannelSpan> &spans, double ymin, double ymax) {
+            for(size_t s = 1; s < spans.size(); ++s) {
+                const double x = static_cast<double>(spans[s].start_bin);
+                auto *ln = new TLine(x, ymin, x, ymax);
+                ln->SetLineColor(kGray + 2);
+                ln->SetLineStyle(2);
+                ln->Draw();
+            }
+        }
+
+        void draw_channel_dividers_2d(const std::vector<ChannelSpan> &spans, double nbins_total) {
+            for(size_t s = 1; s < spans.size(); ++s) {
+                const double x = static_cast<double>(spans[s].start_bin);
+                auto *lnv = new TLine(x, 0, x, nbins_total);
+                lnv->SetLineColor(kGray + 2);
+                lnv->SetLineStyle(2);
+                lnv->Draw();
+                auto *lnh = new TLine(0, x, nbins_total, x);
+                lnh->SetLineColor(kGray + 2);
+                lnh->SetLineStyle(2);
+                lnh->Draw();
+            }
+        }
+
+        void draw_version_stamp() {
+            // Bottom-right of the master canvas so the stamp never sits over a sub-pad's
+            // histogram title on multi-panel pages (top-right NDC lies inside the top-right
+            // sub-pad and overlaps its title there).
+            TText *t = new TText();
+            t->SetNDC();
+            t->SetTextFont(42);
+            t->SetTextSize(0.022f);
+            t->SetTextAlign(31); // bottom-right anchor
+            std::string pv = "PROfit v" + std::string(PROJECT_VERSION_STR);
+            t->DrawText(0.995, 0.005, pv.c_str());
+        }
+
+        std::string cov2spline_display_name(const PROconfig &config, const std::string &systname) {
+            auto it = config.m_mcgen_variation_plotname_map.find(systname);
+            if(it != config.m_mcgen_variation_plotname_map.end() && !it->second.empty()) {
+                return it->second;
+            }
+            return systname;
+        }
+    }
+
+    int plotCov2SplineChecks(const PROconfig &config, const PROspec &cv, const PROsyst &syst, const std::string &filename, int var_index) {
+        if(syst.cov2spline_debug_info.empty()) {
+            return 1;
+        }
+
+        set_matrix_palette();
+
+        TCanvas c("c_cov2spline", "covariance_to_spline checks", 1600, 1100);
+        c.Print((filename + "[").c_str(), "pdf");
+
+        const std::vector<ChannelSpan> spans = cov2spline_channel_spans(config, var_index);
+
+        for(const auto &[systname, dbg]: syst.cov2spline_debug_info) {
+            const std::string display = cov2spline_display_name(config, systname);
+            const int nbins = static_cast<int>(dbg.original_frac_cov.rows());
+            const int K = static_cast<int>(dbg.kept_indices.size());
+            const int n_eig = static_cast<int>(dbg.eigenvalues.size());
+
+            // ---- Reconstructed covariance and residual (rank-K approximation) ----
+            Eigen::MatrixXf recon = Eigen::MatrixXf::Zero(nbins, nbins);
+            for(int k = 0; k < K; ++k) {
+                const int idx = dbg.kept_indices[k];
+                const float lam = dbg.eigenvalues(idx);
+                const Eigen::VectorXf v = dbg.eigenvectors.col(idx);
+                recon.noalias() += lam * (v * v.transpose());
+            }
+            const Eigen::MatrixXf residual = dbg.original_frac_cov - recon;
+            const float resid_frob = residual.norm();
+            const float orig_frob = dbg.original_frac_cov.norm();
+            const float resid_max_abs = residual.cwiseAbs().maxCoeff();
+
+            // ---- Page 1: summary text ----
+            int n_pos = 0, n_zero = 0, n_neg = 0;
+            const float tol = 10.0f * Eigen::NumTraits<float>::dummy_precision();
+            for(int i = 0; i < n_eig; ++i) {
+                if(dbg.eigenvalues(i) > tol) ++n_pos;
+                else if(dbg.eigenvalues(i) < -tol) ++n_neg;
+                else ++n_zero;
+            }
+            {
+                c.Clear();
+                TPaveText pt(0.05, 0.05, 0.95, 0.95, "NDC");
+                pt.SetFillColor(0);
+                pt.SetBorderSize(0);
+                pt.SetTextAlign(12);
+                pt.SetTextFont(42);
+                pt.SetTextSize(0.030f);
+                TText *title_text = pt.AddText(("covariance_to_spline diagnostics: " + display).c_str());
+                if(title_text) title_text->SetTextSize(0.045f);
+                pt.AddText("");
+                pt.AddText(("systname:  " + systname).c_str());
+                pt.AddText(Form("Bins: %d", nbins));
+                pt.AddText(Form("Eigenvalues: %d total  (positive %d, near-zero %d, negative %d)", n_eig, n_pos, n_zero, n_neg));
+                pt.AddText(Form("Knobs retained: K = %d  of %d positive eigenvalues", K, n_pos));
+                if(K > 0) {
+                    const float lam_max = dbg.eigenvalues(dbg.kept_indices.front());
+                    const float lam_min_kept = dbg.eigenvalues(dbg.kept_indices.back());
+                    pt.AddText(Form("Largest eigenvalue: %.4g    Smallest kept eigenvalue: %.4g", lam_max, lam_min_kept));
+                }
+                pt.AddText(Form("Pre-symmetrization asymmetry (||C - C^T||_F): %.4g", dbg.pre_symm_asymmetry));
+                pt.AddText(Form("Residual ||C_orig - C_recon||_F: %.4g   (relative: %.4g)", resid_frob, orig_frob > 0 ? resid_frob/orig_frob : 0.0f));
+                pt.AddText(Form("Max |residual element|: %.4g", resid_max_abs));
+                pt.Draw();
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+
+            // ---- Page 2: original, reconstructed, residual covariance heatmaps ----
+            auto fill_th2 = [&](const Eigen::MatrixXf &M, const std::string &name, const std::string &title) {
+                auto h = std::make_unique<TH2D>(name.c_str(), title.c_str(), nbins, 0, nbins, nbins, 0, nbins);
+                h->SetDirectory(nullptr);
+                for(int i = 0; i < nbins; ++i)
+                    for(int j = 0; j < nbins; ++j)
+                        h->SetBinContent(i+1, j+1, M(i,j));
+                const float m = std::max(std::fabs(h->GetMaximum()), std::fabs(h->GetMinimum()));
+                h->SetMaximum(m);
+                h->SetMinimum(-m);
+                return h;
+            };
+            {
+                auto h_orig  = fill_th2(dbg.original_frac_cov, "h_cov_orig_"+systname,  (display+" original frac cov;Bin index;Bin index").c_str());
+                auto h_recon = fill_th2(recon,                  "h_cov_recon_"+systname, (display+Form(" reconstructed (rank %d);Bin index;Bin index", K)).c_str());
+                auto h_resid = fill_th2(residual,               "h_cov_resid_"+systname, (display+" residual = orig - recon;Bin index;Bin index").c_str());
+                c.Clear();
+                c.Divide(3, 1);
+                c.cd(1); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_orig->Draw("colz");  draw_channel_dividers_2d(spans, nbins);
+                c.cd(2); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_recon->Draw("colz"); draw_channel_dividers_2d(spans, nbins);
+                c.cd(3); gPad->SetRightMargin(0.14); gPad->SetTopMargin(0.13); h_resid->Draw("colz"); draw_channel_dividers_2d(spans, nbins);
+                c.cd(0);
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+
+            // ---- Page 3: sqrt(diag) per bin, original vs reconstructed ----
+            {
+                auto h_d_orig  = std::make_unique<TH1D>(("h_diag_orig_"+systname).c_str(), (display+" fractional uncertainty per bin;Bin index;#sqrt{diag}").c_str(), nbins, 0, nbins);
+                auto h_d_recon = std::make_unique<TH1D>(("h_diag_recon_"+systname).c_str(), "", nbins, 0, nbins);
+                h_d_orig->SetDirectory(nullptr); h_d_recon->SetDirectory(nullptr);
+                for(int b = 0; b < nbins; ++b) {
+                    h_d_orig ->SetBinContent(b+1, std::sqrt(std::max(0.0f, dbg.original_frac_cov(b,b))));
+                    h_d_recon->SetBinContent(b+1, std::sqrt(std::max(0.0f, recon(b,b))));
+                }
+                h_d_orig->SetLineColor(kBlack);
+                h_d_orig->SetLineWidth(2);
+                h_d_recon->SetLineColor(kRed);
+                h_d_recon->SetLineWidth(2);
+                h_d_recon->SetLineStyle(2);
+                const double ymax = 1.15 * std::max(h_d_orig->GetMaximum(), h_d_recon->GetMaximum());
+                h_d_orig->SetMaximum(ymax);
+                h_d_orig->SetMinimum(0.0);
+                c.Clear();
+                gPad->SetTopMargin(0.13);
+                h_d_orig->Draw("hist");
+                h_d_recon->Draw("hist same");
+                draw_channel_dividers_1d(spans, 0.0, ymax);
+                auto *leg = new TLegend(0.7, 0.78, 0.92, 0.9);
+                leg->SetBorderSize(0);
+                leg->SetFillStyle(0);
+                leg->AddEntry(h_d_orig.get(), "Original (multisim)", "l");
+                leg->AddEntry(h_d_recon.get(), Form("Reconstructed (K=%d)", K), "l");
+                leg->Draw();
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+
+            // ---- Page 4: scree plot (eigenvalues sorted descending, log y) ----
+            std::vector<double> sorted_eigs(n_eig);
+            for(int i = 0; i < n_eig; ++i) sorted_eigs[i] = dbg.eigenvalues(n_eig - 1 - i);
+            {
+                std::vector<double> xs(n_eig), ys(n_eig);
+                bool any_positive = false;
+                double y_floor = 1e-30;
+                for(int i = 0; i < n_eig; ++i) {
+                    xs[i] = i;
+                    ys[i] = sorted_eigs[i] > 0 ? sorted_eigs[i] : y_floor;
+                    if(sorted_eigs[i] > 0) any_positive = true;
+                }
+                auto *g = new TGraph(n_eig, xs.data(), ys.data());
+                g->SetTitle((display + " eigenvalue scree;eigenvalue index (descending);eigenvalue").c_str());
+                g->SetMarkerStyle(20);
+                g->SetMarkerSize(0.6);
+                g->SetMarkerColor(kBlue + 1);
+                g->SetLineColor(kBlue + 1);
+                c.Clear();
+                gPad->SetTopMargin(0.13);
+                if(any_positive) gPad->SetLogy(1);
+                g->Draw("APL");
+                if(K > 0 && K <= n_eig) {
+                    // Mark the boundary of the kept region (right edge of last kept index).
+                    const double x = K - 0.5;
+                    const double y_top = sorted_eigs[0] * 10;
+                    const double y_bot = y_floor;
+                    auto *ln = new TLine(x, y_bot, x, y_top);
+                    ln->SetLineColor(kRed);
+                    ln->SetLineStyle(2);
+                    ln->SetLineWidth(2);
+                    ln->Draw();
+                }
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+                gPad->SetLogy(0);
+            }
+
+            // ---- Page 5: cumulative variance ----
+            {
+                double total = 0.0;
+                for(int i = 0; i < n_eig; ++i) total += std::max(0.0, static_cast<double>(dbg.eigenvalues(i)));
+                std::vector<double> xs(n_eig), ys(n_eig);
+                double running = 0.0;
+                for(int i = 0; i < n_eig; ++i) {
+                    running += std::max(0.0, sorted_eigs[i]);
+                    xs[i] = i + 1;
+                    ys[i] = total > 0 ? running / total : 0.0;
+                }
+                auto *g = new TGraph(n_eig, xs.data(), ys.data());
+                g->SetTitle((display + " cumulative variance captured;Number of modes kept;Fraction of trace").c_str());
+                g->SetMarkerStyle(20);
+                g->SetMarkerSize(0.6);
+                g->SetLineColor(kBlue + 1);
+                g->SetMarkerColor(kBlue + 1);
+                c.Clear();
+                gPad->SetTopMargin(0.13);
+                g->Draw("APL");
+                g->GetHistogram()->SetMinimum(0.0);
+                g->GetHistogram()->SetMaximum(1.05);
+                auto draw_h = [&](double y, int col, const char *label){
+                    auto *ln = new TLine(0, y, n_eig, y);
+                    ln->SetLineColor(col); ln->SetLineStyle(2); ln->Draw();
+                    auto *t = new TLatex(0.92 * n_eig, y + 0.01, label);
+                    t->SetTextSize(0.025f); t->SetTextColor(col); t->Draw();
+                };
+                draw_h(0.90, kGray+2, "90%");
+                draw_h(0.95, kGray+2, "95%");
+                draw_h(0.99, kGray+2, "99%");
+                if(K > 0 && K <= n_eig) {
+                    auto *lnK = new TLine(K, 0, K, 1.05);
+                    lnK->SetLineColor(kRed); lnK->SetLineStyle(2); lnK->SetLineWidth(2);
+                    lnK->Draw();
+                }
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+
+            // ---- Page 6: eigenvector heatmap (kept modes only), entries = sqrt(λ_k) * v_k[b] ----
+            if(K > 0) {
+                auto h_ev = std::make_unique<TH2D>(("h_eigvec_"+systname).c_str(), (display + " eigenvectors (rows = kept knobs);Bin index;Knob k").c_str(), nbins, 0, nbins, K, 0, K);
+                h_ev->SetDirectory(nullptr);
+                for(int k = 0; k < K; ++k) {
+                    const int idx = dbg.kept_indices[k];
+                    const float s = std::sqrt(std::max(0.0f, dbg.eigenvalues(idx)));
+                    const Eigen::VectorXf v = dbg.eigenvectors.col(idx);
+                    for(int b = 0; b < nbins; ++b) {
+                        h_ev->SetBinContent(b+1, k+1, s * v(b));
+                    }
+                }
+                const float m_ev = std::max(std::fabs(h_ev->GetMaximum()), std::fabs(h_ev->GetMinimum()));
+                h_ev->SetMaximum(m_ev);
+                h_ev->SetMinimum(-m_ev);
+                c.Clear();
+                gPad->SetRightMargin(0.13);
+                gPad->SetTopMargin(0.13);
+                h_ev->Draw("colz");
+                // Vertical channel dividers
+                for(size_t s = 1; s < spans.size(); ++s) {
+                    const double x = static_cast<double>(spans[s].start_bin);
+                    auto *ln = new TLine(x, 0, x, K);
+                    ln->SetLineColor(kGray+2); ln->SetLineStyle(2); ln->Draw();
+                }
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+
+            // ---- Per-knob bin response, 4 per page (sqrt(λ_k) * v_k[b]) ----
+            for(int k0 = 0; k0 < K; k0 += 4) {
+                c.Clear();
+                c.Divide(2, 2);
+                for(int kk = 0; kk < 4 && (k0 + kk) < K; ++kk) {
+                    const int k = k0 + kk;
+                    const int idx = dbg.kept_indices[k];
+                    const float s = std::sqrt(std::max(0.0f, dbg.eigenvalues(idx)));
+                    const Eigen::VectorXf v = dbg.eigenvectors.col(idx);
+                    auto h = std::make_unique<TH1D>(Form("h_knob_resp_%s_%d", systname.c_str(), k), Form("%s knob %d   #lambda = %.3g   (+1 #sigma response);Bin index;#sqrt{#lambda} #upoint v_{k}[b]", display.c_str(), k, dbg.eigenvalues(idx)), nbins, 0, nbins);
+                    h->SetDirectory(nullptr);
+                    double yabs = 0;
+                    for(int b = 0; b < nbins; ++b) {
+                        const double y = s * v(b);
+                        h->SetBinContent(b+1, y);
+                        yabs = std::max(yabs, std::fabs(y));
+                    }
+                    h->SetLineColor(kBlue + 1);
+                    h->SetLineWidth(2);
+                    h->SetMaximum(1.2 * (yabs > 0 ? yabs : 1.0));
+                    h->SetMinimum(-1.2 * (yabs > 0 ? yabs : 1.0));
+                    c.cd(kk + 1);
+                    gPad->SetTopMargin(0.13);
+                    h->DrawCopy("hist");
+                    draw_channel_dividers_1d(spans, h->GetMinimum(), h->GetMaximum());
+                    auto *zero = new TLine(0, 0, nbins, 0);
+                    zero->SetLineColor(kBlack); zero->Draw();
+                }
+                c.cd(0);
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+
+            // ---- Per-knob CV ± 1σ band (linear knob: response = 1 ± alpha_b), 4 per page ----
+            const Eigen::VectorXf cv_full = cv.Spec();
+            const bool cv_size_ok = (cv_full.size() == nbins);
+            if(cv_size_ok) {
+                for(int k0 = 0; k0 < K; k0 += 4) {
+                    c.Clear();
+                    c.Divide(2, 2);
+                    for(int kk = 0; kk < 4 && (k0 + kk) < K; ++kk) {
+                        const int k = k0 + kk;
+                        const int idx = dbg.kept_indices[k];
+                        const float s = std::sqrt(std::max(0.0f, dbg.eigenvalues(idx)));
+                        const Eigen::VectorXf v = dbg.eigenvectors.col(idx);
+                        auto h_cv = std::make_unique<TH1D>(Form("h_cv_%s_%d", systname.c_str(), k), Form("%s knob %d   CV #pm 1 #sigma;Bin index;Events", display.c_str(), k), nbins, 0, nbins);
+                        auto h_up = std::make_unique<TH1D>(Form("h_up_%s_%d", systname.c_str(), k), "", nbins, 0, nbins);
+                        auto h_dn = std::make_unique<TH1D>(Form("h_dn_%s_%d", systname.c_str(), k), "", nbins, 0, nbins);
+                        h_cv->SetDirectory(nullptr); h_up->SetDirectory(nullptr); h_dn->SetDirectory(nullptr);
+                        double ymax = 0;
+                        for(int b = 0; b < nbins; ++b) {
+                            const double alpha = s * v(b);
+                            const double y0 = cv_full(b);
+                            h_cv->SetBinContent(b+1, y0);
+                            h_up->SetBinContent(b+1, y0 * (1.0 + alpha));
+                            h_dn->SetBinContent(b+1, y0 * (1.0 - alpha));
+                            ymax = std::max({ymax, std::fabs(y0 * (1.0 + alpha)), std::fabs(y0 * (1.0 - alpha))});
+                        }
+                        h_cv->SetLineColor(kBlack);
+                        h_cv->SetLineWidth(2);
+                        h_up->SetLineColor(kRed + 1);
+                        h_dn->SetLineColor(kAzure + 2);
+                        h_up->SetLineStyle(2);
+                        h_dn->SetLineStyle(2);
+                        h_cv->SetMaximum(1.15 * ymax);
+                        h_cv->SetMinimum(0.0);
+                        c.cd(kk + 1);
+                        gPad->SetTopMargin(0.13);
+                        h_cv->DrawCopy("hist");
+                        h_up->DrawCopy("hist same");
+                        h_dn->DrawCopy("hist same");
+                        draw_channel_dividers_1d(spans, 0.0, 1.15 * ymax);
+                    }
+                    c.cd(0);
+                    draw_version_stamp();
+                    c.Print(filename.c_str(), "pdf");
+                }
+            } else {
+                log<LOG_WARNING>(L"%1% || CV spectrum size %2% != covariance size %3% for systematic %4%; skipping CV-band pages.")
+                    % __func__ % static_cast<int>(cv_full.size()) % nbins % systname.c_str();
+            }
+
+            // ---- Aggregate band: CV ± from original cov vs ± from rank-K sum-of-knobs ----
+            if(cv_size_ok) {
+                auto h_cv  = std::make_unique<TH1D>(("h_aggcv_"+systname).c_str(), (display + " aggregate CV #pm 1 #sigma;Bin index;Events").c_str(), nbins, 0, nbins);
+                auto h_oup = std::make_unique<TH1D>(("h_aggoup_"+systname).c_str(), "", nbins, 0, nbins);
+                auto h_odn = std::make_unique<TH1D>(("h_aggodn_"+systname).c_str(), "", nbins, 0, nbins);
+                auto h_kup = std::make_unique<TH1D>(("h_aggkup_"+systname).c_str(), "", nbins, 0, nbins);
+                auto h_kdn = std::make_unique<TH1D>(("h_aggkdn_"+systname).c_str(), "", nbins, 0, nbins);
+                h_cv->SetDirectory(nullptr); h_oup->SetDirectory(nullptr); h_odn->SetDirectory(nullptr); h_kup->SetDirectory(nullptr); h_kdn->SetDirectory(nullptr);
+                double ymax = 0;
+                for(int b = 0; b < nbins; ++b) {
+                    const double y0 = cv_full(b);
+                    const double sigma_orig  = std::sqrt(std::max(0.0f, dbg.original_frac_cov(b,b))) * y0;
+                    const double sigma_recon = std::sqrt(std::max(0.0f, recon(b,b))) * y0;
+                    h_cv->SetBinContent(b+1, y0);
+                    h_oup->SetBinContent(b+1, y0 + sigma_orig);
+                    h_odn->SetBinContent(b+1, y0 - sigma_orig);
+                    h_kup->SetBinContent(b+1, y0 + sigma_recon);
+                    h_kdn->SetBinContent(b+1, y0 - sigma_recon);
+                    ymax = std::max({ymax, y0 + sigma_orig, y0 + sigma_recon});
+                }
+                h_cv->SetLineColor(kBlack);
+                h_cv->SetLineWidth(2);
+                h_oup->SetLineColor(kBlack); h_odn->SetLineColor(kBlack);
+                h_oup->SetLineStyle(2); h_odn->SetLineStyle(2);
+                h_kup->SetLineColor(kRed + 1); h_kdn->SetLineColor(kRed + 1);
+                h_kup->SetLineStyle(1); h_kdn->SetLineStyle(1);
+                h_cv->SetMaximum(1.15 * ymax);
+                h_cv->SetMinimum(0.0);
+                c.Clear();
+                gPad->SetTopMargin(0.13);
+                h_cv->Draw("hist");
+                // Draw rank-K band first, then original-multisim dashed lines on top so they
+                // remain visible when the two overlap.
+                h_kup->Draw("hist same");
+                h_kdn->Draw("hist same");
+                h_oup->Draw("hist same");
+                h_odn->Draw("hist same");
+                draw_channel_dividers_1d(spans, 0.0, 1.15 * ymax);
+                auto *leg = new TLegend(0.68, 0.76, 0.92, 0.9);
+                leg->SetBorderSize(0); leg->SetFillStyle(0);
+                leg->AddEntry(h_cv.get(),  "CV", "l");
+                leg->AddEntry(h_oup.get(), "CV #pm 1#sigma (original multisim)", "l");
+                leg->AddEntry(h_kup.get(), Form("CV #pm 1#sigma (rank-%d knobs)", K), "l");
+                leg->Draw();
+                draw_version_stamp();
+                c.Print(filename.c_str(), "pdf");
+            }
+        }
+
+        c.Print((filename + "]").c_str(), "pdf");
+        return 0;
+    }
 }

--- a/src/PROsurf.cxx
+++ b/src/PROsurf.cxx
@@ -1232,18 +1232,25 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
         }
     }
 
-    // Parameter labels (rotated -45 degrees)
-    float text_size = x_label_size;
+    // Parameter labels (rotated -45 degrees). Precompute labels so we can also shrink the
+    // font for long names: a -45 deg label of L chars drops ~0.42*size*L in NDC height; with
+    // the 0.30 bottom margin that gives size ~0.6/L. Take the smaller of that and the
+    // nBins-based x_label_size so long names are not clipped off the bottom of the page.
+    std::vector<std::string> labels(barvalues.size());
+    size_t max_label_len = 1;
+    for(size_t i = 0; i < barvalues.size(); ++i) {
+        if(mask_osc && with_osc && i < model.nparams) continue;
+        labels[i] = (with_osc && i < model.nparams)
+            ? ("Log_{10}(" + model.pretty_param_names[i] + ")")
+            : config.m_mcgen_variation_plotname_map.at(names[i]);
+        max_label_len = std::max(max_label_len, labels[i].size());
+    }
+    float len_based_size = std::max(0.012f, std::min(0.030f, 0.6f / (float)max_label_len));
+    float text_size = std::min(x_label_size, len_based_size);
     float label_y = y_axis_min - y_range_size * 0.04f;
     for(size_t i = 0; i < barvalues.size(); ++i) {
         if(mask_osc && with_osc && i < model.nparams) continue;
-        std::string label;
-        if(with_osc && i < model.nparams) {
-            label = "Log_{10}(" + model.pretty_param_names[i] + ")";
-        } else {
-            label = config.m_mcgen_variation_plotname_map.at(names[i]);
-        }
-        TLatex* text = new TLatex(barvalues[i], label_y, label.c_str());
+        TLatex* text = new TLatex(barvalues[i], label_y, labels[i].c_str());
         text->SetTextAlign(13);
         text->SetTextSize(text_size);
         text->SetTextAngle(-45);
@@ -1316,18 +1323,24 @@ void PROfile::Plot(const PROconfig &config, const PROsyst &systs, const PROmodel
     todraw.GetYaxis()->SetTitleOffset(0.8);
 
     float y_min = todraw.GetMinimum();
+    // Precompute labels and shrink the font so the longest -45 deg label fits in the bottom
+    // margin (0.25 of the canvas). A rotated label of L chars drops ~0.42*size*L in NDC height;
+    // with margin ~0.25 that gives size ~0.5/L, capped at the previous fixed 0.03.
+    std::vector<std::string> labels(barvalues.size());
+    size_t max_label_len = 1;
+    for (size_t i = 0; i < barvalues.size(); ++i) {
+        labels[i] = (with_osc && i < model.nparams)
+            ? ("Log_{10}(" + model.pretty_param_names[i] + ")")
+            : config.m_mcgen_variation_plotname_map.at(names[i]);
+        max_label_len = std::max(max_label_len, labels[i].size());
+    }
+    float label_text_size = std::max(0.012f, std::min(0.03f, 0.5f / (float)max_label_len));
     for (size_t i = 0; i < barvalues.size(); ++i) {
         // In syst-only mode (with_osc=false), all entries are splines
         // In with_osc mode, first model.nparams entries are physics, rest are splines
-        std::string label;
-        if (with_osc && i < model.nparams) {
-            label = "Log_{10}(" + model.pretty_param_names[i] + ")";
-        } else {
-            label = config.m_mcgen_variation_plotname_map.at(names[i]);
-        }
-        TLatex* text = new TLatex(barvalues[i], y_min - 0.05, label.c_str());  // Position text below axis
+        TLatex* text = new TLatex(barvalues[i], y_min - 0.05, labels[i].c_str());  // Position text below axis
         text->SetTextAlign(13);
-        text->SetTextSize(0.03);
+        text->SetTextSize(label_text_size);
         text->SetTextAngle(-45);
         text->Draw();
     }

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -95,27 +95,30 @@ namespace PROfit {
                 ++n_covar;
             } else if(syst.mode == "covariance_to_spline") {
                 size_t n_before = splines.size();
+                size_t n_covar_before = covar_names.size();
                 FillSplinesFromCovariance(syst);
                 size_t n_after = splines.size();
+                size_t n_covar_after = covar_names.size();
 
                 // Propagate parent tag + plotname to the synthesized knob entries so downstream
                 // plotting code (PROplot.cxx) can group them under the same tag.
                 // The maps are populated by the XML parser; here we append entries for the
-                // dynamically-generated decomposition knobs.
+                // dynamically-generated decomposition knobs and the optional residual covariance.
                 PROconfig& mut_config = const_cast<PROconfig&>(config);
                 auto parent_tags_it = mut_config.m_mcgen_variation_tags.find(syst.systname);
                 auto parent_plotname_it = mut_config.m_mcgen_variation_plotname_map.find(syst.systname);
-                for(size_t si = n_before; si < n_after; ++si) {
-                    const std::string& knob_name = spline_names[si];
+                auto propagate = [&](const std::string& child_name) {
                     if(parent_tags_it != mut_config.m_mcgen_variation_tags.end()) {
-                        mut_config.m_mcgen_variation_tags[knob_name] = parent_tags_it->second;
+                        mut_config.m_mcgen_variation_tags[child_name] = parent_tags_it->second;
                     }
                     if(parent_plotname_it != mut_config.m_mcgen_variation_plotname_map.end()) {
-                        // Append "_decomp_knob_<i>" suffix onto parent plotname for readability
-                        const std::string suffix = knob_name.substr(syst.systname.size());
-                        mut_config.m_mcgen_variation_plotname_map[knob_name] = parent_plotname_it->second + suffix;
+                        // Append the "_decomp_knob_<i>" / "_resid_cov" suffix onto the parent plotname.
+                        const std::string suffix = child_name.substr(syst.systname.size());
+                        mut_config.m_mcgen_variation_plotname_map[child_name] = parent_plotname_it->second + suffix;
                     }
-                }
+                };
+                for(size_t si = n_before; si < n_after; ++si) propagate(spline_names[si]);
+                for(size_t ci = n_covar_before; ci < n_covar_after; ++ci) propagate(covar_names[ci]);
             }else if(syst.mode == "flat"){
                 this->CreateFlatMatrix(config, syst); 
                 covar_names.push_back(syst.systname); 
@@ -843,25 +846,28 @@ namespace PROfit {
         const Eigen::MatrixXf eigvecs = solver.eigenvectors(); // columns
 
         const int nbins = frac_cov.rows();
-        // Count strictly-positive eigenvalues (clamp near-zero/negative to 0)
+        // List strictly-positive eigenvalues in descending order (near-zero/negative are noise).
         const float tol = 10.0f * Eigen::NumTraits<float>::dummy_precision();
-        std::vector<int> kept_indices; // indices into eigvals, in descending-eigenvalue order
+        std::vector<int> positive_indices; // indices into eigvals, descending eigenvalue
         for(int i = nbins - 1; i >= 0; --i) {
-            if(eigvals(i) > tol) kept_indices.push_back(i);
+            if(eigvals(i) > tol) positive_indices.push_back(i);
         }
-        int K = static_cast<int>(kept_indices.size());
-        if(syst.num_decomp_knobs > 0 && syst.num_decomp_knobs < K) {
+        const int n_pos = static_cast<int>(positive_indices.size());
+        int K = n_pos;
+        if(syst.num_decomp_knobs > 0 && syst.num_decomp_knobs < n_pos) {
             K = syst.num_decomp_knobs;
         }
         if(K == 0) {
             log<LOG_WARNING>(L"%1% || covariance_to_spline systematic %2% has no positive-eigenvalue modes; skipping.") % __func__ % syst.systname.c_str();
             return;
         }
-        // Truncate kept_indices to the actual retained set so debug plots reflect the user's choice.
-        kept_indices.resize(K);
+        // Top-K positive eigenpairs become spline knobs; the remaining positive eigenpairs
+        // (if any, and if requested) are folded into a residual covariance.
+        std::vector<int> kept_indices(positive_indices.begin(), positive_indices.begin() + K);
+        std::vector<int> residual_indices(positive_indices.begin() + K, positive_indices.end());
 
-        log<LOG_INFO>(L"%1% || covariance_to_spline %2%: keeping %3% of %4% eigenvectors (largest eigenvalue=%5%, smallest kept=%6%)")
-            % __func__ % syst.systname.c_str() % K % nbins % eigvals(nbins - 1) % eigvals(kept_indices[K - 1]);
+        log<LOG_INFO>(L"%1% || covariance_to_spline %2%: keeping %3% of %4% eigenvectors as splines (largest eigenvalue=%5%, smallest kept=%6%), %7% residual mode(s)")
+            % __func__ % syst.systname.c_str() % K % nbins % eigvals(nbins - 1) % eigvals(kept_indices[K - 1]) % static_cast<int>(residual_indices.size());
 
         const float lo = -3.0f, hi = 3.0f;
         const int n_segments = 6; // knots at -3, -2, -1, 0, 1, 2
@@ -904,9 +910,51 @@ namespace PROfit {
             spline_names.push_back(knob_name);
             spline_lo.push_back(lo);
             spline_hi.push_back(hi);
+            spline_has_restrict.push_back(false);
+            spline_restrict_lo.push_back(0.0f);
+            spline_restrict_hi.push_back(0.0f);
             spline_binnings.push_back(syst.binning);
             dbg.knob_names.push_back(knob_name);
             ++n_splines;
+        }
+
+        // Fold the un-kept (smaller) positive eigenpairs into a residual covariance so the
+        // rank-K truncation does not throw away variance. Default on; disabled with
+        // include_resid_cov="false" in the XML.
+        // Only register the matrix when this PROsyst's binning matches the systematic's binning,
+        // mirroring external_covariance: covmat entries are summed assuming a common dimension,
+        // while the splines above stay binning-tagged and are safe across variables.
+        if(syst.include_resid_cov && !residual_indices.empty() && other_index == syst.binning) {
+            Eigen::MatrixXf residual_cov = Eigen::MatrixXf::Zero(nbins, nbins);
+            for(int idx : residual_indices) {
+                const float lambda = eigvals(idx);
+                const Eigen::VectorXf vec = eigvecs.col(idx);
+                residual_cov.noalias() += lambda * (vec * vec.transpose());
+            }
+            toFiniteMatrix(residual_cov);
+
+            const std::string resid_name = syst.systname + "_resid_cov";
+            syst_map[resid_name] = {covmat.size(), SystType::Covariance};
+            covmat.push_back(residual_cov);
+            corrmat.push_back(GenerateCorrMatrix(residual_cov));
+            covar_names.push_back(resid_name);
+            ++n_covar;
+
+            dbg.has_residual = true;
+            dbg.n_residual_modes = static_cast<int>(residual_indices.size());
+            dbg.residual_cov = std::move(residual_cov);
+            dbg.residual_cov_name = resid_name;
+
+            log<LOG_INFO>(L"%1% || covariance_to_spline %2%: retained %3% residual mode(s) as covariance %4%")
+                % __func__ % syst.systname.c_str() % dbg.n_residual_modes % resid_name.c_str();
+        } else if(!residual_indices.empty()) {
+            if(!syst.include_resid_cov) {
+                log<LOG_INFO>(L"%1% || covariance_to_spline %2%: dropping %3% residual mode(s) (include_resid_cov=false)")
+                    % __func__ % syst.systname.c_str() % static_cast<int>(residual_indices.size());
+            } else {
+                log<LOG_INFO>(L"%1% || covariance_to_spline %2%: residual covariance not registered for binning %3% (built only at the systematic's binning %4%)")
+                    % __func__ % syst.systname.c_str() % other_index % syst.binning;
+            }
         }
 
         cov2spline_debug_info[syst.systname] = std::move(dbg);

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -828,6 +828,8 @@ namespace PROfit {
 
     void PROsyst::FillSplinesFromCovariance(const SystStruct& syst) {
         Eigen::MatrixXf frac_cov = PROsyst::GenerateFracCovarMatrix(syst);
+        // Capture pre-symmetrization asymmetry as a sanity number for debug plots.
+        const float pre_symm_asymmetry = (frac_cov - frac_cov.transpose()).norm();
         // symmetrize to kill any float-asymmetry before eigendecomposition
         frac_cov = 0.5f * (frac_cov + frac_cov.transpose());
 
@@ -855,12 +857,23 @@ namespace PROfit {
             log<LOG_WARNING>(L"%1% || covariance_to_spline systematic %2% has no positive-eigenvalue modes; skipping.") % __func__ % syst.systname.c_str();
             return;
         }
+        // Truncate kept_indices to the actual retained set so debug plots reflect the user's choice.
+        kept_indices.resize(K);
 
         log<LOG_INFO>(L"%1% || covariance_to_spline %2%: keeping %3% of %4% eigenvectors (largest eigenvalue=%5%, smallest kept=%6%)")
             % __func__ % syst.systname.c_str() % K % nbins % eigvals(nbins - 1) % eigvals(kept_indices[K - 1]);
 
         const float lo = -3.0f, hi = 3.0f;
         const int n_segments = 6; // knots at -3, -2, -1, 0, 1, 2
+
+        Cov2SplineDebugInfo dbg;
+        dbg.original_frac_cov = frac_cov;
+        dbg.pre_symm_asymmetry = pre_symm_asymmetry;
+        dbg.eigenvalues = eigvals;
+        dbg.eigenvectors = eigvecs;
+        dbg.kept_indices = kept_indices;
+        dbg.binning = syst.binning;
+        dbg.knob_names.reserve(K);
 
         for(int k = 0; k < K; ++k) {
             const int ev_idx = kept_indices[k];
@@ -892,8 +905,11 @@ namespace PROfit {
             spline_lo.push_back(lo);
             spline_hi.push_back(hi);
             spline_binnings.push_back(syst.binning);
+            dbg.knob_names.push_back(knob_name);
             ++n_splines;
         }
+
+        cov2spline_debug_info[syst.systname] = std::move(dbg);
     }
 
     float PROsyst::GetSplineShift(std::string name, float shift, int bin) const {


### PR DESCRIPTION
Added covariance_to_spline_checks.pdf debugging information. 

`num_decomp_knobs` sets the number of largest eigenvalues to be turned into splines (default, all eigenvalues with a value that's positive and above some floating point tolerance). 

`include_resid_cov` tells it whether to turn use any remaining positive eigenvalues to make a covariance matrix representing the residual uncertainty after the largest components have been taken out to be treated as splines (true by default).

Example:

`<systematic type="covariance_to_spline" num_decomp_knobs="4" include_resid_cov="true" tag="Flux">expskin_Flux</systematic>`