### PR TITLE
DRAFT V2 Fix MCStat being dropped from fractional-systematics plots

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -426,6 +426,7 @@ namespace PROfit{
 
             //specific bits for covairiancegeneration
             bool m_use_mcstats = false;
+            std::string m_mcstat_systname = "mcstat";  ///< XML name of the mcstat systematic; the key its covariance is registered under (defaults to legacy "mcstat")
             std::vector<std::string> m_mcgen_weightmaps_formulas;
             std::vector<bool> m_mcgen_weightmaps_uses;
             std::vector<std::string> m_mcgen_weightmaps_patterns;

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1284,6 +1284,9 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
                 m_mcgen_variation_type.push_back(variation_type);
                 m_mcgen_variation_type_map[wt] = variation_type;
+                // mcstat's covariance is registered in PROsyst under the systematic's name; remember
+                // that name here so the covariance key matches the tag/plotname maps (both keyed by wt).
+                if(variation_type && std::string(variation_type) == "mcstat") m_mcstat_systname = wt;
 
                 // DetVar variations are handled separately (not weight branches in MC files),
                 // so don't add them to the allowlist that PROcess_CAFAna uses.

--- a/src/PROjector.cxx
+++ b/src/PROjector.cxx
@@ -113,7 +113,7 @@ namespace PROfit {
         // cross-detector correlation for a pre-fit to constrain.
         std::vector<std::string> promote_names;
         for(const std::string &name : systs.covar_names) {
-            if(name == "mcstat") continue;
+            if(name == config.m_mcstat_systname) continue;
             if(std::find(keep_covariance.begin(), keep_covariance.end(), name) != keep_covariance.end()) {
                 log<LOG_INFO>(L"%1% || PROjector keeping systematic %2% as unconstrained covariance.") % __func__ % name.c_str();
                 continue;

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -182,7 +182,9 @@ namespace PROfit {
             Eigen::MatrixXf fractional_mcstat_cov =  prop.variable_mc_stat_err[other_index].array().square().inverse().matrix().asDiagonal();
             toFiniteMatrix(fractional_mcstat_cov);
             Eigen::MatrixXf mcstat_corr = GenerateCorrMatrix(fractional_mcstat_cov);
-            syst_map["mcstat"] = {covmat.size(), SystType::Covariance};
+            // Register under the systematic's XML name (like every other covariance at
+            // syst_map[syst.systname] above) so downstream tag/plotname lookups match its key.
+            syst_map[config.m_mcstat_systname] = {covmat.size(), SystType::Covariance};
             covmat.push_back(fractional_mcstat_cov);
             corrmat.push_back(mcstat_corr);
             ++n_covar;


### PR DESCRIPTION
The mcstat covariance was registered in syst_map under the hardcoded literal "mcstat" (PROsyst), while its tag/plotname live in the config maps under the systematic's XML name (e.g. "MCStat"). Every other covariance is registered under syst.systname, so the case-sensitive plot lookups matched those, but dropped MCStat (and the .at() there would throw std::out_of_range).

This code registers mcstat under its actual XML name like every other systematic: PROconfig remembers the mcstat systematic's name (m_mcstat_systname), PROsyst keys the covariance by it, and the PROjector guard matches it. Works regardless of how the XML cases/spells the name (MCStat, mcstats, empty->null), which the two-function case-insensitive patch does not fully cover.

Alternative to the plot-only case-insensitive fix on scott/fix-mcstat-plotting-caseinsensitive.