### PR TITLE
Display $chi^2$ for shown bins in two-dimensional plots

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -232,7 +232,7 @@ std::vector<FixedSeed> buildBkgOnlyFixedSeeds(const PROmodel &model, const Eigen
     return out;
 }
 
-std::map<std::string, TObject *> draw_fit_result(const PROconfig &config, const PROpeller &prop, const PROmodel &model, const PROsyst &syst, const PROspec &cv, const PROdata &data, const GlobalFitResult &fitres, const std::string &prefix, PlotOptions popt, PlotBounds pbounds);
+std::map<std::string, TObject *> draw_fit_result(const PROconfig &config, const PROpeller &prop, const PROmodel &model, const PROsyst &syst, PROmetric &metric, const PROspec &cv, const PROdata &data, const GlobalFitResult &fitres, const std::string &prefix, PlotOptions popt, PlotBounds pbounds);
 void draw_harmonic_scan_pdf(const GlobalFitResult &fitres, const PROfitterConfig &fit_config, const PROmodel &model, const std::string &filename);
 
 // Walks the collapsed reco bins and logs any with prediction < threshold,
@@ -1450,7 +1450,7 @@ int main(int argc, char* argv[])
         }
         if(binwidth_scale) popt |= PlotOptions::BinWidthScaled;
         if(area_normalized) popt |= PlotOptions::AreaNormalized;
-        std::map<std::string, TObject *> drawn_objs = draw_fit_result(config, prop, metric->GetModel(), metric->GetSysts(), cv, data, fitres, final_output_tag+"_PROfile", popt, pbounds);
+        std::map<std::string, TObject *> drawn_objs = draw_fit_result(config, prop, metric->GetModel(), metric->GetSysts(), *metric, cv, data, fitres, final_output_tag+"_PROfile", popt, pbounds);
 
 
         plot_mcmc_1sigma(final_output_tag+"_PROfile", config, metric->GetSysts(), metric->GetModel(), fitres.fitter.best_fit, fitres.post_param_lo, fitres.post_param_hi, !systs_only, fakedataparams);
@@ -2473,7 +2473,9 @@ int main(int argc, char* argv[])
             }
             auto objs = plot_channels(final_output_tag+"_PROplot_Variable_"+std::to_string(io)+"_ErrorBand.pdf", config, cv_plot, {}, data_plot,
                     other_err_bands.back(), {}, other_channel_chitexts[io], pbounds, opt | PlotOptions::DataMCRatio, io,
-                    false, do_bkg_subtract ? &bkg_subchannels : nullptr);
+                    false, do_bkg_subtract ? &bkg_subchannels : nullptr,
+                    io == config.i_prime ? allcov_metric.get() : nullptr,
+                    io == config.i_prime ? &variable_cvs[io] : nullptr);
             errband_objs.push_back(objs);
         }
 
@@ -2926,7 +2928,7 @@ int main(int argc, char* argv[])
         }
         if(binwidth_scale) popt |= PlotOptions::BinWidthScaled;
         if(area_normalized) popt |= PlotOptions::AreaNormalized;
-        std::map<std::string, TObject *> drawn_objs = draw_fit_result(config, prop, metric->GetModel(), metric->GetSysts(), cv, data, fitres, final_output_tag+"_PROglobal", popt, pbounds);
+        std::map<std::string, TObject *> drawn_objs = draw_fit_result(config, prop, metric->GetModel(), metric->GetSysts(), *metric, cv, data, fitres, final_output_tag+"_PROglobal", popt, pbounds);
 
         TFile fout((final_output_tag+"_PROglobal.root").c_str(), "RECREATE");
         for(const auto &[n, o] : drawn_objs)
@@ -3737,7 +3739,7 @@ void draw_harmonic_scan_pdf(const GlobalFitResult &fitres, const PROfitterConfig
     log<LOG_INFO>(L"%1% || Wrote harmonic scan summary to %2%") % __func__ % filename.c_str();
 }
 
