### PR TITLE
Add inflate systematics option

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -451,6 +451,7 @@ namespace PROfit{
             std::map<std::string, std::vector<int>> m_mcgen_variation_include_only_weights; //map of systematics with include_only_weights (1-based indices of which weights to include in spline universes)
             std::map<std::string, std::pair<float,float>> m_mcgen_variation_restrict; //map of systematics with restrict="lo, hi" (clamp knob value during evaluation and fitting)
             std::map<std::string, float> m_mcgen_variation_scale; //map of systematics with scale factor to apply to weights (e.g., 0.001 for weights stored as x1000)
+            std::map<std::string, float> m_mcgen_variation_inflate; //map of systematics with inflate factor: spline shifts are scaled about 1 (ratio -> 1 + inflate*(ratio-1)) before interpolation; covariance matrices are scaled by inflate^2
             std::map<std::string, int> m_mcgen_variation_num_decomp_knobs; //map of covariance_to_spline systematics to the number of eigenpairs to keep (-1 or missing = keep all)
             std::map<std::string, bool> m_mcgen_variation_include_resid_cov; //map of covariance_to_spline systematics to whether the un-kept eigenpairs are retained as a residual covariance (missing = true)
       

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -83,6 +83,7 @@ namespace PROfit{
         bool force_0_cv = false;    ///< If true, normalise spline shifts by the shift at knob=0.
         std::vector<int> include_only_weights; ///< 1-based indices of weight universes to include; empty = all.
         float scale = 1.0f;         ///< Scale factor applied to all weights (e.g. 0.001 for weights stored as x1000).
+        float inflate = 1.0f;       ///< Uncertainty inflation factor: spline ratios are scaled about 1 (ratio -> 1 + inflate*(ratio-1)) before interpolation; covariance matrices are scaled by inflate^2.
         int num_decomp_knobs = -1;  ///< For "covariance_to_spline": number of top eigenpairs to keep as spline knobs (-1 = keep all).
         bool include_resid_cov = true; ///< For "covariance_to_spline": if true, retain the un-kept (smaller) eigenpairs as a "<systname>_resid_cov" covariance matrix instead of dropping them.
         bool has_restrict = false;  ///< If true, clamp the knob value to [restrict_lo, restrict_hi] during evaluation and fitting.
@@ -120,6 +121,9 @@ namespace PROfit{
             }
             if (version >= 3) {
                 ar & include_resid_cov;
+            }
+            if (version >= 4) {
+                ar & inflate;
             }
         }
 
@@ -325,6 +329,6 @@ namespace PROfit{
 
 };
 
-BOOST_CLASS_VERSION(PROfit::SystStruct, 3)
+BOOST_CLASS_VERSION(PROfit::SystStruct, 4)
 
 #endif

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1252,7 +1252,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 }
 
                 //check for known attributes
