### PR TITLE
Analytic gradient minimizer

### DIFF
--- a/bin/PROfit.cxx
+++ b/bin/PROfit.cxx
@@ -402,7 +402,9 @@ int main(int argc, char* argv[])
                    "central-full (central FD on full chi^2; most accurate, slowest), "
                    "one-sided-full (forward FD on full chi^2; ~2x faster, O(h)), "
                    "central-lin (default; central FD on delta only, M frozen at base; Gauss-Newton, ~5-10x), "
-                   "one-sided-lin (forward FD on delta only, M frozen at base; ~10-20x).")
+                   "one-sided-lin (forward FD on delta only, M frozen at base; ~10-20x), "
+                   "analytic (exact closed-form gradient incl. the dM/dtheta term; no FD truncation, "
+                   "no extra spectrum fills; PROchi binned strategies only, others fall back).")
         ->default_str("central-lin");
 
     app.add_option("--inject-systs", injected_systs, "Systematic shifts to inject. Map of name and shift value in sigmas. Only spline systs are supported right now.");
@@ -628,7 +630,7 @@ int main(int argc, char* argv[])
     std::string bench_tests_str = "all";
     CLI::App *bench_command = app.add_subcommand("scale-test", "Run timing benchmarks for FillSpectra / metric / fit hot paths and emit greppable [SCALETEST] LOG lines.");
     bench_command->add_option("-N,--n", bench_N, "Base call count: FillSpectra=N, metric=N/10, fit=N/100.")->default_val(1000);
-    bench_command->add_option("--tests", bench_tests_str, "Comma-separated subset of {a..n} or {fillspectra,metric,metricgrad,fit,pseudo,collapse,mcmc,all}. Default 'all'.")->default_val("all");
+    bench_command->add_option("--tests", bench_tests_str, "Comma-separated subset of {a..p} or {fillspectra,metric,metricgrad,fit,pseudo,collapse,mcmc,all,gradcheck,gradmodes,grad}. Default 'all'. gradcheck (o) validates every gradient mode vs central-full FD; gradmodes (p) runs N/100 full fits per (fit preset x gradient mode) with matched seeds and emits [GRADBENCH] lines. Neither is in 'all'.")->default_val("all");
 
     //PROletariat, stage+tar+submit grid jobs (replaces grid/maketar_submit_v2.4.sh)
     PROletariatOptions grid_opts;
@@ -3132,6 +3134,9 @@ int main(int argc, char* argv[])
             else if (tok == "l")           bench_mask |= Bench_MetricGrad_Nuis;
             else if (tok == "m")           bench_mask |= Bench_MCMC_Burnin;
             else if (tok == "n")           bench_mask |= Bench_MCMC_Post;
+            else if (tok == "grad")        bench_mask |= Bench_Grad_Group;
+            else if (tok == "gradcheck" || tok == "o") bench_mask |= Bench_GradCheck;
+            else if (tok == "gradmodes" || tok == "gradfit" || tok == "p") bench_mask |= Bench_GradModeFit;
             else log<LOG_WARNING>(L"%1% || scale-test: unknown --tests token '%2%' (ignored)") % __func__ % tok.c_str();
         };
         const std::string &s = bench_tests_str;
@@ -3148,11 +3153,14 @@ int main(int argc, char* argv[])
         if (bench_mask == 0u) bench_mask = PROfit::PRObench::Bench_All;
 
         PROfit::PRObench::BenchOptions bopts;
-        bopts.N      = bench_N;
-        bopts.tests  = bench_mask;
-        bopts.binned = !eventbyevent;
+        bopts.N        = bench_N;
+        bopts.tests    = bench_mask;
+        bopts.binned   = !eventbyevent;
+        bopts.nthreads = (int)nthread;
+        bopts.truth_params = fakeDataParams;
+        bopts.grad_csv = analysis_tag + "_gradbench_fits.csv";
 