-std::map<std::string, TObject *> draw_fit_result(const PROconfig &config, const PROpeller &prop, const PROmodel &model, const PROsyst &syst, const PROspec &cv, const PROdata &data, const GlobalFitResult &fitres, const std::string &prefix, PlotOptions popt, PlotBounds pbounds) {
+std::map<std::string, TObject *> draw_fit_result(const PROconfig &config, const PROpeller &prop, const PROmodel &model, const PROsyst &syst, PROmetric &metric, const PROspec &cv, const PROdata &data, const GlobalFitResult &fitres, const std::string &prefix, PlotOptions popt, PlotBounds pbounds) {
     std::map<std::string, TObject *> drawn_objs;
 
     // Harmonic-scan diagnostics: the scan curve chi2(freq) and the refit seed
@@ -3858,10 +3860,9 @@ std::map<std::string, TObject *> draw_fit_result(const PROconfig &config, const 
         chi2text.SetFillColor(0);
         chi2text.SetBorderSize(0);
         chi2text.SetTextAlign(12);
-        //chi2text.SetTextSize(0.035); 
         texts.push_back(chi2text);
 
-        std::map<std::string, TObject *> tmp_objs = plot_channels((prefix+"_hists.pdf"), config, cv, bf, data, fitres.err_band, fitres.post_err_band, texts, pbounds, popt);
+        std::map<std::string, TObject *> tmp_objs = plot_channels((prefix+"_hists.pdf"), config, cv, bf, data, fitres.err_band, fitres.post_err_band, texts, pbounds, popt, config.i_prime, false, nullptr, &metric, &bf);
         for(const auto &[name, obj] : tmp_objs)
             drawn_objs[name] = obj;
     }

--- a/inc/PROmetric.h
+++ b/inc/PROmetric.h
@@ -117,8 +117,7 @@ namespace PROfit {
              * @param var_index      Variable index.
              * @return Chi-squared for that channel.
              */
-            virtual float getSingleChannelChi(size_t channel_index, const PROspec& cv, size_t var_index,
-                                              const Eigen::MatrixXf &projection = Eigen::MatrixXf()) = 0;
+            virtual float getSingleChannelChi(size_t channel_index, const PROspec& cv, size_t var_index, const Eigen::MatrixXf &projection = Eigen::MatrixXf()) = 0;
             PROmetric() = default;
             virtual ~PROmetric() {}
             /**

--- a/inc/PROmetric.h
+++ b/inc/PROmetric.h
@@ -117,7 +117,8 @@ namespace PROfit {
              * @param var_index      Variable index.
              * @return Chi-squared for that channel.
              */
-            virtual float getSingleChannelChi(size_t channel_index, const PROspec& cv, size_t var_index) = 0;
+            virtual float getSingleChannelChi(size_t channel_index, const PROspec& cv, size_t var_index,
+                                              const Eigen::MatrixXf &projection = Eigen::MatrixXf()) = 0;
             PROmetric() = default;
             virtual ~PROmetric() {}
             /**
@@ -280,4 +281,3 @@ namespace PROfit {
 };
 
 #endif
-

--- a/inc/PROmetrics/PROCNP.h
+++ b/inc/PROmetrics/PROCNP.h
@@ -129,7 +129,7 @@ namespace PROfit{
              * @param var_index             Variable index.
              * @return CNP chi-squared for that channel.
              */
-            float getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index);
+            float getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index, const Eigen::MatrixXf &projection = Eigen::MatrixXf());
 
             /**
              * @brief Fix a spline nuisance parameter at a given value.

--- a/inc/PROmetrics/PROchi.h
+++ b/inc/PROmetrics/PROchi.h
@@ -134,7 +134,7 @@ namespace PROfit{
              * @param var_index             Variable index.
              * @return Chi-squared for that channel.
              */
-            float getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index);
+            float getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index, const Eigen::MatrixXf &projection = Eigen::MatrixXf());
 
             /**
              * @brief Print a breakdown of the chi-squared contributions at @p param.

--- a/inc/PROmetrics/PROpoisson.h
+++ b/inc/PROmetrics/PROpoisson.h
@@ -125,7 +125,7 @@ namespace PROfit{
              * @param var_index      Variable index.
              * @return Poisson chi-squared for that channel.
              */
-            float getSingleChannelChi(size_t channel_index,const PROspec & cv,size_t var_index) ;
+            float getSingleChannelChi(size_t channel_index, const PROspec &cv, size_t var_index, const Eigen::MatrixXf &projection = Eigen::MatrixXf());
 
             /**
              * @brief Print a breakdown of the Poisson chi-squared contributions at @p param.

--- a/inc/PROplot.h
+++ b/inc/PROplot.h
@@ -194,7 +194,7 @@ namespace PROfit{
      *        CV stack and legend (used by --bkg-subtract; their contents are expected to
      *        already be zero in `cv`).
      */
