### PR TITLE
Add `norm_to_covariance` systematic

### DIFF
--- a/inc/PROconfig.h
+++ b/inc/PROconfig.h
@@ -404,6 +404,7 @@ namespace PROfit{
             int m_num_variation_type_spline_to_covariance = 0;
             int m_num_variation_type_flat = 0;
             int m_num_variation_type_norm = 0;
+            int m_num_variation_type_norm_to_covariance = 0;
             int m_num_variation_type_hist1d = 0;
             int m_num_variation_type_hist2d = 0;
 

--- a/inc/PROcreate.h
+++ b/inc/PROcreate.h
@@ -56,7 +56,8 @@ namespace PROfit{
      * event-by-event; afterwards PROsyst reads it to build splines or covariance matrices.
      *
      * Supported modes (stored in the `mode` field): "multisim", "minmax", "covar", "spline",
-     * "external", "flat", "norm", "hist1d", "hist2d", "spline_to_covariance".
+     * "external", "flat", "norm", "norm_to_covariance", "hist1d", "hist2d",
+     * "spline_to_covariance".
      */
     struct SystStruct {
 

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -189,6 +189,9 @@ namespace PROfit {
              */
             void CreateFlatMatrix(const PROconfig& config, const SystStruct& syst);
 
+            /* Function: Build a fully correlated fractional covariance over the selected bins. */
+            void CreateNormMatrix(const PROconfig& config, const SystStruct& syst);
+
             /* Function: Given a SystStruct, load an external fractinal covariance matrix, and calculate correlation matrix, and add matrices to covmat_map and corrtmat_map
              */
             void LoadExternalCovarianceMatrix(const PROconfig& config, const SystStruct& syst);

--- a/src/PROconfig.cxx
+++ b/src/PROconfig.cxx
@@ -1421,7 +1421,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
                     }
                     m_mcgen_variation_inflate[wt] = inflate_val;
                     log<LOG_INFO>(L"%1% || Parsed inflate=%2% for systematic %3%") % __func__ % inflate_val % wt.c_str();
-                    const std::vector<std::string> inflatable_types = {"spline", "spline_to_covariance", "covariance", "external_covariance", "norm", "hist1d", "hist2d"};
+                    const std::vector<std::string> inflatable_types = {"spline", "spline_to_covariance", "covariance", "external_covariance", "norm", "norm_to_covariance", "hist1d", "hist2d"};
                     if(!variation_type || std::find(inflatable_types.begin(), inflatable_types.end(), variation_type) == inflatable_types.end()) {
                         log<LOG_WARNING>(L"%1% || inflate is not supported for systematic %2% (type %3%); it will have no effect.")
                             % __func__ % wt.c_str() % (variation_type ? variation_type : "unspecified");
@@ -1734,9 +1734,10 @@ int PROconfig::LoadFromXML(const std::string &filename){
 
         else if(m_mcgen_variation_type[i] == "flat"){
             m_num_variation_type_flat+=1;
-        }
-        else if(m_mcgen_variation_type[i] == "norm"){
+        } else if(m_mcgen_variation_type[i] == "norm"){
             m_num_variation_type_norm+=1;
+        } else if (m_mcgen_variation_type[i] == "norm_to_covariance") {
+            m_num_variation_type_norm_to_covariance+=1;
         }else if(m_mcgen_variation_type[i] == "spline_to_covariance"){
             m_num_variation_type_spline_to_covariance+=1;
         }else if(m_mcgen_variation_type[i] == "mcstat"){
@@ -1761,6 +1762,7 @@ int PROconfig::LoadFromXML(const std::string &filename){
     log<LOG_INFO>(L"%1% || num_variation_type_external_covariance_to_spline: %2% ") % __func__ % m_num_variation_type_external_covariance_to_spline;
     log<LOG_INFO>(L"%1% || num_variation_type_flat: %2% ") % __func__ % m_num_variation_type_flat;
     log<LOG_INFO>(L"%1% || num_variation_type_norm: %2% ") % __func__ % m_num_variation_type_norm;
+    log<LOG_INFO>(L"%1% || num_variation_type_norm_to_covariance: %2% ") % __func__ % m_num_variation_type_norm_to_covariance;
     log<LOG_INFO>(L"%1% || num_variation_type_spline: %2% ") % __func__ % m_num_variation_type_spline;
     log<LOG_INFO>(L"%1% || num_variation_type_spline_to_covariance: %2% ") % __func__ % m_num_variation_type_spline_to_covariance;
     if(m_use_mcstats){

--- a/src/PROcreate.cxx
+++ b/src/PROcreate.cxx
@@ -425,12 +425,13 @@ namespace PROfit {
             }
         }
 
-        //Do we have any norm spline systeatics?
-        if(inconfig.m_num_variation_type_norm>0){
+        // Do we have any norm systematics?
+        if(inconfig.m_num_variation_type_norm>0 || inconfig.m_num_variation_type_norm_to_covariance>0){
             for(auto& allow_sys : inconfig.m_mcgen_variation_type_map){
                 if(allow_sys.second=="norm"){
-
                     map_systematic_num_universe[allow_sys.first] = 7;
+                }else if(allow_sys.second=="norm_to_covariance"){
+                    map_systematic_num_universe[allow_sys.first] = 0;
                 }
             }
         }
@@ -559,8 +560,8 @@ namespace PROfit {
                     sv.back().knobval = sv.back().knob_index;
                     sv.back().binning = binningindex;
                 }
-                if(sys_mode == "norm") {
-                    log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a spline norm systematic. Processing a such. ") % __func__ % sys_name.c_str();
+                if(sys_mode == "norm" || sys_mode == "norm_to_covariance") {
+                    log<LOG_INFO>(L"%1% || Systematic variation %2% is a match for a normalization systematic. Processing as such. ") % __func__ % sys_name.c_str();
                     map_systematic_knob_vals[sys_name] = {-3.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 3.0f};
                     sv.back().knob_index = map_systematic_knob_vals[sys_name];
                     sv.back().knobval = sv.back().knob_index;
@@ -576,7 +577,8 @@ namespace PROfit {
                     std::string sflat_percent  = sys_name.substr(colonPos + 1);
                     float flat_percent = std::stof(sflat_percent);
 
-                    if(flat_percent >= 0.33333){
+                    // norm_to_covariance should be able to handle >= 0.33
+                    if(sys_mode == "norm" && flat_percent >= 0.33333){
                         log<LOG_ERROR>(L"%1% || Currently norm takes +-3,2,1 sigma. Greater than 33.33% norm error isn't allowed. You entered %2%. Dont.  ") % __func__  %  flat_percent;
                         exit(EXIT_FAILURE);
                     }

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -125,6 +125,10 @@ namespace PROfit {
                 this->CreateFlatMatrix(config, syst); 
                 covar_names.push_back(syst.systname); 
                 ++n_covar;
+            }else if(syst.mode == "norm_to_covariance"){
+                this->CreateNormMatrix(config, syst);
+                covar_names.push_back(syst.systname);
+                ++n_covar;
             }else if(syst.mode == "external_covariance"){
                 if(other_index == syst.binning){
                     //external covariances are only created for specific binning
@@ -482,6 +486,28 @@ namespace PROfit {
 
         return;
     }
+
+    void PROsyst::CreateNormMatrix(const PROconfig &config, const SystStruct& syst){
+        std::string sysname = syst.GetSysName();
+        log<LOG_INFO>(L"%1% || Generating a correlated normalization covariance matrix for %2%.") % __func__ % sysname.c_str();
+
+        int nbins = config.m_num_variable_bins_total[other_index];
+        Eigen::MatrixXf fracM = Eigen::MatrixXf::Zero(nbins, nbins);
+        Eigen::MatrixXf corrM = Eigen::MatrixXf::Zero(nbins, nbins);
+        const float covariance = syst.norm_value * syst.norm_value * syst.inflate * syst.inflate;
+
+        for(int row : syst.norm_bins){
+            for(int col : syst.norm_bins){
+                fracM(row, col) = covariance;
+                corrM(row, col) = 1.0;
+            }
+        }
+
+        syst_map[sysname] = {covmat.size(), SystType::Covariance};
+        covmat.push_back(fracM);
+        corrmat.push_back(corrM);
+    }
+
     Eigen::MatrixXf PROsyst::LoadExternalFractionalCovariance(const PROconfig &config, const SystStruct& syst){
         //this is matrix name
         std::string matrixname = syst.GetSysName();


### PR DESCRIPTION
Adds `norm_to_covariance` systematic type, for cases in which we don't want to fit `norm` but still want to keep the systematic. The covariance matrix is fully correlated among bins matching the string in the systematic:
```xml
<systematic type="norm_to_covariance" binning="reco" plotname="Targets_POT" tag="norm">nu_uBooNE:0.02</systematic>
```
An example matching all sub-channels:

<img width="944" height="632" alt="Screenshot 2026-07-23 at 2 41 21 p m" src="https://github.com/user-attachments/assets/90d3fb8d-39c1-45cc-8c8d-86adcc0361c6" />

An example matching only one sub-channel:

<img width="940" height="626" alt="Screenshot 2026-07-23 at 2 13 49 p m" src="https://github.com/user-attachments/assets/35242b26-8128-4122-9376-ffacf69f3a12" />

And the fractional uncertainty is the same as with `type="norm"`:

<img width="262" height="257" alt="Screenshot 2026-07-23 at 2 41 40 p m" src="https://github.com/user-attachments/assets/d5ff9d90-aba2-4972-9744-b05841005f44" />