-        PROfit::PRObench::run_scale_test(config, prop, *metric, fitConfig, bopts);
+        PROfit::PRObench::run_scale_test(config, prop, *metric, data, fitConfig, bopts);
     }
 
     if(*protest_command){

--- a/inc/PRObench.h
+++ b/inc/PRObench.h
@@ -30,6 +30,7 @@
 #define PROBENCH_H
 
 #include "PROconfig.h"
+#include "PROdata.h"
 #include "PROmetric.h"
 #include "PROpeller.h"
 #include "PROfitter.h"
@@ -67,11 +68,14 @@ namespace PRObench {
         Bench_MetricGrad_Nuis  = 1u << 11, ///< (l) PROmetric() chi² + finite-diff gradient, vary nuis only.
         Bench_MCMC_Burnin      = 1u << 12, ///< (m) Metropolis::step() during burnin (tune_mode=true; proposal Cholesky rebuilt every step + tune()).
         Bench_MCMC_Post        = 1u << 13, ///< (n) Metropolis::step() post-burnin (tune_mode=false; cached proposal Cholesky, no tune()).
+        Bench_GradCheck        = 1u << 14, ///< (o) Gradient cross-validation: every mode (incl. analytic) vs the central-full FD reference at random points. [GRADCHECK] lines.
+        Bench_GradModeFit      = 1u << 15, ///< (p) Repeated full PROfitter::Fit per gradient mode with matched seeds; logs wall time, LBFGS iterations, metric calls, best chi². [GRADBENCH] lines.
         Bench_FillSpectra_Group = Bench_FillSpectra_All | Bench_FillSpectra_Phys | Bench_FillSpectra_Nuis,
         Bench_Metric_Group      = Bench_Metric_All       | Bench_Metric_Phys       | Bench_Metric_Nuis,
         Bench_MetricGrad_Group  = Bench_MetricGrad_All   | Bench_MetricGrad_Phys   | Bench_MetricGrad_Nuis,
         Bench_Fit_Group         = Bench_Fit,
         Bench_MCMC_Group        = Bench_MCMC_Burnin      | Bench_MCMC_Post,
+        Bench_Grad_Group        = Bench_GradCheck        | Bench_GradModeFit,  ///< NOT in Bench_All: opt-in via --tests gradcheck/gradmodes/grad.
         Bench_All               = Bench_FillSpectra_Group | Bench_Metric_Group | Bench_MetricGrad_Group | Bench_Fit_Group | Bench_PseudoUniverse | Bench_Collapse | Bench_MCMC_Group,
     };
 
@@ -83,6 +87,15 @@ namespace PRObench {
         unsigned tests    = Bench_All;     ///< Bitmask of benchmarks to run.
         uint32_t rng_seed = 0xBEEFCAFE;    ///< Fixed seed for reproducibility.
         bool     binned   = true;          ///< FillSpectra binned vs event-by-event.
+        int      nthreads = 1;             ///< Worker threads for the (p) gradmodes fit benchmark (universes fitted in parallel).
+        /// Injected fake-data parameter vector (physics + splines) the chain built its
+        /// data spectrum from; used by the (p) benchmark to report truth for
+        /// parameter-recovery plots ([GRADBENCH-TRUTH] line). May be empty.
+        Eigen::VectorXf truth_params;
+        /// Output CSV for the (p) benchmark's per-fit records. PROlog suppresses
+        /// repeated-format lines after ~1000 emissions, so per-fit data goes to a
+        /// file; only the per-cell [GRADBENCH-SUMMARY] lines are logged.
+        std::string grad_csv = "gradbench_fits.csv";
     };
 
     /**
@@ -117,6 +130,7 @@ namespace PRObench {
         const PROconfig &config,
         const PROpeller &prop,
         PROmetric &metric,
+        const PROdata &data,
         const PROfitterConfig &fitconfig,
         const BenchOptions &opts);
 

--- a/inc/PROcess.h
+++ b/inc/PROcess.h
@@ -92,6 +92,19 @@ namespace PROfit{
     PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, FillSpectraCache &cache, bool binned = true, size_t var_index = 0);
 
     /**
+     * @brief Analytic Jacobian of the BINNED FillSpectra spectrum with respect to all parameters.
+     * @details Column j holds d(spec)/d(param_j) in full (uncollapsed) bin space, evaluated
+     * at @p params, for j = 0..nphys-1 (physics, via PROmodel::get_probs_grad) then
+     * j = nphys..nphys+nsplines-1 (spline nuisances, via PROsyst::GetSplineShiftDeriv).
+     * Self-contained: recomputes the per-spline factors and physics result it needs rather
+     * than trusting the cache's pinned state (the Tier 1.3 incremental path deliberately
+     * leaves the cache at an older central point). Only the constant cache members
+     * (unweighted_sums, phys_grid) are reused/populated.
+     * @return Matrix (nbins_var_full, nphys + nsplines).
+     */
+    Eigen::MatrixXf FillSpectraGradient(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, FillSpectraCache &cache, size_t var_index = 0);
+
+    /**
      * @brief Master spectrum-filling function combining oscillation weights and systematic spline weights.
      * @details Iterates over MC events (or uses pre-binned histograms when @p binned is true),
      * computes oscillation probabilities via @p inmodel, applies spline shifts from @p insyst,

--- a/inc/PROfitter.h
+++ b/inc/PROfitter.h
@@ -570,6 +570,11 @@ namespace PROfit {
             MultiPROgressBar * progress;           ///< Pointer to progress bar (non-owning); null when not used.
             bool run_progress;                     ///< True if a progress bar should be updated during fitting.
 
+            /// Total L-BFGS-B iterations summed over every local refinement in the most
+            /// recent Fit() call (reset at Fit() entry). Diagnostic for gradient-mode
+            /// benchmarking: pairs with PROmetric::getCallCount() to characterise cost.
+            size_t total_lbfgs_iterations = 0;
+
             std::vector<Eigen::VectorXf> freq_seed_points; ///< Seed points found by the harmonic frequency scan.
             std::vector<float> freq_seed_values;           ///< Chi-squared values at the harmonic seed points.
             std::vector<float> harmonic_scan_pos;          ///< Diagnostic: frequency positions of the last harmonic scan curve (sorted, finite points only).

--- a/inc/PROmetric.h
+++ b/inc/PROmetric.h
@@ -58,14 +58,18 @@ namespace PROfit {
              *     replacing M⁻¹δ — the linearised form is exact (modulo FD
              *     truncation in dδ/dθ).
              *
-             * Combined with the FD stencil this gives four configurations:
+             * Combined with the FD stencil this gives four FD configurations,
+             * plus a fully analytic fifth mode (no FD anywhere: dδ/dθ from
+             * FillSpectraGradient, the uᵀ(dM/dθ)u term in closed form via one
+             * GEMV, pull derivative analytic; PROchi binned strategies only):
              *
-             *  | Mode                  | δ FD       | M handling        | Pull deriv |
-             *  |-----------------------|------------|-------------------|------------|
-             *  | GradientCentralFull   | central    | rebuilt per FD    | via FD     |
-             *  | GradientOneSidedFull  | one-sided  | rebuilt per FD    | via FD     |
-             *  | GradientCentralLin    | central    | frozen at base    | analytic   |
-             *  | GradientOneSidedLin   | one-sided  | frozen at base    | analytic   |
+             *  | Mode                  | δ deriv       | M handling        | Pull deriv |
+             *  |-----------------------|---------------|-------------------|------------|
+             *  | GradientCentralFull   | central FD    | rebuilt per FD    | via FD     |
+             *  | GradientOneSidedFull  | one-sided FD  | rebuilt per FD    | via FD     |
+             *  | GradientCentralLin    | central FD    | frozen at base    | analytic   |
+             *  | GradientOneSidedLin   | one-sided FD  | frozen at base    | analytic   |
+             *  | GradientAnalytic      | exact         | exact dM/dθ term  | analytic   |
              *
              * Boundary handling: any FD step that lands on a parameter bound is
              * downgraded to a one-sided stencil pointing into the interior,
@@ -74,10 +78,11 @@ namespace PROfit {
              * preserved across all modes — LBFGSB depends on it.
              */
             enum GradientMode {
-                GradientCentralFull,    ///< Central FD on full chi². Most accurate, slowest (rebuilds covariance + Cholesky per FD step).
+                GradientCentralFull,    ///< Central FD on full chi². Most accurate FD mode, slowest (rebuilds covariance + Cholesky per FD step).
                 GradientOneSidedFull,   ///< One-sided forward FD on full chi². ~2× faster, O(h) vs O(h²).
                 GradientCentralLin,     ///< Default: central FD on δ only, M frozen at base (Gauss-Newton). 5–10× faster; exact at the minimum.
                 GradientOneSidedLin,    ///< One-sided FD on δ only, M frozen at base. 10–20× faster.
+                GradientAnalytic,       ///< Exact analytic gradient: dδ/dθ via FillSpectraGradient AND the (M⁻¹δ)ᵀ(dM/dθ)(M⁻¹δ) term in closed form. No FD truncation, no extra spectrum fills. Binned strategies only (falls back to FD for EventByEvent).
             };
 
             std::vector<bool> is_fixed; ///< Per-parameter flags: true if the parameter is held fixed during fitting.
@@ -233,6 +238,7 @@ namespace PROfit {
                                             || s == "onesided-lin"
                                             || s == "onesided-linearised"
                                             || s == "one-sided-linearized")     return GradientOneSidedLin;
+                if (s == "analytic"         || s == "exact")                    return GradientAnalytic;
                 return fallback;
             }
 
@@ -243,6 +249,7 @@ namespace PROfit {
                     case GradientOneSidedFull: return "one-sided-full";
                     case GradientCentralLin:   return "central-linearised";
                     case GradientOneSidedLin:  return "one-sided-linearised";
+                    case GradientAnalytic:     return "analytic";
                 }
                 return "unknown";
             }

--- a/inc/PROmodel.h
+++ b/inc/PROmodel.h
@@ -117,6 +117,21 @@ public:
      */
     virtual Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const;
 