-    std::map<std::string, TObject *> plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotBounds &bounds, PlotOptions opt = PlotOptions::Default, int var_index = 0, bool ratio_bool = false, const std::vector<size_t> *skip_stack_subchannels = nullptr);
+    std::map<std::string, TObject *> plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotBounds &bounds, PlotOptions opt = PlotOptions::Default, int var_index = 0, bool ratio_bool = false, const std::vector<size_t> *skip_stack_subchannels = nullptr, PROmetric *chi_metric = nullptr, const PROspec *chi_spec = nullptr);
 
     /**
      * @brief Return global subchannel indices whose `m_fullnames[i]` contains `pattern` as a substring.

--- a/src/PROmetrics/PROCNP.cxx
+++ b/src/PROmetrics/PROCNP.cxx
@@ -348,7 +348,7 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
 
     return value;}
 
-float PROCNP::getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index) {
+float PROCNP::getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index, const Eigen::MatrixXf &projection) {
 
     size_t nbin = config.m_channel_variable_bins[config.GetLocalChannelIndexFromGlobalChannelIndex(global_channel_index)][var_index].NBins();
     size_t startBin = config.GetCollapsedGlobalVariableBinStart(global_channel_index,var_index);
@@ -381,6 +381,14 @@ float PROCNP::getSingleChannelChi(size_t global_channel_index, const PROspec &cv
     }
 
     Eigen::VectorXf delta = (CollapseMatrix(config, cv.Spec()) - normdata)(idx);
+    if(projection.size()) {
+        Eigen::MatrixXf active_projection(projection.rows(), idx.size());
+        for(Eigen::Index col = 0; col < idx.size(); ++col) {
+            active_projection.col(col) = projection.col(idx(col) - (Eigen::Index)startBin);
+        }
+        M = active_projection * M * active_projection.transpose();
+        delta = active_projection * delta;
+    }
     float covar_portion = delta.dot(M.llt().solve(delta));
     float value = covar_portion;
 

--- a/src/PROmetrics/PROchi.cxx
+++ b/src/PROmetrics/PROchi.cxx
@@ -400,7 +400,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
     return value;
 }
 
-float PROchi::getSingleChannelChi(size_t global_channel_index, const PROspec & cv, size_t var_index) {
+float PROchi::getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index, const Eigen::MatrixXf &projection) {
 
     size_t nbin = config.m_channel_variable_bins[config.GetLocalChannelIndexFromGlobalChannelIndex(global_channel_index)][var_index].NBins();
     size_t startBin = config.GetCollapsedGlobalVariableBinStart(global_channel_index, var_index);
@@ -428,6 +428,14 @@ float PROchi::getSingleChannelChi(size_t global_channel_index, const PROspec & c
     }
 
     Eigen::VectorXf delta = (CollapseMatrix(config, cv.Spec()) - (shape_only ? data.Normalize(config,cv) : data.Spec()))(idx);
+    if(projection.size()) {
+        Eigen::MatrixXf active_projection(projection.rows(), idx.size());
+        for(Eigen::Index col = 0; col < idx.size(); ++col) {
+            active_projection.col(col) = projection.col(idx(col) - (Eigen::Index)startBin);
+        }
+        M = active_projection * M * active_projection.transpose();
+        delta = active_projection * delta;
+    }
     float covar_portion = delta.dot(M.llt().solve(delta));
     float value = covar_portion;//pull;
 
@@ -439,4 +447,3 @@ void PROchi::print([[maybe_unused]] const Eigen::VectorXf &param){
 
 return;
 }
-

--- a/src/PROmetrics/PROpoisson.cxx
+++ b/src/PROmetrics/PROpoisson.cxx
@@ -306,7 +306,7 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
     return value;
 }
 
-float PROpoisson::getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index) {
+float PROpoisson::getSingleChannelChi(size_t global_channel_index, const PROspec &cv, size_t var_index, const Eigen::MatrixXf &projection) {
 
     // m_channel_variable_bins is indexed by LOCAL channel index (PROchi and
     // PROCNP convert the same way); using the global index breaks any config
@@ -315,15 +315,21 @@ float PROpoisson::getSingleChannelChi(size_t global_channel_index, const PROspec
     size_t startBin = config.GetCollapsedGlobalVariableBinStart(global_channel_index,var_index);
 
 
-    //const Eigen::VectorXf &vdata = data.Spec().segment(startBin, nbin);
-    const Eigen::VectorXf vdata = (shape_only
+    // const Eigen::VectorXf &vdata = data.Spec().segment(startBin, nbin);
+    Eigen::VectorXf vdata = (shape_only
         ? data.Normalize(config,cv)
         : data.Spec()).segment(startBin, nbin);
-    const Eigen::VectorXf vmc = CollapseMatrix(config, cv.Spec()).segment(startBin, nbin);
+    Eigen::VectorXf vmc = CollapseMatrix(config, cv.Spec()).segment(startBin, nbin);
     // Mask applies only to the fitting variable (mask snapshot is for i_prime);
     // startBin offsets the channel-local segment into the global mask.
     const bool masked = (var_index == (size_t)config.i_prime) && hasActiveBinMask();
-    float poisson = BakerCousinsChi2(vmc, vdata, masked ? &active_bins : nullptr, (Eigen::Index)startBin);
+    if(projection.size()) {
+        vmc = projection * vmc;
+        vdata = projection * vdata;
+    }
+    float poisson = BakerCousinsChi2(vmc, vdata,
+        projection.size() ? nullptr : (masked ? &active_bins : nullptr),
+        projection.size() ? 0 : (Eigen::Index)startBin);
     //float pull = Pull(subvector2);
     float value = poisson; //+ pull
 

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -744,7 +744,7 @@ namespace PROfit{
         log<LOG_DEBUG>(L"%1% || Finished plot_detector_ratios") % __func__;
     }                                                                              
 
-    void plot_hist1ds(TCanvas* c, TH1D* cv_hist, TGraphAsymmErrors* errband, THStack* cvstack, std::vector<std::pair<std::string, const char*>>* subplots, TH1D* bf_hist, TGraphAsymmErrors* posterrband, TH1D* data_hist, std::string* dat_str, PlotOptions opt, std::string hist_titles, std::string ratio_titles, const std::string &filename, PlotBounds &bounds, TText* text){
+    void plot_hist1ds(TCanvas* c, TH1D* cv_hist, TGraphAsymmErrors* errband, THStack* cvstack, std::vector<std::pair<std::string, const char*>>* subplots, TH1D* bf_hist, TGraphAsymmErrors* posterrband, TH1D* data_hist, std::string* dat_str, PlotOptions opt, std::string hist_titles, std::string ratio_titles, const std::string &filename, PlotBounds &bounds, const std::string &text){
 
         log<LOG_DEBUG>(L"%1% || Plotting 1D Histogram %2%") % __func__ % hist_titles.c_str();
         std::unique_ptr<TLegend> leg = std::make_unique<TLegend>(0.38,0.74,0.89,0.91);
@@ -904,12 +904,11 @@ namespace PROfit{
             posterrband->Draw("2 same");
         }
 
-        if(text) {
+        if(!text.empty()) {
             TLine *dummy_line = new TLine(0,0,0.1,0);
             dummy_line->SetLineColor(kWhite);
             dummy_line->SetLineWidth(0);
-            const char* label = text->GetTitle();
-            TLegendEntry *chi_entry = leg->AddEntry(dummy_line,label,"l");
+            TLegendEntry *chi_entry = leg->AddEntry(dummy_line,text.c_str(),"l");
             chi_entry->SetTextFont(42);
             chi_entry->SetTextSize(0.03);
         }
@@ -1162,6 +1161,11 @@ namespace PROfit{
 
                         // Helpers to plot chi^2 for each heatmap/slice/projection
                         const size_t channel_start = config.GetCollapsedGlobalVariableBinStart(global_channel_index, other_index);
+
+                        // In `groups`, each outer vector is one displayed bin; its inner vector lists the flattened
+                        // source bins to sum. For a 3x2 Y projection, groups looks like {{0, 2, 4}, {1, 3, 5}}, i.e.,
+                        // the first bin contains bins 0, 2, and 4 from the flat bins, and the second bin contains bins
+                        // 1, 3, and 5 from the flat bins.
                         auto make_projection = [&](const std::vector<std::vector<size_t>> &groups) {
                             size_t nrows = 0;
                             for(const auto &group : groups) {
@@ -1345,9 +1349,7 @@ namespace PROfit{
                                 objs[mdc+"_data_slice_ybin"+std::to_string(ybin)] = data_hist_slice->Clone();
                             }
 
-                            TText slice_chi_text;
-                            slice_chi_text.SetTitle(slice_chi_label.c_str());
-                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, ybin_str, ratio_titles, filename, bounds, slice_chi_label.empty() ? nullptr : &slice_chi_text);
+                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, ybin_str, ratio_titles, filename, bounds, slice_chi_label);
                         }
 
                         // Plot the second variable in bins of the first variable
@@ -1409,9 +1411,7 @@ namespace PROfit{
                                 objs[mdc+"_data_slice_xbin"+std::to_string(xbin)] = data_hist_slice->Clone();
                             }
 
-                            TText slice_chi_text;
-                            slice_chi_text.SetTitle(slice_chi_label.c_str());
-                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, xbin_str, ratio_titles_y, filename, bounds, slice_chi_label.empty() ? nullptr : &slice_chi_text);
+                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, xbin_str, ratio_titles_y, filename, bounds, slice_chi_label);
                         }
 
                         const std::string hist_title_y = config.m_mode_plotnames[mode]+" "+config.m_detector_plotnames[det]+" "+config.m_channel_names[channel]+";"+ytitle2d+";"+ytitle;
@@ -1511,9 +1511,7 @@ namespace PROfit{
                             }
                         }
                         const std::string y_chi_label = chi_label(make_projection(y_projection_groups));
-                        TText y_chi_text;
-                        y_chi_text.SetTitle(y_chi_label.c_str());
-                        plot_hist1ds(&c, &cv_hist_y, channel_errband_y, cvstack_y, &subplots_y, bf_hist_y, post_channel_errband_y, data_hist_y, &dat_str, opt, hist_title_y, ratio_titles_y, filename, bounds, y_chi_label.empty() ? nullptr : &y_chi_text);
+                        plot_hist1ds(&c, &cv_hist_y, channel_errband_y, cvstack_y, &subplots_y, bf_hist_y, post_channel_errband_y, data_hist_y, &dat_str, opt, hist_title_y, ratio_titles_y, filename, bounds, y_chi_label);
                     }
 
                     std::vector<float> edges = config.m_channel_variable_bins[channel][other_index].Edges();
@@ -1637,20 +1635,15 @@ namespace PROfit{
                         objs[mdc+"_posterrband"] = post_channel_errband->Clone();
                     }
 
-                    TText* text = NULL;
-                    TText projected_x_chi_text;
+                    std::string chi_label_text;
                     if(config.m_channel_variable_dims[channel][other_index] == 2 && !projected_x_chi_label.empty()) {
-                        projected_x_chi_text.SetTitle(projected_x_chi_label.c_str());
-                        text = &projected_x_chi_text;
+                        chi_label_text = projected_x_chi_label;
                     } else if(texts.size()!=0) {
-                        if(texts.size()==1){
-                            text = (TText*)texts.front().GetListOfLines()->First();
-                        }else{
-                            text = (TText*)texts.at(global_channel_index).GetListOfLines()->First();
-                        }
+                        TPaveText &box = texts.size() == 1 ? texts.front() : texts.at(global_channel_index);
+                        if(TText *line = (TText*)box.GetListOfLines()->First()) chi_label_text = line->GetTitle();
                     }
                     // should probably be switching this to a more clear boolean...
-                    plot_hist1ds(&c, &cv_hist, channel_errband, cvstack, &subplots, bf_hist, post_channel_errband, data_hist, &dat_str, opt, hist_titles, ratio_titles, filename, bounds, text);
+                    plot_hist1ds(&c, &cv_hist, channel_errband, cvstack, &subplots, bf_hist, post_channel_errband, data_hist, &dat_str, opt, hist_titles, ratio_titles, filename, bounds, chi_label_text);
                     ++global_channel_index;
                     cv_hists.push_back(cv_hist);
 		    if(data){

--- a/src/PROplot.cxx
+++ b/src/PROplot.cxx
@@ -5,6 +5,7 @@
 #include "TH1F.h"
 #include "TLatex.h"
 #include "TLegend.h"
+#include "TLegendEntry.h"
 #include "TMarker.h"
 #include "TText.h"
 #include <cmath>
@@ -908,7 +909,9 @@ namespace PROfit{
             dummy_line->SetLineColor(kWhite);
             dummy_line->SetLineWidth(0);
             const char* label = text->GetTitle();
-            leg->AddEntry(dummy_line,label,"l");
+            TLegendEntry *chi_entry = leg->AddEntry(dummy_line,label,"l");
+            chi_entry->SetTextFont(42);
+            chi_entry->SetTextSize(0.03);
         }
 
 
@@ -1045,7 +1048,7 @@ namespace PROfit{
         log<LOG_DEBUG>(L"%1% || Finishing Plotting 1D Histogram %2%") % __func__ % hist_titles.c_str();
     }
 
-    std::map<std::string, TObject *> plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotBounds &bounds, PlotOptions opt, int other_index, bool ratio_bool, const std::vector<size_t> *skip_stack_subchannels) {
+    std::map<std::string, TObject *> plot_channels(const std::string &filename, const PROconfig &config, std::optional<PROspec> cv, std::optional<PROspec> best_fit, std::optional<PROdata> data, std::optional<PROerrorbar> errband, std::optional<PROerrorbar> posterrband, std::vector<TPaveText> &texts, PlotBounds &bounds, PlotOptions opt, int other_index, bool ratio_bool, const std::vector<size_t> *skip_stack_subchannels, PROmetric *chi_metric, const PROspec *chi_spec) {
 
         log<LOG_DEBUG>(L"%1% || Starting plot_channels") % __func__;
         std::string rat_y_title = bool(opt&PlotOptions::DataMCRatio) ? "Data/MC" : "Data/Best-Fit";
@@ -1142,6 +1145,7 @@ namespace PROfit{
                         posterrband_1d = make_1d_err(*posterrband, channel_nbins_x, channel_nbins_y, tot_offset, config.m_channel_variable_dims[channel][other_index]);
                     }
 
+                    std::string projected_x_chi_label; // We want to pass this to the 1d plotter outside the 2d plotting
                     if(config.m_channel_variable_dims[channel][other_index] == 2){
                         gStyle->SetPalette(kViridis);
                         std::string joined_title = config.m_channel_variable_units[channel][other_index];
@@ -1155,6 +1159,59 @@ namespace PROfit{
 
                         std::vector<float> edges_x = config.m_channel_variable_bins[channel][other_index].Edges(0);
                         std::vector<float> edges_y = config.m_channel_variable_bins[channel][other_index].Edges(1);
+
+                        // Helpers to plot chi^2 for each heatmap/slice/projection
+                        const size_t channel_start = config.GetCollapsedGlobalVariableBinStart(global_channel_index, other_index);
+                        auto make_projection = [&](const std::vector<std::vector<size_t>> &groups) {
+                            size_t nrows = 0;
+                            for(const auto &group : groups) {
+                                if(std::any_of(group.begin(), group.end(), [&](size_t bin) {
+                                    return config.IsBinActive(other_index, channel_start + bin);
+                                })) ++nrows;
+                            }
+
+                            // Maps from original bins (nbins_p_2dchan) to active bins in projection (nrows)
+                            Eigen::MatrixXf projection = Eigen::MatrixXf::Zero(nrows, nbins_p_2dchan);
+                            size_t row = 0;
+                            for(const auto &group : groups) {
+                                bool active = false;
+                                for(size_t bin : group) {
+                                    if(config.IsBinActive(other_index, channel_start + bin)) {
+                                        projection(row, bin) = 1.0f;
+                                        active = true;
+                                    }
+                                }
+                                if (active) ++row; // Only advance matrix row if at least one bin in group is active
+                            }
+                            return projection;
+                        };
+                        auto chi_label = [&](const Eigen::MatrixXf &projection) {
+                            if(!chi_metric || !chi_spec || projection.rows() == 0) return std::string();
+                            const float chi2 = chi_metric->getSingleChannelChi(global_channel_index, *chi_spec, other_index, projection);
+                            return std::string("#chi^{2}/nbins = ") + to_string_prec(chi2, 2) + "/" + std::to_string(projection.rows());
+                        };
+                        auto draw_chi_label = [&](const std::string &label) {
+                            if(label.empty()) return;
+                            TPaveText text(0.62, 0.91, 0.89, 0.96, "NDC");
+                            text.AddText(label.c_str());
+                            text.SetFillColor(0);
+                            text.SetBorderSize(0);
+                            text.SetTextAlign(12);
+                            text.SetTextFont(42);
+                            text.SetTextSize(0.03);
+                            text.DrawClone();
+                        };
+
+                        std::vector<std::vector<size_t>> full_groups(nbins_p_2dchan);
+                        for(size_t bin = 0; bin < (size_t)nbins_p_2dchan; ++bin) full_groups[bin] = {bin};
+                        const std::string full_chi_label = chi_label(make_projection(full_groups));
+                        std::vector<std::vector<size_t>> x_projection_groups(channel_nbins_x);
+                        for(size_t xbin = 0; xbin < channel_nbins_x; ++xbin) {
+                            for(size_t ybin = 0; ybin < channel_nbins_y; ++ybin) {
+                                x_projection_groups[xbin].push_back(xbin*channel_nbins_y + ybin);
+                            }
+                        }
+                        projected_x_chi_label = chi_label(make_projection(x_projection_groups));
 
                         const std::string plot_title_2d = config.m_detector_plotnames[det]+" "+config.m_channel_names[channel]+" CV";
                         auto make_slice_title = [&](size_t slice_number, const std::string &slice_variable, float low_edge, float high_edge, const std::string &horizontal_axis) {
@@ -1178,6 +1235,7 @@ namespace PROfit{
                         p2d.cd();
                         cv_hist->SetTitle(hist_title.c_str());
                         cv_hist->Draw("colz");
+                        draw_chi_label(full_chi_label);
                         objs[mdc+"_cv2d"] = cv_hist->Clone();
                         c.cd();
                         p2d.Draw();
@@ -1198,6 +1256,7 @@ namespace PROfit{
                             TPad pbfd("pbfd", "pbfd", 0, 0, 1, 1);
                             pbfd.cd();
                             bf_hist->Draw("colz");
+                            draw_chi_label(full_chi_label);
                             objs[mdc+"_bestfit2d"] = bf_hist->Clone();
                             c.cd();
                             pbfd.Draw();
@@ -1219,6 +1278,7 @@ namespace PROfit{
                             TPad pdata("pdata", "pdata", 0, 0, 1, 1);
                             pdata.cd();
                             data_hist->Draw("colz");
+                            draw_chi_label(full_chi_label);
                             objs[mdc+"_data2d"] = data_hist->Clone();
                             c.cd();
                             pdata.Draw();
@@ -1230,6 +1290,11 @@ namespace PROfit{
 
                         // Plot the first variable in bins of the second variable
                         for(size_t ybin = 1; ybin <= channel_nbins_y; ybin++) {
+                            std::vector<std::vector<size_t>> groups(channel_nbins_x);
+                            for(size_t xbin = 0; xbin < channel_nbins_x; ++xbin) {
+                                groups[xbin] = {xbin*channel_nbins_y + (ybin-1)};
+                            }
+                            const std::string slice_chi_label = chi_label(make_projection(groups));
                             TGraphAsymmErrors *post_channel_errband = NULL; 
                             if(posterrband) {
                                 post_channel_errband = new TGraphAsymmErrors(bf_hist->ProjectionX("xslc_bf", ybin, ybin));
@@ -1280,12 +1345,19 @@ namespace PROfit{
                                 objs[mdc+"_data_slice_ybin"+std::to_string(ybin)] = data_hist_slice->Clone();
                             }
 
-                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, ybin_str, ratio_titles, filename, bounds, {});
+                            TText slice_chi_text;
+                            slice_chi_text.SetTitle(slice_chi_label.c_str());
+                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, ybin_str, ratio_titles, filename, bounds, slice_chi_label.empty() ? nullptr : &slice_chi_text);
                         }
 
                         // Plot the second variable in bins of the first variable
                         const std::string ratio_titles_y = ";"+ytitle2d+";"+rat_y_title;
                         for(size_t xbin = 1; xbin <= channel_nbins_x; ++xbin) {
+                            std::vector<std::vector<size_t>> groups(channel_nbins_y);
+                            for(size_t ybin = 0; ybin < channel_nbins_y; ++ybin) {
+                                groups[ybin] = {(xbin-1)*channel_nbins_y + ybin};
+                            }
+                            const std::string slice_chi_label = chi_label(make_projection(groups));
                             TGraphAsymmErrors *post_channel_errband = NULL;
                             if(posterrband) {
                                 post_channel_errband = new TGraphAsymmErrors(bf_hist->ProjectionY("yslc_bf", xbin, xbin));
@@ -1337,7 +1409,9 @@ namespace PROfit{
                                 objs[mdc+"_data_slice_xbin"+std::to_string(xbin)] = data_hist_slice->Clone();
                             }
 
-                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, xbin_str, ratio_titles_y, filename, bounds, {});
+                            TText slice_chi_text;
+                            slice_chi_text.SetTitle(slice_chi_label.c_str());
+                            plot_hist1ds(&c, &cv_hist_slice, channel_errband, {}, {}, bf_hist_slice, post_channel_errband, data_hist_slice, &dat_str, {}, xbin_str, ratio_titles_y, filename, bounds, slice_chi_label.empty() ? nullptr : &slice_chi_text);
                         }
 
                         const std::string hist_title_y = config.m_mode_plotnames[mode]+" "+config.m_detector_plotnames[det]+" "+config.m_channel_names[channel]+";"+ytitle2d+";"+ytitle;
@@ -1429,7 +1503,17 @@ namespace PROfit{
                         TGraphAsymmErrors *post_channel_errband_y = posterrband ? make_y_errorband(*posterrband, bf_hist_y) : NULL;
                         if(channel_errband_y) objs[mdc+"_preerrband_y"] = channel_errband_y->Clone();
                         if(post_channel_errband_y) objs[mdc+"_posterrband_y"] = post_channel_errband_y->Clone();
-                        plot_hist1ds(&c, &cv_hist_y, channel_errband_y, cvstack_y, &subplots_y, bf_hist_y, post_channel_errband_y, data_hist_y, &dat_str, opt, hist_title_y, ratio_titles_y, filename, bounds, {});
+
+                        std::vector<std::vector<size_t>> y_projection_groups(channel_nbins_y);
+                        for(size_t ybin = 0; ybin < channel_nbins_y; ++ybin) {
+                            for(size_t xbin = 0; xbin < channel_nbins_x; ++xbin) {
+                                y_projection_groups[ybin].push_back(xbin*channel_nbins_y + ybin);
+                            }
+                        }
+                        const std::string y_chi_label = chi_label(make_projection(y_projection_groups));
+                        TText y_chi_text;
+                        y_chi_text.SetTitle(y_chi_label.c_str());
+                        plot_hist1ds(&c, &cv_hist_y, channel_errband_y, cvstack_y, &subplots_y, bf_hist_y, post_channel_errband_y, data_hist_y, &dat_str, opt, hist_title_y, ratio_titles_y, filename, bounds, y_chi_label.empty() ? nullptr : &y_chi_text);
                     }
 
                     std::vector<float> edges = config.m_channel_variable_bins[channel][other_index].Edges();
@@ -1554,7 +1638,11 @@ namespace PROfit{
                     }
 
                     TText* text = NULL;
-                    if(texts.size()!=0) {
+                    TText projected_x_chi_text;
+                    if(config.m_channel_variable_dims[channel][other_index] == 2 && !projected_x_chi_label.empty()) {
+                        projected_x_chi_text.SetTitle(projected_x_chi_label.c_str());
+                        text = &projected_x_chi_text;
+                    } else if(texts.size()!=0) {
                         if(texts.size()==1){
                             text = (TText*)texts.front().GetListOfLines()->First();
                         }else{


### PR DESCRIPTION
This PR addresses #481 by making it so each slice and projection in a set of two-dimensional plots shows the $\chi^2/\text{nbins}$ only for the displayed bins rather than for the whole fit. It also adds the full $\chi^2$ to the two-dimensional heat maps. 

For each 2D slice or projection, a matrix $P$ maps the original flattened bins onto the bins displayed on that page as $s' = Ps$, where $s$ contains the original bins and $s'$ the ones displayed. Each row of $P$ is one displayed bin. It selects or sums over bins from $s$ to construct $s'$.

For `PROchi` and `PROCNP`, the residual and covariance are projected like $\delta' = P\delta, M' = PMP^T$ and $\chi^2 = \delta'^T(M')^{-1}\delta'$. For the Poisson metric, the prediction and data are projected first  as $\mu' = P\mu, n' = Pn$, and the Poisson statistic is evaluated using the projected counts. 

A few examples:

<img width="926" height="628" alt="Screenshot 2026-08-08 at 2 24 43 p m" src="https://github.com/user-attachments/assets/79007b62-cb5e-42b5-9517-65ca2c588ac2" />


<img width="881" height="634" alt="Screenshot 2026-08-08 at 2 25 06 p m" src="https://github.com/user-attachments/assets/3ffce67e-cf49-4c7c-ad38-6ca79f29611c" />

<img width="917" height="638" alt="Screenshot 2026-08-08 at 2 25 23 p m" src="https://github.com/user-attachments/assets/d5945359-6a18-488f-9230-9545179429bb" />
