### PR TITLE
Nan/INF in hist reweight var should lead to weight of 1

### DIFF
--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -1358,10 +1358,10 @@ namespace PROfit {
                 if(spline_bin < 0) continue;
                 int var_num = inconfig.m_mcgen_variation_histaxisvars_map.at(var_syst_objs.front()->systname)[0];
                 float val = vars[var_num].first();
-                if(std::isnan(val) || std::isinf(val)) continue;
                 TH1 *h = inconfig.m_mcgen_variation_hist1d_map.at(var_syst_objs.front()->systname);
                 int bin = h->FindBin(val);
                 float wgt = h->GetBinContent(bin);
+                if(std::isnan(val) || std::isinf(val)) wgt = 1;
                 if(val < h->GetXaxis()->GetXmin() || val > h->GetXaxis()->GetXmax()) wgt = 1;
 
                 // Only filling 1 sigma, so just combine CV and Universe filling
@@ -1376,10 +1376,10 @@ namespace PROfit {
                 int yvar_num = inconfig.m_mcgen_variation_histaxisvars_map.at(var_syst_objs.front()->systname)[1];
                 float xval = vars[xvar_num].first();
                 float yval = vars[yvar_num].first();
-                if(std::isnan(xval) || std::isnan(yval) || std::isinf(xval) || std::isinf(yval)) continue;
                 TH2 *h = inconfig.m_mcgen_variation_hist2d_map.at(var_syst_objs.front()->systname);
                 int bin = h->FindBin(xval, yval);
                 float wgt = h->GetBinContent(bin);
+                if(std::isnan(xval) || std::isnan(yval) || std::isinf(xval) || std::isinf(yval)) wgt = 1;
                 if(xval < h->GetXaxis()->GetXmin() || xval > h->GetXaxis()->GetXmax()
                     || yval < h->GetYaxis()->GetXmin() || yval > h->GetYaxis()->GetXmax()) wgt = 1;
 


### PR DESCRIPTION
If an event has a value of NaN or INF for the variable used for histogram reweighting, set the weight to 1.

Before we ignored the event which led to situations where an event was included in the fit but not in the spline calculations (e.g., we fit in reco E, but reweight in muon angle and there is no muon so the angle is set to NaN).

There are alternatives that are cleaner, e.g., using separate subchannels, and those are being used, but this at least prevents people from getting wildly incorrect weights when putting everything in a single subchannel.