### PR TITLE
Correctly grab x label for `bins2D` plots

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -531,12 +531,11 @@ namespace PROfit{
             const Binning& GetChannelVariableBins(size_t channel_index, size_t other_index) const;
 
             /* Function: build the X-axis title for a channel as "label [unit]",
-             * omitting either part if empty. For 2D variables, the legacy
-             * combined "xtitle;ytitle" string in m_channel_variable_units is
-             * returned as-is.
-             */
+             * omitting either part if empty. For 2D variables, the combined
+             */ "xtitle;ytitle" is split and the first part is returned.
             std::string GetChannelXAxisTitle(size_t channel_index) const;
             std::string GetChannelXAxisTitle(size_t channel_index, size_t other_index) const;
+            std::string GetChannelAxisTitle(size_t channel_index, size_t other_index, size_t dim) const;
 
             /**
              * @brief Install a runtime fit-region mask over the collapsed bins of one variable.

--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -532,7 +532,8 @@ namespace PROfit{
 
             /* Function: build the X-axis title for a channel as "label [unit]",
              * omitting either part if empty. For 2D variables, the combined
-             */ "xtitle;ytitle" is split and the first part is returned.
+             * "xtitle;ytitle" is split and the first part is returned.
+            */
             std::string GetChannelXAxisTitle(size_t channel_index) const;
             std::string GetChannelXAxisTitle(size_t channel_index, size_t other_index) const;
             std::string GetChannelAxisTitle(size_t channel_index, size_t other_index, size_t dim) const;

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -2043,6 +2043,20 @@ std::string PROconfig::GetChannelXAxisTitle(size_t channel_index, size_t other_i
                            m_channel_variable_units[channel_index][other_index]);
 }
 