+    /**
+     * @brief Derivatives of get_probs with respect to each physics parameter.
+     * @details grads[p] has the same shape as get_probs' return (n_phys_bins x
+     * n_prob_types) and holds d(prob)/d(phys_p) in the fitter's INTERNAL space
+     * (i.e. the log10 chain factor is included for is_log10 parameters). The
+     * base-class default computes a central finite difference on get_probs —
+     * well-conditioned since probabilities are O(1) — so every model supports
+     * the analytic-gradient chi² mode; models with closed-form derivatives
+     * (2-flavour family, PRO3p1) override for exactness.
+     * @param phys      Physics parameter vector in the fitter's internal space.
+     * @param var_arrs  Same flat-grid layout as get_probs.
+     * @return One matrix per physics parameter.
+     */
+    virtual std::vector<Eigen::MatrixXf> get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const;
+
     std::unordered_map<std::string, size_t> param_name_to_index; ///< Fast lookup: parameter name -> index in param_names.
 
     /**

--- a/inc/PROmodels/PROmodel2flav.h
+++ b/inc/PROmodels/PROmodel2flav.h
@@ -46,6 +46,9 @@ public:
     float Pmumu(float dmsq, float sinsq2thmumu, float le) const;
 
     Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
+
+    /** @brief Closed-form derivatives of get_probs (see PROmodel::get_probs_grad). */
+    std::vector<Eigen::MatrixXf> get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
 };
 
 /**
@@ -113,6 +116,9 @@ public:
     float Pmue(float dmsq, float sinsq2thmue, float le) const;
 
     Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
+
+    /** @brief Closed-form derivatives of get_probs (see PROmodel::get_probs_grad). */
+    std::vector<Eigen::MatrixXf> get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
 };
 
 /**
@@ -143,6 +149,9 @@ public:
     float Pee(float dmsq, float sinsq2thee, float le) const;
 
     Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
+
+    /** @brief Closed-form derivatives of get_probs (see PROmodel::get_probs_grad). */
+    std::vector<Eigen::MatrixXf> get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
 };
 
 }

--- a/inc/PROmodels/PROmodel3p1.h
+++ b/inc/PROmodels/PROmodel3p1.h
@@ -83,6 +83,9 @@ public:
      * @return Matrix (n_phys_bins, 4): columns = {1, P_mumu, P_mue, P_ee}.
      */
     Eigen::MatrixXf get_probs(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
+
+    /** @brief Closed-form derivatives of get_probs (see PROmodel::get_probs_grad). */
+    std::vector<Eigen::MatrixXf> get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const override;
 };
 
 /**

--- a/inc/PROsyst.h
+++ b/inc/PROsyst.h
@@ -248,6 +248,12 @@ namespace PROfit {
             float GetSplineShift(int syst_num, float shift, int bin) const;
             float GetSplineShift(std::string name, float shift, int bin) const;
 
+            /* Function: Analytic derivative d(weight)/d(shift) of GetSplineShift for the
+             * same (spline, shift, bin). Evaluates the derivative of the cubic segment
+             * GetSplineShift would use, so the two are consistent everywhere including
+             * beyond the outermost knots. Returns 0 for an out-of-range bin. */
+            float GetSplineShiftDeriv(int syst_num, float shift, int bin) const;
+
             /* Function: Get cv spectrum shifted using spline */
             PROspec GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, std::string name, float shift) const;
             PROspec GetSplineShiftedSpectrum(const PROconfig& config, const PROpeller& prop, int syst_num, float shift) const;

--- a/src/PRObench.cxx
+++ b/src/PRObench.cxx
@@ -1,7 +1,9 @@
 #include "PRObench.h"
 
 #include "PROlog.h"
+#include "PROdata.h"
 #include "PROmetric.h"
+#include "PROmetrics/PROchi.h"
 #include "PROmodel.h"
 #include "PROsyst.h"
 #include "PROpeller.h"
@@ -13,10 +15,13 @@
 #include <Eigen/Eigen>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
+#include <fstream>
 #include <random>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace PROfit {
@@ -412,12 +417,201 @@ BenchResult time_collapse(const std::string &tag,
     return r;
 }
 