-                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar", "restrict", "mirror", "num_decomp_knobs", "include_resid_cov"};
+                const std::vector<std::string> expected_attrs = {"name", "type", "plotname", "binning", "knobvals", "tag", "prior", "center", "force_0_cv", "include_only_weights", "scale","filename", "xvar", "yvar", "restrict", "mirror", "num_decomp_knobs", "include_resid_cov", "inflate"};
                 for (const tinyxml2::XMLAttribute* attr = pAllowList->FirstAttribute(); attr; attr = attr->Next()) {
                     std::string name = attr->Name();
                     if (std::find(expected_attrs.begin(), expected_attrs.end(), name) == expected_attrs.end()) {
@@ -1273,6 +1273,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 const char *include_only_weights_str = pAllowList->Attribute("include_only_weights");
                 const char *restrict_str = pAllowList->Attribute("restrict");
                 const char *scale = pAllowList->Attribute("scale");
+                const char *inflate = pAllowList->Attribute("inflate");
                 const char *filename = pAllowList->Attribute("filename");
                 const char *xvar = pAllowList->Attribute("xvar");
                 const char *yvar = pAllowList->Attribute("yvar");
@@ -1410,6 +1411,21 @@ int PROconfig::LoadFromXML(const std::string &filename){
                 if(scale) {
                     m_mcgen_variation_scale[wt] = std::strtof(scale, NULL);
                     log<LOG_INFO>(L"%1% || Parsed scale=%2% for systematic %3%") % __func__ % m_mcgen_variation_scale[wt] % wt.c_str();
+                }
+                if(inflate) {
+                    char *end;
+                    float inflate_val = std::strtof(inflate, &end);
+                    if(end == inflate || inflate_val <= 0) {
+                        log<LOG_ERROR>(L"%1% || ERROR! inflate attribute for systematic %2% must be a positive number, got '%3%'") % __func__ % wt.c_str() % inflate;
+                        throw std::invalid_argument(std::string("inflate attribute for systematic '") + wt + "' must be a positive number");
+                    }
+                    m_mcgen_variation_inflate[wt] = inflate_val;
+                    log<LOG_INFO>(L"%1% || Parsed inflate=%2% for systematic %3%") % __func__ % inflate_val % wt.c_str();
+                    const std::vector<std::string> inflatable_types = {"spline", "spline_to_covariance", "covariance", "external_covariance", "norm", "hist1d", "hist2d"};
+                    if(!variation_type || std::find(inflatable_types.begin(), inflatable_types.end(), variation_type) == inflatable_types.end()) {
+                        log<LOG_WARNING>(L"%1% || inflate is not supported for systematic %2% (type %3%); it will have no effect.")
+                            % __func__ % wt.c_str() % (variation_type ? variation_type : "unspecified");
+                    }
                 }
                 if(mirrored) {
                     if(strcmp(mirrored, "false") == 0 || strcmp(mirrored, "no") == 0 || strcmp(mirrored, "0") == 0)

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -486,6 +486,11 @@ namespace PROfit {
                     sv.back().scale = inconfig.m_mcgen_variation_scale.at(sys_name);
                     log<LOG_INFO>(L"%1% || Setting scale=%2% for systematic %3%") % __func__ % sv.back().scale % sys_name.c_str();
                 }
+                // Check if inflate is set for this systematic
+                if(inconfig.m_mcgen_variation_inflate.find(sys_name) != inconfig.m_mcgen_variation_inflate.end()) {
+                    sv.back().inflate = inconfig.m_mcgen_variation_inflate.at(sys_name);
+                    log<LOG_INFO>(L"%1% || Setting inflate=%2% for systematic %3%") % __func__ % sv.back().inflate % sys_name.c_str();
+                }
                 if(sys_mode == "spline" || sys_mode == "spline_to_covariance") {
                     bool override_knobs = inconfig.m_mcgen_variation_knobval_override.find(sys_name) != inconfig.m_mcgen_variation_knobval_override.end();
                     if(!override_knobs && map_systematic_knob_vals.find(sys_name) == map_systematic_knob_vals.end()) {

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -414,10 +414,16 @@ namespace PROfit {
 
         std::string sysname = syst.GetSysName();
 
-        //generate matrix only if it's not already in the map 
+        //generate matrix only if it's not already in the map
         if(syst_map.find(sysname) == syst_map.end()){
             std::pair<Eigen::MatrixXf, Eigen::MatrixXf> matrices = PROsyst::GenerateCovarMatrices(syst);
 
+            // If inflate is set, scale the covariance by inflate^2 (uncertainty scales by inflate).
+            // The correlation matrix is unchanged by a constant scaling.
+            if(syst.inflate != 1.0f) {
+                log<LOG_INFO>(L"%1% || Applying inflate=%2% (covariance x %3%) for systematic %4%") % __func__ % syst.inflate % (syst.inflate * syst.inflate) % sysname.c_str();
+                matrices.first *= syst.inflate * syst.inflate;
+            }
 
             syst_map[sysname] = {covmat.size(), SystType::Covariance};
             covmat.push_back(matrices.first);
@@ -540,6 +546,12 @@ namespace PROfit {
     void PROsyst::LoadExternalCovarianceMatrix(const PROconfig &config, const SystStruct& syst){
         std::string matrixname = syst.GetSysName();
         Eigen::MatrixXf fracM = LoadExternalFractionalCovariance(config, syst);
+
+        // If inflate is set, scale the covariance by inflate^2 (uncertainty scales by inflate).
+        if(syst.inflate != 1.0f) {
+            log<LOG_INFO>(L"%1% || Applying inflate=%2% (covariance x %3%) for systematic %4%") % __func__ % syst.inflate % (syst.inflate * syst.inflate) % matrixname.c_str();
+            fracM *= syst.inflate * syst.inflate;
+        }
 
         // Generate correlation matrix from fractional covariance
         Eigen::MatrixXf corrM = PROsyst::GenerateCorrMatrix(fracM);
@@ -765,6 +777,16 @@ namespace PROfit {
             PROspec ratio_at_0 = ratios[knob0_index];
             for (size_t i = 0; i < ratios.size(); ++i) {
                 ratios[i] = ratios[i] / ratio_at_0;
+            }
+        }
+
+        // If inflate is set, scale the spline shifts about 1 (ratio -> 1 + inflate*(ratio - 1))
+        // before interpolation, inflating the uncertainty while keeping the no-shift value of 1 fixed.
+        if (syst.inflate != 1.0f) {
+            log<LOG_INFO>(L"%1% || Applying inflate=%2% to spline shifts for systematic %3%") % __func__ % syst.inflate % syst.systname.c_str();
+            for (PROspec& ratio : ratios) {
+                Eigen::VectorXf& v = ratio.Spec();
+                v = (1.0f + syst.inflate * (v.array() - 1.0f)).matrix();
             }
         }
 


### PR DESCRIPTION
Adds an option to inflate a certain systematic, making it larger by some factor (or smaller by inflating by values less than one).

This works for splines:

`<allowlist type="spline" binning="var1" plotname="ZExp_b1" inflate="10.0" tag="QE-MEC">ZExpPCAWeighter_SBNNuSyst_ZExpPCA_multisigma_b1</allowlist>` inflates this systematic by a factor of 10, by changing the spline ratios: (ratio -> 1 + inflate*(ratio - 1))


`<allowlist type="covariance" plotname="NonRESBGvpCC1pi" inflate="10.0" tag="NonRESBG">GENIEReWeight_SBN_v1_multisim_NonRESBGvpCC1pi</allowlist>` inflates this systematic by a factor of 10, by multiplying each element of the covariance matrix by 10^2.