+std::string PROconfig::GetChannelAxisTitle(size_t channel_index, size_t other_index, size_t dim) const {
+    const std::string title = GetChannelXAxisTitle(channel_index, other_index);
+    if(channel_index >= m_channel_variable_dims.size() ||
+       other_index >= m_channel_variable_dims[channel_index].size() ||
+       m_channel_variable_dims[channel_index][other_index] != 2) {
+        return dim == 0 ? title : "";
+    }
+
+    const size_t separator = title.find(';');
+    if(dim == 0) return title.substr(0, separator);
+    if(dim == 1 && separator != std::string::npos) return title.substr(separator + 1);
+    return "";
+}
+
 std::string PROconfig::GetChannelUnit(size_t channel_index, size_t other_index) const {
     // 2D variables keep the legacy combined "xtitle;ytitle" string in their
     // units slot, so it isn't a real unit -- skip straight to the channel-level.

--- a/src/PROdata.cxx
+++ b/src/PROdata.cxx
@@ -51,7 +51,7 @@ TH1D PROdata::toTH1D(const PROconfig &inconfig, int global_channel_index, int ot
     int nbins_dim = inconfig.m_channel_variable_bins[local_channel_index][other_index].NBinsAlong(dim);
     std::vector<float> bin_edges =  inconfig.m_channel_variable_bins[local_channel_index][other_index].Edges();
     std::string hist_name = inconfig.m_channel_names[local_channel_index] + " Data";
-    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(local_channel_index, other_index);
+    std::string xaxis_title = inconfig.GetChannelAxisTitle(local_channel_index, other_index, dim);
 
 
     //fill 1D hist
@@ -297,4 +297,3 @@ Eigen::VectorXf PROdata::Normalize(const PROconfig &inconfig, const PROspec &tar
 
     return spec.array()*output.array();
 }
-

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -1684,7 +1684,7 @@ namespace PROfit{
                         log<LOG_INFO>(L"%1% || hsum for tag '%2%': nbins=%3%, max=%4%, integral=%5%")
                             % __func__ % tag.c_str() % hsum->GetNbinsX() % hsum->GetMaximum() % hsum->Integral();
 
-                        hsum->SetXTitle(config.m_channel_plotnames[channel].c_str());
+                        hsum->SetXTitle(config.GetChannelAxisTitle(channel, other_index, 0).c_str());
                         hsum->SetYTitle("Fractional Uncertainty");
                         hsum->SetLineColor(kBlack);
                         hsum->SetLineWidth(2);
@@ -1739,7 +1739,7 @@ namespace PROfit{
                         hsum->SetBinContent(i+1, sqrt(hsum->GetBinContent(i+1)));
                     }
                     leg->AddEntry(hsum,"Sum","l");
-                    hsum->SetXTitle(config.m_channel_plotnames[channel].c_str());
+                    hsum->SetXTitle(config.GetChannelAxisTitle(channel, other_index, 0).c_str());
                     hsum->SetTitle(("Summary: "+name).c_str());
                     hsum->SetYTitle("Fractional Uncertainty");
                     hsum->SetLineColor(kBlack);

--- a/src/PROspec.cxx
+++ b/src/PROspec.cxx
@@ -109,7 +109,7 @@ TH1D PROspec::toTH1DSlices(PROconfig const & inconfig, int subchannel_index, int
     int nbins_dim = inconfig.m_channel_variable_bins[channel_index][other_index].NBinsAlong(dim);
     std::vector<float> bin_edges = inconfig.m_channel_variable_bins[channel_index][other_index].Edges(dim);
     std::string hist_name = inconfig.m_fullnames[subchannel_index];
-    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(channel_index, other_index);
+    std::string xaxis_title = inconfig.GetChannelAxisTitle(channel_index, other_index, dim);
 
     //fill 1D hist
     TH1D hSpec((hist_name+std::to_string(other_index)+std::to_string(dim)+std::to_string(subchannel_index)).c_str(),hist_name.c_str(), nbins_dim, &bin_edges[0]);
@@ -138,7 +138,7 @@ TH1D PROspec::toTH1D(PROconfig const & inconfig, int subchannel_index, int other
     int nbins_dim = inconfig.m_channel_variable_bins[channel_index][other_index].NBinsAlong(dim);
     std::vector<float> bin_edges = inconfig.m_channel_variable_bins[channel_index][other_index].Edges(dim);
     std::string hist_name = inconfig.m_fullnames[subchannel_index];
-    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(channel_index, other_index);
+    std::string xaxis_title = inconfig.GetChannelAxisTitle(channel_index, other_index, dim);
 
 
     // project along input dimension
@@ -165,7 +165,7 @@ TH2D PROspec::toTH2D(PROconfig const & inconfig, int subchannel_index, int other
     //set up hist specs
     std::vector<float> bin_edges = inconfig.m_channel_variable_bins[channel_index][other_index].Edges(dim);
     std::string hist_name = inconfig.m_fullnames[subchannel_index];
-    std::string xaxis_title =  inconfig.GetChannelXAxisTitle(channel_index, other_index);
+    std::string xaxis_title = inconfig.GetChannelAxisTitle(channel_index, other_index, 0);
 
     // 2D binning info
     size_t channel_nbins_x = inconfig.m_channel_variable_bins[channel_index][other_index].NBinsAlong(0);
@@ -179,6 +179,7 @@ TH2D PROspec::toTH2D(PROconfig const & inconfig, int subchannel_index, int other
     TH2D hSpec(hist_name.c_str(),hist_name.c_str(), channel_nbins_x, edges_x.data(), channel_nbins_y, edges_y.data());
     hSpec.SetDirectory(nullptr);  // detach from gDirectory; multiple calls reuse names and would otherwise warn.
     hSpec.GetXaxis()->SetTitle(xaxis_title.c_str());
+    hSpec.GetYaxis()->SetTitle(inconfig.GetChannelAxisTitle(channel_index, other_index, 1).c_str());
 
     for(int xbin = 0; xbin < (int)channel_nbins_x; xbin++){
         for(int ybin = 0; ybin < (int)channel_nbins_y; ybin++){


### PR DESCRIPTION
Correctly grab `x` label instead of full 2D label when plotting `bins2D` in `_DetVar*.pdf` and `_fractional_systematics.pdf`