+// (o) Gradient cross-validation. Evaluates the gradient at random parameter
+// points under every mode and compares against the central-full FD reference.
+// Points rejected by the model constraint (chi² plateau, zero gradient) are
+// skipped. Emits one [GRADCHECK] line per mode.
+void run_grad_check(PROmetric &metric, const std::vector<Eigen::VectorXf> &params)
+{
+    metric.setBounds(metric.LowerBound(), metric.UpperBound());
+    const size_t np = metric.nParams();
+
+    const std::vector<PROmetric::GradientMode> modes = {
+        PROmetric::GradientOneSidedFull,
+        PROmetric::GradientCentralLin,
+        PROmetric::GradientOneSidedLin,
+        PROmetric::GradientAnalytic,
+    };
+
+    // Reference gradients (central FD on the full chi²) at every usable point.
+    std::vector<Eigen::VectorXf> refs;
+    std::vector<size_t> used_points;
+    Eigen::VectorXf gref = Eigen::VectorXf::Zero(np);
+    metric.setGradientMode(PROmetric::GradientCentralFull);
+    for (size_t k = 0; k < params.size(); ++k) {
+        metric.reset();
+        float chi2 = metric(params[k], gref, true);
+        if (chi2 >= 1e9f) continue; // constraint-rejected plateau: all modes return zero gradient
+        refs.push_back(gref);
+        used_points.push_back(k);
+    }
+    log<LOG_INFO>(L"[GRADCHECK] reference=central-full points_used=%1% of %2%")
+        % refs.size() % params.size();
+
+    Eigen::VectorXf g = Eigen::VectorXf::Zero(np);
+    for (auto mode : modes) {
+        metric.setGradientMode(mode);
+        double max_abs = 0, sum_abs = 0, max_rel = 0, sum_rel = 0;
+        long   n_comp = 0;
+        for (size_t r = 0; r < refs.size(); ++r) {
+            metric.reset();
+            metric(params[used_points[r]], g, true);
+            for (size_t i = 0; i < np; ++i) {
+                const double a = std::abs((double)g(i) - (double)refs[r](i));
+                // Guard tiny denominators: FD reference noise dominates below ~1e-3.
+                const double rel = a / std::max(std::abs((double)refs[r](i)), 1e-3);
+                max_abs = std::max(max_abs, a);   sum_abs += a;
+                max_rel = std::max(max_rel, rel); sum_rel += rel;
+                ++n_comp;
+            }
+        }
+        const double denom = std::max(1L, n_comp);
+        log<LOG_INFO>(L"[GRADCHECK] mode=%1% points=%2% max_abs=%3% mean_abs=%4% max_rel=%5% mean_rel=%6%")
+            % PROmetric::gradientModeName(mode) % refs.size()
+            % max_abs % (sum_abs / denom) % max_rel % (sum_rel / denom);
+    }
+}
+
+// (p) Repeated full fits per (fit preset × gradient mode) on a SHARED set of
+// Poisson-fluctuated pseudo-data universes:
+//   - The base data spectrum (whatever the main chain built — Asimov at the CLI
+//     injected point unless real data was supplied) is Poisson-fluctuated once
+//     per universe with fixed seeds; every (preset, mode) cell fits the SAME
+//     universes, and for a given (preset, universe) every gradient mode uses
+//     the same PROfitter seed. LHS/PSO evaluate chi² only, so L-BFGS-B starts
+//     from identical points across modes — differences in iterations / calls /
+//     wall time / recovered parameters are due to the gradient alone.
+//   - Fits run in parallel over universes (opts.nthreads workers); results are
+//     logged after each cell completes so [GRADBENCH] lines never interleave.
+//   - Fitted physics parameters are logged per fit for parameter-recovery
+//     plots; the injected truth is logged once as [GRADBENCH-TRUTH].
+// Metrics are constructed fresh per universe as PROchi/BinnedChi2 regardless of
+// the CLI --chi2 choice (the analytic mode is PROchi-only so far, and a fresh
+// metric is needed anyway to bind the per-universe data).
+void run_grad_mode_fits(const PROconfig &config, const PROpeller &prop,
+                        PROmetric &base_metric, const PROdata &base_data,
+                        int n_universes, uint32_t base_seed, int nthreads,
+                        const Eigen::VectorXf &truth_params,
+                        const std::string &csv_path)
+{
+    const PROmodel &model = base_metric.GetModel();
+    const PROsyst  &syst  = base_metric.GetSysts();
+    const size_t nphys = model.nparams;
+
+    const Eigen::VectorXf bench_ub = base_metric.UpperBound();
+    const Eigen::VectorXf bench_lb = base_metric.LowerBound();
+
+    // ---- Shared universes: Poisson fluctuations of the base data spectrum ----
+    std::vector<PROdata> universes;
+    universes.reserve(n_universes);
+    for (int u = 0; u < n_universes; ++u) {
+        PROspec fluc = PROspec::PoissonVariation(
+            PROspec(base_data.Spec(), base_data.Error()), base_seed + (uint32_t)u);
+        universes.emplace_back(fluc.Spec(), fluc.Error());
+    }
+
+    // Per-fit records go to a CSV: PROlog suppresses repeated-format lines
+    // after ~1000 emissions, which silently drops per-fit lines in a
+    // 4-preset × 5-mode × 100-universe sweep. Only summaries are logged.
+    std::ofstream csv(csv_path);
+    if (!csv) {
+        log<LOG_ERROR>(L"[GRADBENCH] cannot open output CSV '%1%'; aborting fit benchmark.")
+            % csv_path.c_str();
+        return;
+    }
+    if (truth_params.size() >= (Eigen::Index)nphys) {
+        std::string tstr;
+        for (size_t i = 0; i < nphys; ++i)
+            tstr += (i ? " " : "") + model.param_names[i] + "=" + std::to_string(truth_params(i));
+        log<LOG_INFO>(L"[GRADBENCH-TRUTH] universes=%1% phys: %2%")
+            % n_universes % tstr.c_str();
+        csv << "# truth " << tstr << "\n";
+    }
+    csv << "preset,mode,fit,wall_s,lbfgs_iters,metric_calls,chi2";
+    for (size_t i = 0; i < nphys; ++i) csv << ",phys" << i;
+    csv << "\n";
+    log<LOG_INFO>(L"[GRADBENCH] per-fit records -> %1%") % csv_path.c_str();
+
+    const std::vector<std::string> presets = {"sensitivity", "fast", "good", "overkill"};
+    const std::vector<PROmetric::GradientMode> modes = {
+        PROmetric::GradientCentralFull,
+        PROmetric::GradientOneSidedFull,
+        PROmetric::GradientCentralLin,
+        PROmetric::GradientOneSidedLin,
+        PROmetric::GradientAnalytic,
+    };
+
+    struct FitRec {
+        double wall_s = 0;
+        size_t iters = 0, calls = 0;
+        float  chi2 = 0;
+        Eigen::VectorXf phys;
+    };
+
+    for (const auto &preset : presets) {
+        // Preset defaults only — CLI --fit-options are deliberately NOT applied
+        // here so the four presets are compared as-shipped.
+        PROfitterConfig pcfg({}, preset, /*isScan=*/false);
+        for (auto mode : modes) {
+            pcfg.gradient_mode = mode;
+
+            std::vector<FitRec> recs(n_universes);
+            std::atomic<int> next{0};
+            auto worker = [&]() {
+                for (int u = next.fetch_add(1); u < n_universes; u = next.fetch_add(1)) {
+                    PROchi m("", config, prop, &syst, model, universes[u],
+                             PROmetric::BinnedChi2, /*shape_only=*/false);
+                    m.setBounds(bench_lb, bench_ub);
+                    // Same fitter seed per universe across all (preset, mode)
+                    // cells → identical LHS/PSO trajectories per universe.
+                    PROfitter fitter(bench_ub, bench_lb, pcfg,
+                                     base_seed ^ 0x5eedu ^ (uint32_t)u);
+                    auto t0 = std::chrono::high_resolution_clock::now();
+                    float chi2 = fitter.Fit(m);
+                    auto t1 = std::chrono::high_resolution_clock::now();
+                    FitRec &r = recs[u];
+                    r.wall_s = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() * 1e-6;
+                    r.iters  = fitter.total_lbfgs_iterations;
+                    r.calls  = m.getCallCount();
+                    r.chi2   = chi2;
+                    r.phys   = fitter.best_fit.head(nphys);
+                }
+            };
+            std::vector<std::thread> pool;
+            const int nw = std::max(1, std::min(nthreads, n_universes));
+            for (int t = 0; t < nw; ++t) pool.emplace_back(worker);
+            for (auto &t : pool) t.join();
+
+            double sum_s = 0, sum_iters = 0, sum_calls = 0, sum_chi = 0;
+            double best_chi = std::numeric_limits<double>::infinity();
+            for (int u = 0; u < n_universes; ++u) {
+                const FitRec &r = recs[u];
+                csv << preset << ',' << PROmetric::gradientModeName(mode) << ','
+                    << u << ',' << r.wall_s << ',' << r.iters << ','
+                    << r.calls << ',' << r.chi2;
+                for (size_t i = 0; i < nphys; ++i) csv << ',' << r.phys(i);
+                csv << "\n";
+                sum_s += r.wall_s; sum_iters += (double)r.iters;
+                sum_calls += (double)r.calls; sum_chi += (double)r.chi2;
+                best_chi = std::min(best_chi, (double)r.chi2);
+            }
+            csv.flush();
+            const double dn = std::max(1, n_universes);
+            log<LOG_INFO>(L"[GRADBENCH-SUMMARY] preset=%1% mode=%2% fits=%3% mean_wall_s=%4% mean_lbfgs_iters=%5% mean_metric_calls=%6% mean_chi2=%7% best_chi2=%8%")
+                % preset.c_str() % PROmetric::gradientModeName(mode) % n_universes
+                % (sum_s / dn) % (sum_iters / dn) % (sum_calls / dn)
+                % (sum_chi / dn) % best_chi;
+        }
+    }
+}
+
 }  // namespace
 
 std::vector<BenchResult> run_scale_test(
     const PROconfig &config,
     const PROpeller &prop,
     PROmetric &metric,
+    const PROdata &data,
     const PROfitterConfig &fitconfig,
     const BenchOptions &opts)
 {
@@ -534,6 +728,26 @@ std::vector<BenchResult> run_scale_test(
         results.push_back(time_mcmc_step("mcmc_step_post", config, metric,
                                          N_fill, /*burnin=*/false,
                                          opts.rng_seed ^ 0x20u));
+    }
+
+    // ---- (o) Gradient cross-validation ----
+    // N_metric random points; every mode compared against central-full FD.
+    if (opts.tests & Bench_GradCheck) {
+        auto p = draw_param_set(model, syst, N_metric, opts.rng_seed ^ 0x40u, true, true);
+        run_grad_check(metric, p);
+        // Restore the CLI-selected mode for any tests that follow.
+        metric.setGradientMode(fitconfig.gradient_mode);
+    }
+
+    // ---- (p) Fit benchmark: preset × gradient-mode sweep ----
+    // N_fit shared Poisson-fluctuated universes fitted per (preset, mode) with
+    // matched seeds, in parallel over opts.nthreads workers. This is the
+    // headline comparison for the analytic-gradient work; results go to
+    // [GRADBENCH] / [GRADBENCH-SUMMARY] lines rather than BenchResult rows.
+    if (opts.tests & Bench_GradModeFit) {
+        run_grad_mode_fits(config, prop, metric, data, N_fit,
+                           opts.rng_seed ^ 0x80u, opts.nthreads, opts.truth_params,
+                           opts.grad_csv);
     }
 
     log<LOG_INFO>(L"%1% || ===== PRObench scale-test complete: %2% tests =====")

--- a/src/PROcess.cxx
+++ b/src/PROcess.cxx
@@ -231,6 +231,103 @@ namespace PROfit {
     }
 
 
+    Eigen::MatrixXf FillSpectraGradient(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, FillSpectraCache &cache, size_t var_index) {
+        const size_t nbins_var = inconfig.m_num_variable_bins_total[var_index];
+        const size_t nsplines  = insyst.GetNSplines();
+        const size_t nphys     = inmodel.nparams;
+        Eigen::VectorXf phys   = params.segment(0, nphys);
+        Eigen::VectorXf shifts = params.segment(nphys, params.size() - nphys);
+
+        // ---- Per-spline factors f_i(k) and derivatives f'_i(k), same math as FillSpectra ----
+        Eigen::MatrixXf factors  = Eigen::MatrixXf::Ones(nbins_var, nsplines);
+        Eigen::MatrixXf dfactors = Eigen::MatrixXf::Zero(nbins_var, nsplines);
+        Eigen::VectorXf systw    = Eigen::VectorXf::Constant(nbins_var, 1);
+        for(int i = 0; i < (int)nsplines; ++i) {
+            size_t binning = insyst.spline_binnings[i];
+            if(binning == var_index) {
+                for(size_t k = 0; k < nbins_var; ++k) {
+                    factors(k, i)  = insyst.GetSplineShift(i, shifts(i), (int)k);
+                    dfactors(k, i) = insyst.GetSplineShiftDeriv(i, shifts(i), (int)k);
+                }
+            } else {
+                const size_t nbins_binning = inconfig.m_num_variable_bins_total[binning];
+                Eigen::VectorXf spline_vals(nbins_binning), spline_derivs(nbins_binning);
+                for(size_t b = 0; b < nbins_binning; ++b) {
+                    spline_vals(b)   = insyst.GetSplineShift(i, shifts(i), (int)b);
+                    spline_derivs(b) = insyst.GetSplineShiftDeriv(i, shifts(i), (int)b);
+                }
+                // The migration factor is LINEAR in the spline values, so its derivative
+                // is the same GEMV applied to the per-bin spline derivatives.
+                Eigen::VectorXf weighted  = inprop.variable_hist_storage.WeightedColSum(binning, var_index, spline_vals);
+                Eigen::VectorXf dweighted = inprop.variable_hist_storage.WeightedColSum(binning, var_index, spline_derivs);
+                auto it_us = cache.unweighted_sums.find(binning);
+                if(it_us == cache.unweighted_sums.end())
+                    it_us = cache.unweighted_sums.emplace(binning, inprop.variable_hist_storage.UnweightedColSum(binning, var_index)).first;
+                const Eigen::VectorXf &unweighted = it_us->second;
+                for(size_t k = 0; k < nbins_var; ++k) {
+                    if(unweighted(k) > 0) {
+                        factors(k, i)  = weighted(k)  / unweighted(k);
+                        dfactors(k, i) = dweighted(k) / unweighted(k);
+                    }
+                }
+            }
+            systw.array() *= factors.col(i).array();
+        }
+
+        // ---- Physics result (H * probs) and per-parameter probability derivatives ----
+        Eigen::VectorXf result;
+        std::vector<Eigen::MatrixXf> pgrads;
+        if(inmodel.is_trivial) {
+            result = inmodel.H_combined[var_index].col(0);
+        } else {
+            // Reuse (or build) the constant flat physics grid exactly as FillSpectra does.
+            if(!cache.phys_grid_valid) {
+                const size_t N_ivars = inmodel.ivars.size();
+                std::vector<size_t> ivar_sizes(N_ivars);
+                for(size_t k = 0; k < N_ivars; ++k)
+                    ivar_sizes[k] = inprop.variable_midbin[inmodel.ivars[k]].size();
+                cache.phys_grid.assign(N_ivars, std::vector<float>(inmodel.n_phys_bins));
+                for(long int flat = 0; flat < inmodel.n_phys_bins; ++flat) {
+                    long int rem = flat;
+                    for(int k = (int)N_ivars - 1; k >= 0; --k) {
+                        cache.phys_grid[k][flat] = inprop.variable_midbin[inmodel.ivars[k]][rem % ivar_sizes[k]];
+                        rem /= (long int)ivar_sizes[k];
+                    }
+                }
+                cache.phys_grid_valid = true;
+            }
+            auto probs = inmodel.get_probs(phys, cache.phys_grid);
+            Eigen::Map<const Eigen::VectorXf> probs_flat(probs.data(), probs.size());
+            result = inmodel.H_combined[var_index] * probs_flat;
+            pgrads = inmodel.get_probs_grad(phys, cache.phys_grid);
+        }
+
+        // ---- Assemble d(spec)/d(param) columns; spec = systw .* result ----
+        Eigen::MatrixXf G = Eigen::MatrixXf::Zero(nbins_var, nphys + nsplines);
+        if(!inmodel.is_trivial) {
+            for(size_t p = 0; p < nphys; ++p) {
+                Eigen::Map<const Eigen::VectorXf> dprobs_flat(pgrads[p].data(), pgrads[p].size());
+                G.col(p) = systw.cwiseProduct(inmodel.H_combined[var_index] * dprobs_flat);
+            }
+        }
+        constexpr float kTiny = 1e-30f;
+        for(size_t i = 0; i < nsplines; ++i) {
+            for(size_t k = 0; k < nbins_var; ++k) {
+                const float f = factors(k, i);
+                float excl; // product of all OTHER splines' factors at bin k
+                if(std::abs(f) > kTiny) {
+                    excl = systw(k) / f;
+                } else {
+                    excl = 1.0f;
+                    for(size_t j = 0; j < nsplines; ++j)
+                        if(j != i) excl *= factors(k, j);
+                }
+                G(k, nphys + i) = excl * dfactors(k, i) * result(k);
+            }
+        }
+        return G;
+    }
+
     PROspec FillSpectra(const PROconfig &inconfig, const PROpeller &inprop, const PROsyst &insyst, const PROmodel &inmodel, const Eigen::VectorXf &params, bool binned, size_t var_index){
         PROspec myspectrum(inconfig.m_num_variable_bins_total[var_index]);
         Eigen::VectorXf phys   = params.segment(0, inmodel.nparams);

--- a/src/PROfitter.cxx
+++ b/src/PROfitter.cxx
@@ -155,6 +155,7 @@ float PROfitter::Fit(PROmetric &metric, const Eigen::VectorXf &seed_pt ) {
 float PROfitter::Fit(PROmetric &metric, const std::vector<Eigen::VectorXf> &seed_points, const std::vector<FixedSeed> &fixed_seeds ) {
 
     metric.setGradientMode(fitconfig.gradient_mode);
+    total_lbfgs_iterations = 0;
 
     const bool tim_on = PROfit::GetScanTimingEnabled();
     auto fit_t0 = tim_on ? std::chrono::steady_clock::now()
@@ -272,6 +273,7 @@ float PROfitter::Fit(PROmetric &metric, const std::vector<Eigen::VectorXf> &seed
             log<LOG_INFO>(L"%1% || Starting local minimization attempt %2%/%3%") % __func__ % attempt % fitconfig.n_max_local_retries;
 
             niter = solver.minimize(metric, x, fx, lb, ub);
+            total_lbfgs_iterations += (size_t)std::max(niter, 0);
 
             chi2s_localfits.push_back(fx);
 
@@ -339,6 +341,7 @@ float PROfitter::Fit(PROmetric &metric, const std::vector<Eigen::VectorXf> &seed
                     log<LOG_INFO>(L"%1% || Starting local minimization attempt %2%/%3%") % __func__ % attempt % fitconfig.n_max_local_retries;
 
                     niter = solver.minimize(metric, x, fx, lb, ub);
+                    total_lbfgs_iterations += (size_t)std::max(niter, 0);
 
                     chi2s_localfits.push_back(fx);
 
@@ -431,6 +434,7 @@ float PROfitter::Fit(PROmetric &metric, const std::vector<Eigen::VectorXf> &seed
                 log<LOG_INFO>(L"%1% || Starting fixed-seed local minimization attempt %2%/%3%") % __func__ % attempt % fitconfig.n_max_local_retries;
 
                 niter = solver.minimize(metric, x, fx, flb, fub);
+                total_lbfgs_iterations += (size_t)std::max(niter, 0);
 
                 chi2s_localfits.push_back(fx);
 
@@ -476,6 +480,7 @@ float PROfitter::Fit(PROmetric &metric, const std::vector<Eigen::VectorXf> &seed
                 log<LOG_INFO>(L"%1% || Starting local minimization attempt %2%/%3%") % __func__ % attempt % fitconfig.n_max_local_retries;
 
                 niter = solver.minimize(metric, x, fx, lb, ub);
+                total_lbfgs_iterations += (size_t)std::max(niter, 0);
 
                 chi2s_localfits.push_back(fx);
 

--- a/src/PROmetrics/PROCNP.cxx
+++ b/src/PROmetrics/PROCNP.cxx
@@ -169,7 +169,16 @@ float PROCNP::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         // Linearised modes intentionally freeze M (including M_stat) at the
         // base point — this is the Gauss-Newton approximation, dropping the
         // (M⁻¹δ)^T (dM/dθ) (M⁻¹δ) term that's second-order in δ.
-        const GradientMode mode = gradient_mode;
+        GradientMode mode = gradient_mode;
+        // Analytic gradient is implemented in PROchi only so far; the CNP stat
+        // covariance adds a μ-dependent term that is not yet wired up. Use the
+        // closest approximation (Gauss-Newton linearised, exact at the minimum).
+        if (mode == GradientAnalytic) {
+            static std::atomic<bool> warned_analytic{false};
+            if(!warned_analytic.exchange(true))
+                log<LOG_WARNING>(L"%1% || Analytic gradient not implemented for PROCNP; using central-linearised.") % __func__;
+            mode = GradientCentralLin;
+        }
         const bool linearised = (mode == GradientCentralLin) || (mode == GradientOneSidedLin);
         const bool one_sided  = (mode == GradientOneSidedFull) || (mode == GradientOneSidedLin);
         const size_t nsyst = syst->GetNSplines();

--- a/src/PROmetrics/PROchi.cxx
+++ b/src/PROmetrics/PROchi.cxx
@@ -215,7 +215,17 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         // stencil pointing into the interior, and the "out-of-bounds gradient
         // bounce" is applied (zero the gradient when it would push further
         // out of the box).
-        const GradientMode mode = gradient_mode;
+        GradientMode mode = gradient_mode;
+        // The analytic gradient needs the binned factorised spectrum
+        // (spec = systw .* H*probs); the event-by-event fill mixes physics and
+        // systematics per event, so fall back to full FD there.
+        if (mode == GradientAnalytic && strat == EventByEvent) {
+            static std::atomic<bool> warned_ebe{false};
+            if(!warned_ebe.exchange(true))
+                log<LOG_WARNING>(L"%1% || Analytic gradient not available for EventByEvent strategy; falling back to central-full FD.") % __func__;
+            mode = GradientCentralFull;
+        }
+        const bool analytic   = (mode == GradientAnalytic);
         const bool linearised = (mode == GradientCentralLin) || (mode == GradientOneSidedLin);
         const bool one_sided  = (mode == GradientOneSidedFull) || (mode == GradientOneSidedLin);
 
@@ -226,7 +236,7 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
         // prior_covariance_inv (correlated) — no FD on the pull.
         Eigen::VectorXf Minv_delta_b;
         Eigen::VectorXf pull_grad_nuis; // size = nsyst, dP/dθ_n
-        if (linearised) {
+        if (linearised || analytic) {
             Minv_delta_b = M.llt().solve(delta);
             const Eigen::VectorXf centered = subvector2 - syst->spline_centers;
             if (!correlated_systematics) {
@@ -236,6 +246,45 @@ float PROchi::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &gradient
             } else {
                 pull_grad_nuis = 2.0f * (prior_covariance_inv * centered);
             }
+        }
+
+        if (analytic) {
+            // ----- Fully analytic gradient -----
+            // dχ²/dθ = 2 uᵀ (Tᵀ ds/dθ)|idx − uᵀ (dM/dθ) u + dP/dθ,  u = M⁻¹δ.
+            // With M_sys = (Tᵀ diag(s) F diag(s) T)(idx,idx) and w = T·expand(u),
+            // the covariance term collapses to uᵀ(dM/dθ)u = 2 (ds/dθ)·(w∘g) with
+            // g = F (w∘s) computed ONCE per gradient call — so unlike the
+            // linearised FD modes this term is NOT dropped.
+            const Eigen::SparseMatrix<float> &T = config.GetCollapsingMatrixSparse();
+            Eigen::VectorXf u_c = Eigen::VectorXf::Zero(T.cols());
+            for(size_t k = 0; k < reduced_size; ++k)
+                u_c(non_empty_indices[k]) = Minv_delta_b(k);
+            const Eigen::VectorXf w_full = T * u_c;
+            const Eigen::VectorXf g_full = syst->fractional_covariance * w_full.cwiseProduct(result.Spec());
+            const Eigen::VectorXf wg = w_full.cwiseProduct(g_full);
+
+            Eigen::MatrixXf G = FillSpectraGradient(config, peller, *syst, model, param, fs_cache, config.i_prime);
+            Eigen::MatrixXf TtG = T.transpose() * G; // collapsed-space Jacobian (ncollapsed × nparams)
+            Eigen::VectorXf grad_vec = 2.0f * (TtG(idx, Eigen::all).transpose() * Minv_delta_b)
+                                     - 2.0f * (G.transpose() * wg);
+            grad_vec.segment(model.nparams, nsyst) += pull_grad_nuis;
+
+            for (size_t i = 0; i < model.nparams + nsyst; i++) {
+                if(is_fixed.size() > 0 && is_fixed.at(i)) { gradient(i) = 0.0f; continue; }
+                gradient(i) = grad_vec(i);
+                // Same boundary "bounce" as the FD paths: zero the gradient when
+                // it would push further out of the box (LBFGSB depends on this).
+                const float boundary_tol = 2.0f * std::numeric_limits<float>::epsilon();
+                const bool at_lower = std::fabs(param(i) - lb(i)) < boundary_tol;
+                const bool at_upper = std::fabs(ub(i) - param(i)) < boundary_tol;
+                if ((at_lower && gradient(i) > 0) || (at_upper && gradient(i) < 0))
+                    gradient(i) = 0.0f;
+                if (!std::isfinite(gradient(i))) gradient(i) = 0.0f;
+            }
+
+            last_param = param;
+            last_value = value;
+            return value;
         }
 
         // ----- Helpers (closures over the outer scope) -----

--- a/src/PROmetrics/PROpoisson.cxx
+++ b/src/PROmetrics/PROpoisson.cxx
@@ -148,7 +148,15 @@ float PROpoisson::operator()(const Eigen::VectorXf &param, Eigen::VectorXf &grad
         // GradientOneSidedFull — but with a fixed forward stencil rather than
         // the LBFGS-direction-tracking heuristic, which was always somewhat
         // approximate.
-        const GradientMode mode = gradient_mode;
+        GradientMode mode = gradient_mode;
+        // Analytic gradient is implemented in PROchi only so far. For Poisson the
+        // linearised chain rule is already exact modulo FD truncation in dδ/dθ.
+        if (mode == GradientAnalytic) {
+            static std::atomic<bool> warned_analytic{false};
+            if(!warned_analytic.exchange(true))
+                log<LOG_WARNING>(L"%1% || Analytic gradient not implemented for PROpoisson; using central-linearised.") % __func__;
+            mode = GradientCentralLin;
+        }
         const bool linearised = (mode == GradientCentralLin) || (mode == GradientOneSidedLin);
         const bool one_sided  = (mode == GradientOneSidedFull) || (mode == GradientOneSidedLin);
 

--- a/src/PROmodel.cxx
+++ b/src/PROmodel.cxx
@@ -74,6 +74,24 @@ Eigen::MatrixXf PROmodel::get_probs(const Eigen::VectorXf &phys, const std::vect
     return probs;
 }
 
+std::vector<Eigen::MatrixXf> PROmodel::get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const {
+    // Central FD on the probabilities only. Probabilities are O(1), so this is
+    // far better conditioned than FD on the full chi²; models with cheap
+    // closed-form derivatives should still override for exactness and speed.
+    std::vector<Eigen::MatrixXf> grads(nparams);
+    const float h = 1e-3f;
+    Eigen::VectorXf p = phys;
+    for(size_t i = 0; i < nparams; ++i) {
+        p(i) = phys(i) + h;
+        Eigen::MatrixXf plus = get_probs(p, var_arrs);
+        p(i) = phys(i) - h;
+        Eigen::MatrixXf minus = get_probs(p, var_arrs);
+        p(i) = phys(i);
+        grads[i] = (plus - minus) / (2.0f * h);
+    }
+    return grads;
+}
+
 void PROmodel::build_param_index() {
     param_name_to_index.clear();
     for(size_t i = 0; i < param_names.size(); ++i){

--- a/src/PROmodels/PROmodel2flav.cxx
+++ b/src/PROmodels/PROmodel2flav.cxx
@@ -95,6 +95,31 @@ Eigen::MatrixXf PROnumudis::get_probs(const Eigen::VectorXf &phys, const std::ve
     return probs;
 }
 
+std::vector<Eigen::MatrixXf> PROnumudis::get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const {
+    const auto &le_arr = var_arrs[0];
+    float dmsq = maybe_convert_log("dmsq", phys(0));
+    float sinsq2thmumu = maybe_convert_log("sinsq2thmm", phys(1));
+
+    // Chain factors d(linear)/d(internal); log10 params: d(10^x)/dx = ln10 * 10^x.
+    constexpr float LN10 = 2.302585093f;
+    float ddm = is_log10[0] ? LN10 * dmsq : 1.0f;
+    float dss = is_log10[1] ? LN10 * sinsq2thmumu : 1.0f;
+    // Match get_probs' clamp: the clamped parameter has zero local sensitivity.
+    if(sinsq2thmumu > 1) { sinsq2thmumu = 1; dss = 0; }
+    if(sinsq2thmumu < 0) { sinsq2thmumu = 0; dss = 0; }
+
+    float freq = 1.266932679f * dmsq;
+    std::vector<Eigen::MatrixXf> grads(2, Eigen::MatrixXf::Zero(le_arr.size(), model_functions.size()));
+    for(size_t i = 0; i < le_arr.size(); ++i) {
+        // P_mumu = 1 - s * sin^2(freq * le)
+        float x = freq * le_arr[i];
+        float sinterm = std::sin(x);
+        grads[0](i, 1) = -sinsq2thmumu * std::sin(2.0f*x) * 1.266932679f * le_arr[i] * ddm;
+        grads[1](i, 1) = -sinterm * sinterm * dss;
+    }
+    return grads;
+}
+
 // ------------------------------------------------------------------
 // PROnumudisTEST
 // ------------------------------------------------------------------
@@ -261,6 +286,29 @@ Eigen::MatrixXf PROnueapp::get_probs(const Eigen::VectorXf &phys, const std::vec
     return probs;
 }
 
+std::vector<Eigen::MatrixXf> PROnueapp::get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const {
+    const auto &le_arr = var_arrs[0];
+    float dmsq = maybe_convert_log("dmsq", phys(0));
+    float sinsq2thmue = maybe_convert_log("sinsq2thme", phys(1));
+
+    constexpr float LN10 = 2.302585093f;
+    float ddm = is_log10[0] ? LN10 * dmsq : 1.0f;
+    float dss = is_log10[1] ? LN10 * sinsq2thmue : 1.0f;
+    if(sinsq2thmue > 1) { sinsq2thmue = 1; dss = 0; }
+    if(sinsq2thmue < 0) { sinsq2thmue = 0; dss = 0; }
+
+    float freq = 1.266932679f * dmsq;
+    std::vector<Eigen::MatrixXf> grads(2, Eigen::MatrixXf::Zero(le_arr.size(), model_functions.size()));
+    for(size_t i = 0; i < le_arr.size(); ++i) {
+        // P_mue = s * sin^2(freq * le)
+        float x = freq * le_arr[i];
+        float sinterm = std::sin(x);
+        grads[0](i, 1) = sinsq2thmue * std::sin(2.0f*x) * 1.266932679f * le_arr[i] * ddm;
+        grads[1](i, 1) = sinterm * sinterm * dss;
+    }
+    return grads;
+}
+
 // ------------------------------------------------------------------
 // PROnuedis
 // ------------------------------------------------------------------
@@ -345,6 +393,29 @@ Eigen::MatrixXf PROnuedis::get_probs(const Eigen::VectorXf &phys, const std::vec
     }
 
     return probs;
+}
+
+std::vector<Eigen::MatrixXf> PROnuedis::get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const {
+    const auto &le_arr = var_arrs[0];
+    float dmsq = maybe_convert_log("dmsq", phys(0));
+    float sinsq2thee = maybe_convert_log("sinsq2thee", phys(1));
+
+    constexpr float LN10 = 2.302585093f;
+    float ddm = is_log10[0] ? LN10 * dmsq : 1.0f;
+    float dss = is_log10[1] ? LN10 * sinsq2thee : 1.0f;
+    if(sinsq2thee > 1) { sinsq2thee = 1; dss = 0; }
+    if(sinsq2thee < 0) { sinsq2thee = 0; dss = 0; }
+
+    float freq = 1.266932679f * dmsq;
+    std::vector<Eigen::MatrixXf> grads(2, Eigen::MatrixXf::Zero(le_arr.size(), model_functions.size()));
+    for(size_t i = 0; i < le_arr.size(); ++i) {
+        // P_ee = 1 - s * sin^2(freq * le)
+        float x = freq * le_arr[i];
+        float sinterm = std::sin(x);
+        grads[0](i, 1) = -sinsq2thee * std::sin(2.0f*x) * 1.266932679f * le_arr[i] * ddm;
+        grads[1](i, 1) = -sinterm * sinterm * dss;
+    }
+    return grads;
 }
 
 }

--- a/src/PROmodels/PROmodel3p1.cxx
+++ b/src/PROmodels/PROmodel3p1.cxx
@@ -179,6 +179,40 @@ Eigen::MatrixXf PRO3p1::get_probs(const Eigen::VectorXf &phys, const std::vector
     return probs;
 }
 
+std::vector<Eigen::MatrixXf> PRO3p1::get_probs_grad(const Eigen::VectorXf &phys, const std::vector<std::vector<float>> &var_arrs) const {
+    const auto &le_arr = var_arrs[0];
+    float dmsq  = maybe_convert_log("dmsq",  phys(0));
+    float Ue4sq = maybe_convert_log("Ue4^2", phys(1));
+    float Um4sq = maybe_convert_log("Um4^2", phys(2));
+
+    // Chain factors d(linear)/d(internal); all three params are log10 by default.
+    constexpr float LN10 = 2.302585093f;
+    float ddm = is_log10[0] ? LN10 * dmsq  : 1.0f;
+    float dUe = is_log10[1] ? LN10 * Ue4sq : 1.0f;
+    float dUm = is_log10[2] ? LN10 * Um4sq : 1.0f;
+
+    constexpr float k = 1.266932679f;
+    std::vector<Eigen::MatrixXf> grads(3, Eigen::MatrixXf::Zero(le_arr.size(), model_functions.size()));
+    for(size_t i = 0; i < le_arr.size(); ++i) {
+        float x = k * dmsq * le_arr[i];
+        float sinterm = std::sin(x);
+        float s2 = sinterm * sinterm;
+        float dsin2_ddm = std::sin(2.0f*x) * k * le_arr[i] * ddm;  // d(sin^2 x)/d(internal dmsq)
+
+        // col 1: P_mumu = 1 - 4 Um(1-Um) sin^2
+        grads[0](i, 1) = -4.0f * Um4sq * (1.0f - Um4sq) * dsin2_ddm;
+        grads[2](i, 1) = -4.0f * (1.0f - 2.0f*Um4sq) * s2 * dUm;
+        // col 2: P_mue = 4 Ue Um sin^2
+        grads[0](i, 2) =  4.0f * Ue4sq * Um4sq * dsin2_ddm;
+        grads[1](i, 2) =  4.0f * Um4sq * s2 * dUe;
+        grads[2](i, 2) =  4.0f * Ue4sq * s2 * dUm;
+        // col 3: P_ee = 1 - 4 Ue(1-Ue) sin^2
+        grads[0](i, 3) = -4.0f * Ue4sq * (1.0f - Ue4sq) * dsin2_ddm;
+        grads[1](i, 3) = -4.0f * (1.0f - 2.0f*Ue4sq) * s2 * dUe;
+    }
+    return grads;
+}
+
 // ------------------------------------------------------------------
 // PRO3p1_angles
 // ------------------------------------------------------------------

--- a/src/PROsyst.cxx
+++ b/src/PROsyst.cxx
@@ -759,6 +759,26 @@ namespace PROfit {
         return c[0] + x*(c[1] + x*(c[2] + x*c[3]));
     }
 
+    float PROsyst::GetSplineShiftDeriv(int spline_num, float shift, int bin) const {
+        const Spline& spline = splines[spline_num];
+        if (bin < 0 || bin >= spline.bins) return 0;
+
+        // Same segment lookup as GetSplineShift so value and derivative always
+        // come from the same cubic.
+        int offset = bin * spline.segments_per_bin;
+        const SplineSegment* segs = &spline.segments[offset];
+        const SplineSegment* end = segs + spline.segments_per_bin;
+        const SplineSegment* seg = std::upper_bound(segs, end, shift, [](float x, const SplineSegment& s) { return x < s.knot; });
+        if (seg != segs) --seg;
+
+        float hi = seg + 1 < end ? seg[1].knot : spline_hi[spline_num];
+        float width = hi - seg->knot;
+        float x = (shift - seg->knot) / width;
+        const auto& c = seg->coeffs;
+        // d/dshift of c0 + x(c1 + x(c2 + x c3)) with x = (shift-knot)/width
+        return (c[1] + x*(2.0f*c[2] + 3.0f*x*c[3])) / width;
+    }
+
     void PROsyst::FillSpline(const SystStruct& syst, bool unmirrored) {
         std::vector<PROspec> ratios;
         ratios.reserve(syst.p_multi_spec.size());


### PR DESCRIPTION
Testing an analytic gradient minimizer to use with L-BFGS. This calculates the gradient analytically, considering how spline systematics, covariance matrix systematics, and oscillation physics parameters affect the chi2.

Previously, an analytic gradient was partially implemented when using GradientCentralLin or GradientOneSidedLin. The spline pull term penalties and the covariance systematic penalty with a shifted spectrum were calculated analytically, but finite difference methods were used to calculate the predicted spectrum change.

Only implemented for PROchi, not PROpoisson or PROCNP. Only implemented for 3+1 and two-flavor oscillation models.

From some first tests minimizing 100 poisson-fluctuated fake data sets, it looks like the speed is approximately unchanged, but the accuracy of minimization is higher for each preset.

<img width="6600" height="3900" alt="gradbench_comparison" src="https://github.com/user-attachments/assets/513bb565-3b95-4ca6-9971-cc6ae6f22114" />
