### PR TITLE
Fix PROCNP slicing derived models to PROmodel base

### DIFF
--- a/inc/PROCNP.h
+++ b/inc/PROCNP.h
@@ -46,7 +46,7 @@ namespace PROfit{
             const PROconfig config; ///< Analysis configuration (owned copy).
             const PROpeller peller; ///< MC event store (owned copy).
             const PROsyst *syst;    ///< Systematic object (non-owning pointer).
-            const PROmodel model;   ///< Physics model (owned copy).
+            const PROmodel &model;  ///< Physics model (non-owning reference, as in PROchi; an owned copy would slice derived models to the PROmodel base, losing their get_probs override).
             const PROdata data;     ///< Observed data spectrum (owned copy).
             EvalStrategy strat;     ///< Evaluation strategy.
             bool shape_only;        ///< If true, compute chi-squared on area-normalised spectra.


### PR DESCRIPTION
PROCNP stored the physics model as an owned by-value copy (const PROmodel model). Template-fit models are derived classes with an overridden get_probs and their own state; copy-constructing them into a base-class member slices that away, so the base get_probs runs with an empty ivars/var_arrs and aborts on var_arrs[0]
(stl_vector.h assertion, SIGABRT) as soon as profile calls FillSpectra with metric->GetModel().

Store a non-owning reference instead, matching PROchi, whose docs already note all heavy objects are stored as references owned by the caller.

Allows one to run -c PROCNP with template fit model.